### PR TITLE
Install Requires(post|pre) and PreReq into the chroot

### DIFF
--- a/expanddeps
+++ b/expanddeps
@@ -254,6 +254,7 @@ if ($spec) {
   $packvers = $d->{'version'};
   $subpacks = $d->{'subpacks'};
   @packdeps = @{$d->{'deps'} || []};
+  push(@packdeps, @{$d->{'prereqs'}}) if $d->{'prereqs'};
 }
 
 Build::readdeps($cf, undef, \%repo);


### PR DESCRIPTION
This is needed for post-build-checks to be able to execute
the package scripts and makes the behaviour of build
consistent with OBS.

Second try. The behaviour is now always enabled.
