### PR TITLE
Don't emulate VGA on POWER

### DIFF
--- a/build
+++ b/build
@@ -866,7 +866,7 @@ check_for_ppc()
 
     export kvm_bin="/usr/bin/qemu-system-ppc64"
     export console=hvc0
-    export KVM_OPTIONS="-enable-kvm -M pseries -mem-path /hugetlbfs"
+    export KVM_OPTIONS="-enable-kvm -M pseries -mem-path /hugetlbfs -vga none"
     export VM_KERNEL=/boot/vmlinux
     export VM_INITRD=/boot/initrd
     if [ -z "$RUNNING_IN_VM" -a "$VM_TYPE" = "kvm" ];then


### PR DESCRIPTION
qemu adds graphics emulation even with -no-graphics specifite. Disable VGA explicitly.
