### PR TITLE
Modify initvm usage for non-x86_64 hosts

### DIFF
--- a/common_functions
+++ b/common_functions
@@ -54,9 +54,14 @@ check_use_emulator()
         return 1
     fi
 
+    INITVM=$BUILD_DIR/initvm
+    if test "$BUILD_HOST_ARCH" != "x86_64"; then
+        INITVM="$BUILD_DIR/initvm.$BUILD_HOST_ARCH"
+    fi
+
     # to run the qemu initialization in the XEN chroot, we need to
     # register it with a static program or shell script
-    if test -e $BUILD_DIR/initvm && \
+    if test -e $INITVM && \
         test -e $BUILD_DIR/qemu-reg; then
         return 0	# prefer initvm to handle registration
     elif test -e /bin/bash-static \


### PR DESCRIPTION
Fall-back to initvm.$(uname -m) for non-x86_64 hosts.
