### PR TITLE
recreate vmdisk images if needed

### DIFF
--- a/build
+++ b/build
@@ -70,6 +70,7 @@ VM_INITRD=
 VMDISK_ROOTSIZE=4096
 VMDISK_SWAPSIZE=1024
 VMDISK_FILESYSTEM=ext3
+VMDISK_ROOT_CLEAN=no
 # settings are for speed and not data safety, we format anyway on next run
 VMDISK_MOUNT_OPTIONS=__default
 HUGETLBFSPATH=
@@ -973,6 +974,11 @@ while test -n "$1"; do
 	VMDISK_FILESYSTEM="$ARG"
 	shift
       ;;
+      *-vmdisk-clean)
+        needarg
+        VMDISK_ROOT_CLEAN="$ARG"
+        shift
+      ;;
       *-vmdisk-mount-options|--vm-disk-mount-options)
        needarg
         # options needs to be quoted to handle argument which might start with "-o ..."
@@ -1308,6 +1314,10 @@ if test -z "$RUNNING_IN_VM" ; then
 	    XENID="${XENID##*/}"
 	    XENID="${XENID#root_}"
 	    xm destroy "build_$XENID" >/dev/null 2>&1
+	fi
+	if [ "$VMDISK_ROOT_CLEAN" = "yes" ];
+	    #delete VM image so later we can recreate a new one
+	    rm -rf "$VM_IMAGE"
 	fi
 	if test ! -e "$VM_IMAGE"; then
 	    echo "Creating $VM_IMAGE (${VMDISK_ROOTSIZE}M)"


### PR DESCRIPTION
This adds ability to delete root image before create new one.

That's allow us to do over commit on the machines where we have not so much disk space.
