### PR TITLE
Do not include () when parsing macro option definition

### DIFF
--- a/Build/Rpm.pm
+++ b/Build/Rpm.pm
@@ -286,7 +286,7 @@ reexpand:
 	  $line = 'MACRO';
 	  last;
 	} elsif ($macname eq 'define' || $macname eq 'global') {
-	  if ($line =~ /^\s*([0-9a-zA-Z_]+)(\([^\)]*\))?\s*(.*?)$/) {
+	  if ($line =~ /^\s*([0-9a-zA-Z_]+)(?:\(([^\)]*)\))?\s*(.*?)$/) {
 	    my $macname = $1;
 	    my $macargs = $2;
 	    my $macbody = $3;


### PR DESCRIPTION
Otherwise the following warning is issued later:
`Odd number of elements in hash assignment at /usr/lib/build/Build/Rpm.pm line 131`
