### PR TITLE
track added/removed/modified patch automatically

### DIFF
--- a/vc
+++ b/vc
@@ -133,6 +133,24 @@ set +e
 	elif [ ! $just_edit ]; then
 		echo "- "
 		echo
+		if [ "$(which osc 2>/dev/null)" ]; then
+			OSC_STATUS="$(cd "$pkgpath" &> /dev/null; osc st)"
+			ADDED="$(sed -n 's/^A[[:blank:]]\+\([^[:blank:]].*\.\(patch\|diff\)\)$/  * \1/p' <<< "$OSC_STATUS")"
+			DELETED="$(sed -n 's/^D[[:blank:]]\+\([^[:blank:]].*\.\(patch\|diff\)\)$/  * \1/p' <<< "$OSC_STATUS")"
+			MODIFIED="$(sed -n 's/^M[[:blank:]]\+\([^[:blank:]].*\.\(patch\|diff\)\)$/  * \1/p' <<< "$OSC_STATUS")"
+			if [ -n "$ADDED" ]; then
+			    echo "- added patches:"
+			    echo "$ADDED"
+			fi
+			if [ -n "$DELETED" ]; then
+			    echo "- removed patches:"
+			    echo "$DELETED"
+			fi
+			if [ -n "$MODIFIED" ]; then
+			    echo "- modified patches:"
+			    echo "$MODIFIED"
+			fi
+		fi
 	fi
 	cat $changelog
 } >> "$tmpfile"


### PR DESCRIPTION
Automatically add information about added, removed or modified patches, when
editor is invoked. That means when -m is passed or file with comment is
passed, no record is added.

Signed-off-by: Tomáš Čech sleep_walker@suse.cz
