### PR TITLE
Enable interpretation of backslash escapes

### DIFF
--- a/vc
+++ b/vc
@@ -125,7 +125,7 @@ set +e
 		echo
 	fi
 	if [ -n "$message" ]; then
-		echo "- $message"
+		echo -e "- $message"
 		echo
 	elif [ -n "$content" ]; then
 		cat "$content"


### PR DESCRIPTION
Otherwise it's impossible to pass messages spanning over multiple lines.
