### PR TITLE
build patches from Tizen Tools Team

### DIFF
--- a/build
+++ b/build
@@ -72,6 +72,7 @@ DO_LINT=
 DO_CHECKS=true
 CLEAN_BUILD=
 USE_SYSTEM_QEMU=
+KEEP_PACKS=
 SPECFILES=()
 SRCDIR=
 BUILD_JOBS=
@@ -994,6 +995,9 @@ while test -n "$1"; do
       *-use-system-qemu)
 	USE_SYSTEM_QEMU="--use-system-qemu"
       ;;
+      --keep-packs)
+	KEEP_PACKS="--keep-packs"
+      ;;
       *-root)
 	needarg
 	BUILD_ROOT="$ARG"
@@ -1761,7 +1765,7 @@ for SPECFILE in "${SPECFILES[@]}" ; do
 	if test "$DO_INIT" = true ; then
 	    # do first stage of init_buildsystem
 	    rm -f $BUILD_ROOT/.build.success
-	    set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" --prepare "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USE_SYSTEM_QEMU $USEUSEDFORBUILD $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
+	    set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" --prepare "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USE_SYSTEM_QEMU $KEEP_PACKS $USEUSEDFORBUILD $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
 	    echo "$* ..."
             start_time=`date +%s`
 	    "$@" || cleanup_and_exit 1
@@ -2155,7 +2159,7 @@ for SPECFILE in "${SPECFILES[@]}" ; do
 	CREATE_BUILD_BINARIES=
 	test "$BUILDTYPE" = preinstallimage && mkdir -p $BUILD_ROOT/.preinstall_image
 	egrep '^#[       ]*needsbinariesforbuild[       ]*$' >/dev/null <$MYSRCDIR/$SPECFILE && CREATE_BUILD_BINARIES=--create-build-binaries
-	set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USE_SYSTEM_QEMU $USEUSEDFORBUILD $CREATE_BUILD_BINARIES $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
+	set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USE_SYSTEM_QEMU $KEEP_PACKS $USEUSEDFORBUILD $CREATE_BUILD_BINARIES $RPMLIST "$MYSRCDIR/$SPECFILE" $ADDITIONAL_PACKS
 	echo "$* ..."
         start_time=`date +%s`
 	"$@" || cleanup_and_exit 1

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -35,6 +35,7 @@ RPMIDFMT="%{NAME}-%{VERSION}-%{RELEASE} %{BUILDTIME}\n"
 
 PREPARE_VM=
 USE_SYSTEM_QEMU=
+KEEP_PACKS=
 USEUSEDFORBUILD=
 LIST_STATE=
 RPMLIST=
@@ -50,6 +51,10 @@ while test -n "$1" ; do
 	--use-system-qemu)
 	    shift
 	    USE_SYSTEM_QEMU=true
+	    ;;
+	--keep-packs)
+	    shift
+	    KEEP_PACKS=true
 	    ;;
 	--create-build-binaries)
 	    shift
@@ -924,23 +929,25 @@ rpm_e()
 #
 # delete all packages we don't want
 #
-mkdir -p $BUILD_ROOT/.init_b_cache/todelete
-for PKG in $BUILD_ROOT/.init_b_cache/alreadyinstalled/* ; do
-    PKG=${PKG##*/}
-    test "$PKG" = "*" && continue
-    ln $BUILD_ROOT/.init_b_cache/alreadyinstalled/$PKG $BUILD_ROOT/.init_b_cache/todelete/$PKG
-done
-for PKG in $PACKAGES_TO_INSTALL $PACKAGES_TO_CBINSTALL ; do
-    rm -f $BUILD_ROOT/.init_b_cache/todelete/$PKG
-done
-for PKG in $BUILD_ROOT/.init_b_cache/todelete/* ; do
-    PKG=${PKG##*/}
-    test "$PKG" = "*" && continue
-    echo "deleting $PKG"
-    rpm_e "$PKG"
-    check_exit
-done
-rm -rf "$BUILD_ROOT/.init_b_cache/todelete"
+if [ -z "$KEEP_PACKS" ]; then
+    mkdir -p $BUILD_ROOT/.init_b_cache/todelete
+    for PKG in $BUILD_ROOT/.init_b_cache/alreadyinstalled/* ; do
+        PKG=${PKG##*/}
+        test "$PKG" = "*" && continue
+        ln $BUILD_ROOT/.init_b_cache/alreadyinstalled/$PKG $BUILD_ROOT/.init_b_cache/todelete/$PKG
+    done
+    for PKG in $PACKAGES_TO_INSTALL $PACKAGES_TO_CBINSTALL ; do
+        rm -f $BUILD_ROOT/.init_b_cache/todelete/$PKG
+    done
+    for PKG in $BUILD_ROOT/.init_b_cache/todelete/* ; do
+        PKG=${PKG##*/}
+        test "$PKG" = "*" && continue
+        echo "deleting $PKG"
+        rpm_e "$PKG"
+        check_exit
+    done
+    rm -rf "$BUILD_ROOT/.init_b_cache/todelete"
+fi
 
 rm -rf "$BUILD_ROOT/.init_b_cache/preinstalls"
 mkdir -p "$BUILD_ROOT/.init_b_cache/preinstalls"


### PR DESCRIPTION
The first patch is minor changes about --configdir parse issue.

The second patch is update uid/gid id not match, This is usefull to share build root between developers.

We plan to integrate this build module to Tizen SDK, so this feature is a must request, If this is not allowed any other way to create a build root, which can be used by other developers?

The third patch is a new option --keep-packs, this is still a new request by Tizen SDK, without --keep-packs option, build always remove useless package and when building another packages just removed packages will be installed again, this is not necessary. With --keep-packs, build can create a full build root env, which can build hundreds of packages with --noinit option and speed up building.

Please help to reivew these patches, If upstream have more correct way to implement these feature, we are pleasure to wait.

Thanks
Tizen Tools Team
