### PR TITLE
Do not specify compression format for Arch packages when extracting

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -232,7 +232,7 @@ preinstall()
 	fi
 	rm -rf .init_b_cache/scripts/control control.tar.gz data.tar.gz
     elif test -e "$BUILD_ROOT/.init_b_cache/rpms/$1.arch" ; then
-	$TAR -z -f "$BUILD_ROOT/.init_b_cache/rpms/$1.arch"
+	$TAR -f "$BUILD_ROOT/.init_b_cache/rpms/$1.arch"
 	if test -f .INSTALL ; then
 	    cat .INSTALL > ".init_b_cache/scripts/$1.post"
 	    echo 'type post_install >/dev/null 2>&1 && post_install' >> ".init_b_cache/scripts/$1.post"


### PR DESCRIPTION
Arch packages are now using xz compression for packages, which were using gzip
compression before. When using GNU tar instead of bsdtar, they will be extracted
as gzip format instead, because the script explicitly tells tar that the package
uses gzip compression.

Remove the option for this and let tar guess the compression format of the
package, so both gzip and xz compressed packages could be handled.

The error message without this patch is the following:

```
[  575s] [1/26] preinstalling filesystem...
[  575s]
[  575s] gzip: stdin: not in gzip format
[  575s] tar: Child returned status 1
[  575s] tar: Error is not recoverable: exiting now
```

This post is the announcement when Arch added support for xz compression:
https://www.archlinux.org/news/switching-to-xz-compression-for-new-packages/
