### PR TITLE
detect xz/lzma support in rpm5

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -195,8 +195,8 @@ preinstall()
     if test -e "$BUILD_ROOT/.init_b_cache/rpms/$1.rpm" ; then
 	PAYLOADDECOMPRESS=cat
 	case `rpm -qp --nodigest --nosignature --qf "%{PAYLOADCOMPRESSOR}\n" "$BUILD_ROOT/.init_b_cache/rpms/$1.rpm"` in
-	    lzma) rpm --showrc | grep PayloadIsLzma > /dev/null || PAYLOADDECOMPRESS="lzma -d" ;;
-	    xz) rpm --showrc | grep PayloadIsXz > /dev/null || PAYLOADDECOMPRESS="xz -d" ;;
+	    lzma) rpm --showrc | egrep 'PayloadIsLzma|_lzma' > /dev/null || PAYLOADDECOMPRESS="lzma -d" ;;
+	    xz) rpm --showrc | egrep 'PayloadIsXz|_xz' > /dev/null || PAYLOADDECOMPRESS="xz -d" ;;
 	esac
 	if test "$PAYLOADDECOMPRESS" = "lzma -d" ; then
 	    if ! lzma </dev/null >/dev/null 2>&1 ; then


### PR DESCRIPTION
rpm5 doesn't use PayloadIsLzma, but rather has _lzma in "rpm --showrc".
Same with PayloadIsXz / _xz.

So we check for both with egrep.

The fix was tested with rpm(4) and rpm5 on Arch Linux,
where the "rpm" package is rpm5 and "rpm-org" is rpm(4).
