### PR TITLE
build: make sure /bin, /usr/bin are in $PATH

### DIFF
--- a/build
+++ b/build
@@ -646,7 +646,7 @@ trap fail_exit EXIT
 
 shopt -s nullglob
 
-export PATH=$BUILD_DIR:/sbin:/usr/sbin:$PATH
+export PATH=$BUILD_DIR:/sbin:/usr/sbin:/bin:/usr/bin:$PATH
 
 if vm_detect_2nd_stage ; then
     set "/.build-srcdir/$RECIPEFILE"


### PR DESCRIPTION
eg. on archlinux /bin is a symlink to /usr/bin, and /bin is not
in $PATH.  building rpm packages for openSUSE fails because the
chroot environment has /bin/rpm invoked as `chroot $BUILD_ROOT rpm`.
