### PR TITLE
Make it possible to specify Type: in prjconf and have non-rpm.rpm chroots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ install:
 	    killchroot \
 	    getmacros \
 	    getoptflags \
+	    gettype \
 	    getchangetarget \
 	    common_functions \
 	    init_buildsystem \

--- a/gettype
+++ b/gettype
@@ -1,0 +1,36 @@
+#!/usr/bin/perl -w
+
+BEGIN {
+  unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/build');
+}
+
+use strict;
+
+use Build;
+
+my ($dist, $archs, $configdir, $debug);
+
+while (@ARGV)  {
+  if ($ARGV[0] eq '--dist') {
+    shift @ARGV;
+    $dist = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--archpath') {
+    shift @ARGV;
+    $archs = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--configdir') {
+    shift @ARGV;
+    $configdir = shift @ARGV;
+    next;
+  }
+  last;
+}
+
+die("Usage: gettype --dist <dist> --archpath <archpath> [--configdir <configdir>]\n") if @ARGV;
+
+my $cf = Build::read_config_dist($dist, $archs, $configdir);
+exit 0 unless $cf->{'type'};
+print "$cf->{'type'}\n";

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -699,8 +699,24 @@ else
 
     echo "$GUESSED_DIST" > $BUILD_ROOT/.guessed_dist
     test -n "$BUILD_DIST" || BUILD_DIST="$GUESSED_DIST"
-    PSUF=rpm
-    test -L $BUILD_ROOT/.init_b_cache/rpms/rpm.rpm || PSUF=deb
+    DIST_TYPE=`gettype --dist "$BUILD_DIST" --configdir "$BUILD_DIR/configs" --archpath "$BUILD_ARCH"`
+    if [ -n $DIST_TYPE ]; then
+            case $DIST_TYPE in
+            	spec)
+            		PSUF=rpm 
+            		;;
+            	dsc)
+            		PSUF=deb
+            		;;
+            	*)
+            	        PSUF=rpm
+	    		test -L $BUILD_TARGET/.init_b_cache/rpms/rpm.rpm || PSUF=deb
+			;;
+            esac            		
+    else
+	    PSUF=rpm
+	    test -L $BUILD_TARGET/.init_b_cache/rpms/rpm.rpm || PSUF=deb
+    fi
 fi
 
 #


### PR DESCRIPTION
See Daniel Gollub's email in response to SB2-OBS patches

Signed-off-by: Carsten Munk carsten.munk@gmail.com
