### PR TITLE
Optimize VM image setup

### DIFF
--- a/build
+++ b/build
@@ -1286,7 +1286,9 @@ if test "$VMDISK_MOUNT_OPTIONS" = __default; then
 	VMDISK_MOUNT_OPTIONS='-o data=writeback,commit=150,noatime'
     elif test "$VMDISK_FILESYSTEM" = btrfs ; then
         VMDISK_MOUNT_OPTIONS='-o nobarrier,noatime'
-    elif test "$VMDISK_FILESYSTEM" = "ext4" -o "$VMDISK_FILESYSTEM" = "ext3" ; then
+    elif test "$VMDISK_FILESYSTEM" = "ext4" ; then
+	VMDISK_MOUNT_OPTIONS='-o noatime'
+    elif test "$VMDISK_FILESYSTEM" = "ext3" ; then
 	VMDISK_MOUNT_OPTIONS='-o data=writeback,nobarrier,commit=150,noatime'
     elif test "$VMDISK_FILESYSTEM" = "ext2" ; then
 	VMDISK_MOUNT_OPTIONS='-o noacl,noatime'


### PR DESCRIPTION
These changes save over 5s on a VM setup phase of a typical
armv7l build. Instead of asking mkfs.ext4 to create a journal
(which is causing it to do flushed writes of lots of zero blocks)
and immediately deleting it afterwards, simply don't create it
initially. This alone saves 2s.

Prefering fallocate to make use of persistent preallocation
avoids fragmentation and small other fixes further speed up
the initial build setup phase by several seconds typically.
