### PR TITLE
Set personality syscall for aarch64

### DIFF
--- a/build
+++ b/build
@@ -865,7 +865,7 @@ case "$archname" in
     alpha*) PERSONALITY_SYSCALL=324 ;;
     sparc*) PERSONALITY_SYSCALL=191 ;;
     ia64*) PERSONALITY_SYSCALL=1140 ;;
-    i?86*|ppc*|arm*|sh4|cris|m68k|s390*|unicore32|microblaze)   PERSONALITY_SYSCALL=136 ;;
+    i?86*|ppc*|aarch64*|arm*|sh4|cris|m68k|s390*|unicore32|microblaze)   PERSONALITY_SYSCALL=136 ;;
     *) echo "ARCHITECTURE PERSONALITY IS UNKNOWN"; exit 1;;
 esac
 


### PR DESCRIPTION
aarch64 uses the wellknown syscall number like on most other architectures.
