### PR TITLE
Add pkg-config to default arch.conf

### DIFF
--- a/configs/arch.conf
+++ b/configs/arch.conf
@@ -12,5 +12,5 @@ Required: binutils gcc glibc libtool
 Support: acl autoconf automake zlib bzip2 filesystem curl
 Support: libtool ncurses perl gpgme libarchive openssl libssh2
 Support: libassuan libgpg-error attr expat xz pacman pacman-mirrorlist
-Support: fakeroot file sudo patch make net-tools
+Support: fakeroot file sudo patch make net-tools pkg-config
 


### PR DESCRIPTION
pkg-config is expected to be found at building time and is not supposed to land in and PKGBUILD's dependencies.
Now in order to build many packages in obs one has to workaround this by adding pkg-config to makedepends.
