### PR TITLE
Adding support for .tgz as a valid tar.gz file name

### DIFF
--- a/debtransform
+++ b/debtransform
@@ -239,7 +239,7 @@ if ($tags->{'DEBTRANSFORM-FILES-TAR'}) {
 }
 
 if (!$tarfile || !@debtarfiles) {
-  my @tars = grep {/\.tar(?:\.gz|\.bz2)?$/} @dir;
+  my @tars = grep {/\.tgz$|\.tar(?:\.gz|\.bz2)?$/} @dir;
   my @debtars = grep {/^debian\.tar(?:\.gz|\.bz2)?$/} @tars;
   if (!$tarfile) {
     @tars = grep {!/^debian\.tar(?:\.gz|\.bz2)?$/} @tars;
@@ -278,6 +278,13 @@ if ($tarfile =~ /\.zip/) {
     $tmptar = "$out/$tarfile";
     print "converting $dir/$old to $tarfile\n";
     system( ( "debtransformzip", "$dir/$old", "$tmptar" )) == 0 || die("cannot transform .zip to .tar.gz");
+}
+if ($tarfile =~ /\.tgz$/) {
+    my $old = $tarfile;
+    $tarfile =~ s/\.tgz/\.tar.gz/;
+    $tmptar = "$out/$tarfile";
+    print "renaming $dir/$old to $tarfile\n";
+    system ( ("mv",  "$dir/$old",  "$tmptar" ) ) == 0 || die("cannot rename .tgz to .tar.gz");
 }
 
 my @files;


### PR DESCRIPTION
Adding support for .tgz as a valid tar.gz file name
as suggested by Michael Schroeder in
http://lists.opensuse.org/opensuse-packaging/2012-12/msg00034.html

I implemented it as detecting and renaming. This is less intrusive than changing all sorts of locations to deal with .tgz endings. Plus it could later be expanded to add best compression.
