### PR TITLE
Upload .changes files as well

### DIFF
--- a/build
+++ b/build
@@ -2263,7 +2263,7 @@ for SPECFILE in "${SPECFILES[@]}" ; do
 	fi
 
 	mkdir -p $BUILD_ROOT/$TOPDIR/DEBS
-	for DEB in $BUILD_ROOT/$TOPDIR/*.deb ; do
+	for DEB in $BUILD_ROOT/$TOPDIR/BUILD/*.{deb,changes} ; do
 	    test -e "$DEB" && mv "$DEB" "$BUILD_ROOT/$TOPDIR/DEBS"
 	done
 	# link sources over


### PR DESCRIPTION
This is used for some local Collabora bugzilla hooks in bs_sched that are going to be upstreamed soon. Having the .changes files available to users is also pretty handy as they don't need to unpack the entire .deb to see what has changed in the debian changelog.
