### PR TITLE
Adjust error message for binfmt-misc setup

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -606,9 +606,10 @@ else
 
 	    if [ -x "$BUILD_DIR/initvm.`uname -m`" -a -e "$BUILD_DIR/qemu-reg" ]; then
 	        $BUILD_DIR/initvm.`uname -m`
-	    else
-	        echo "Warning: could not register binfmt handlers. Neither build-initvm nor /usr/sbin/qemu-binfmt-conf.sh exist"
-	    fi
+            else
+                echo "Warning: could not register binfmt handlers. "
+                echo "Either build-initvm or $BUILD_DIR/qemu-reg missing."
+            fi
 
 	    echo 0 > /proc/sys/vm/mmap_min_addr
 	    read mmap_min_addr < /proc/sys/vm/mmap_min_addr


### PR DESCRIPTION
The error message was just outdated and didn't match
the actual code check anymore.
