### PR TITLE
Add new --addprereqs option

### DIFF
--- a/build
+++ b/build
@@ -60,6 +60,7 @@ BUILD_JOBS=
 ABUILD_TARGET=
 CREATE_BASELIBS=
 USEUSEDFORBUILD=
+ADDPREREQS=
 LIST_STATE=
 VM_IMAGE=
 VM_SWAP=
@@ -165,6 +166,10 @@ Known Parameters:
               Specify what architectures to select from the RPMs
 
   --verify    Run verify when initializing the build root
+
+  --addprereqs
+              Also install packages required by PreReq, Requires(pre),
+              and Requires(post) in the build chroot.
 
   --extra-packs pack
               Also install package 'pack'
@@ -958,6 +963,9 @@ while test -n "$1"; do
       *-useusedforbuild)
 	USEUSEDFORBUILD="--useusedforbuild"
       ;;
+      *-addprereqs)
+	ADDPREREQS="--addprereqs"
+      ;;
       *-list*state)
 	LIST_STATE=true
       ;;
@@ -1217,7 +1225,7 @@ if test -n "$LIST_STATE" ; then
        }
        for SPECFILE in $BUILD_ROOT/usr/src/packages/SPECS/*.spec ; do : ; done
     fi
-    init_buildsystem --cachedir "$CACHE_DIR" --list-state "${definesnstuff[@]}" "${repos[@]}" $USEUSEDFORBUILD $SPECFILE $BUILD_EXTRA_PACKS
+    init_buildsystem --cachedir "$CACHE_DIR" --list-state "${definesnstuff[@]}" "${repos[@]}" $USEUSEDFORBUILD $ADDPREREQS $SPECFILE $BUILD_EXTRA_PACKS
     ERR=$?
     rm -rf $BUILD_ROOT
     cleanup_and_exit $ERR
@@ -1429,7 +1437,7 @@ for SPECFILE in "${SPECFILES[@]}" ; do
 	if test "$DO_INIT" = true ; then
 	    # do fist stage of init_buildsystem
 	    rm -f $BUILD_ROOT/.build.success
-	    set -- init_buildsystem --cachedir "$CACHE_DIR" --prepare "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USEUSEDFORBUILD $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
+	    set -- init_buildsystem --cachedir "$CACHE_DIR" --prepare "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USEUSEDFORBUILD $ADDPREREQS $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
 	    echo "$* ..."
 	    "$@" || cleanup_and_exit 1
 	    check_exit
@@ -1702,7 +1710,7 @@ for SPECFILE in "${SPECFILES[@]}" ; do
 	echo "BUILD_INCARNATION=$INCARNATION" > $BUILD_ROOT/.buildenv
 	CREATE_BUILD_BINARIES=
 	egrep '^#[       ]*needsbinariesforbuild[       ]*$' >/dev/null <$MYSRCDIR/$SPECFILE && CREATE_BUILD_BINARIES=--create-build-binaries
-	set -- init_buildsystem --cachedir "$CACHE_DIR" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USEUSEDFORBUILD $CREATE_BUILD_BINARIES $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
+	set -- init_buildsystem --cachedir "$CACHE_DIR" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USEUSEDFORBUILD $ADDPREREQS $CREATE_BUILD_BINARIES $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
 	echo "$* ..."
 	"$@" || cleanup_and_exit 1
 	check_exit

--- a/build.1
+++ b/build.1
@@ -96,6 +96,11 @@ same packages used for the srcrpm build.
 .B --norootforbuild
 
 .TP
+.B --addprereqs
+Also install packages required by PreReq, Requires(pre),
+and Requires(post) in the build chroot. Useful for running
+checks that execute the package scripts, like post-build-checks.
+.TP
 .B --help
 Print a short help text.
 .TP

--- a/expanddeps
+++ b/expanddeps
@@ -8,7 +8,7 @@ use strict;
 
 use Build;
 
-my ($dist, $rpmdeps, $archs, $configdir, $useusedforbuild);
+my ($dist, $rpmdeps, $archs, $configdir, $useusedforbuild, $addprereqs);
 
 while (@ARGV)  {
   if ($ARGV[0] eq '--dist') {
@@ -34,6 +34,11 @@ while (@ARGV)  {
   if ($ARGV[0] eq '--useusedforbuild') {
     shift @ARGV;
     $useusedforbuild = 1;
+    next;
+  }
+  if ($ARGV[0] eq '--addprereqs') {
+    shift @ARGV;
+    $addprereqs = 1;
     next;
   }
   if ($ARGV[0] eq '--define') {
@@ -254,6 +259,8 @@ if ($spec) {
   $packvers = $d->{'version'};
   $subpacks = $d->{'subpacks'};
   @packdeps = @{$d->{'deps'} || []};
+  push(@packdeps, @{$d->{'prereqs'}})
+    if $addprereqs && $d->{'prereqs'};
 }
 
 Build::readdeps($cf, undef, \%repo);

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -35,6 +35,7 @@ RPMIDFMT="%{NAME}-%{VERSION}-%{RELEASE} %{BUILDTIME}\n"
 
 PREPARE_VM=
 USEUSEDFORBUILD=
+ADDPREREQS=
 LIST_STATE=
 RPMLIST=
 CLEAN_BUILD=
@@ -53,6 +54,10 @@ while test -n "$1" ; do
 	--useusedforbuild)
 	    shift
 	    USEUSEDFORBUILD=--useusedforbuild
+	    ;;
+	--addprereqs)
+	    shift
+	    ADDPREREQS=--addprereqs
 	    ;;
 	--list-state)
 	    shift
@@ -579,7 +584,7 @@ else
 	#
 	RPMLIST=$BUILD_ROOT/.init_b_cache/rpmlist
 	test -z "$LIST_STATE" && echo "expanding package dependencies..."
-	if ! $BUILD_DIR/expanddeps $USEUSEDFORBUILD "${definesnstuff[@]}" --dist "$BUILD_DIST" --depfile "$CACHE_FILE" --archpath "$BUILD_ARCH" --configdir $BUILD_DIR/configs "${PKGS[@]}" > $RPMLIST ; then
+	if ! $BUILD_DIR/expanddeps $USEUSEDFORBUILD $ADDPREREQS "${definesnstuff[@]}" --dist "$BUILD_DIST" --depfile "$CACHE_FILE" --archpath "$BUILD_ARCH" --configdir $BUILD_DIR/configs "${PKGS[@]}" > $RPMLIST ; then
 	    rm -f $BUILD_IS_RUNNING
 	    cleanup_and_exit 1
 	fi


### PR DESCRIPTION
To install Requires(post|pre) and PreReq into the chroot.
This is needed for post-build-checks to be able to execute
the package scripts.

See also http://lists.opensuse.org/opensuse-buildservice/2012-03/msg00054.html
