### PR TITLE
Preserve the user ownership too from the old changelog

### DIFF
--- a/vc
+++ b/vc
@@ -170,5 +170,3 @@ user=`stat -c "%G:%U" "$changelog"`
 mv "$tmpfile" "$changelog"
 chmod $mode "$changelog"
 chown $user "$changelog"
-mv "$tmpfile" "$changelog"
-chmod $mode "$changelog"


### PR DESCRIPTION
If I run the osc vc as another user as I have multiple account on obs instance the changelog changes its ownership for the other user. That is not desired and this fixes the problem.
