### PR TITLE
add vmdisk-cleanup, to remove VM root disk if needed

### DIFF
--- a/build
+++ b/build
@@ -72,6 +72,7 @@ VMDISK_SWAPSIZE=1024
 VMDISK_FILESYSTEM=ext3
 # settings are for speed and not data safety, we format anyway on next run
 VMDISK_MOUNT_OPTIONS=__default
+VMDISK_ROOT_CLEAN=no
 HUGETLBFSPATH=
 MEMSIZE=
 RUNNING_IN_VM=
@@ -979,6 +980,11 @@ while test -n "$1"; do
        VMDISK_MOUNT_OPTIONS=$(echo $ARG | sed 's/^\"\(.*\)\"$/\1/g')
        shift
       ;;
+      *-vmdisk-cleanup)
+        needarg
+        VMDISK_ROOT_CLEAN="$ARG"
+        shift
+      ;;
       *-rpmlist)
 	needarg
 	RPMLIST="--rpmlist $ARG"
@@ -1308,6 +1314,11 @@ if test -z "$RUNNING_IN_VM" ; then
 	    XENID="${XENID##*/}"
 	    XENID="${XENID#root_}"
 	    xm destroy "build_$XENID" >/dev/null 2>&1
+	fi
+	if [ "$VMDISK_ROOT_CLEAN" = "yes" ]; then
+	    #delete VM image so later we can recreate a new one
+	    echo "Deleting $VM_IMAGE"
+	    rm -rf "$VM_IMAGE"
 	fi
 	if test ! -e "$VM_IMAGE"; then
 	    echo "Creating $VM_IMAGE (${VMDISK_ROOTSIZE}M)"


### PR DESCRIPTION
On workers with limited amount of the disk space, we need to cleanup VM root disk and recreate it again, to do over commit.
