### PR TITLE
support host_arch macro in project conf 

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -153,6 +153,9 @@ sub read_config {
   my @macros = split("\n", $std_macros.$extra_macros);
   push @macros, "%define _target_cpu $arch";
   push @macros, "%define _target_os linux";
+  my $host_arch = `uname -m`;
+  chomp $host_arch;
+  push @macros, "%define _host_arch $host_arch";
   my $config = {'macros' => \@macros, 'arch' => $arch};
   my @config;
   if (ref($cfile)) {


### PR DESCRIPTION
Hi all,

```
This is a patch to support _host_arch, which can be used as a condition to select different Pre-install
packages for different host arch.

For example, on x86_64 bit system, we need qemu.x86_64, but on i686
system, we may need qemu.i586 instead.
```

Thanks
Qiang
