### PR TITLE
recipe_build_arch() should not run prepare() again

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -23,7 +23,7 @@ recipe_prepare_arch() {
 }
 
 recipe_build_arch() {
-    chroot $BUILD_ROOT su -c "cd $TOPDIR/BUILD && makepkg -f" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
+    chroot $BUILD_ROOT su -c "cd $TOPDIR/BUILD && makepkg -e -f" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
     for PKG in $BUILD_ROOT/$TOPDIR/BUILD/*.pkg.tar.?z ; do
 	test -e "$PKG" && mv "$PKG" "$BUILD_ROOT/$TOPDIR/ARCHPKGS"
     done


### PR DESCRIPTION
recipe_prepare_arch() would run makepkg -o (upto prepare()),
followed by recipe_build_arch() with makepkg -f, which includes
everything up to prepare() as well.  this would lead to spurious
build failures from failing patches:

  1054:0 > rm -rf src pkg
  1055:0 > makepkg -s -o
  ==> Making package: openntpd 3.9p1-24 (Fri Apr 25 13:43:31 CEST 2014)
  ==> Checking runtime dependencies...
  ==> Checking buildtime dependencies...
  ==> Retrieving sources...
    -> Found openntpd-3.9p1.tar.gz
    -> Found linux-adjtimex.patch
    -> Found openntpd.tmpfiles
    -> Found openntpd.service
  ==> Validating source files with sha256sums...
      openntpd-3.9p1.tar.gz ... Passed
      linux-adjtimex.patch ... Passed
      openntpd.tmpfiles ... Passed
      openntpd.service ... Passed
  ==> Extracting sources...
    -> Extracting openntpd-3.9p1.tar.gz with bsdtar
  ==> Starting prepare()...
  patching file configure.ac
  patching file defines.h
  patching file openbsd-compat/Makefile.in
  patching file openbsd-compat/openbsd-compat.h
  patching file openbsd-compat/port-linux.c
  ==> Sources are ready.
  1056:0 > makepkg -f
  ==> Making package: openntpd 3.9p1-24 (Fri Apr 25 13:43:34 CEST 2014)
  ==> Checking runtime dependencies...
  ==> Checking buildtime dependencies...
  ==> Retrieving sources...
    -> Found openntpd-3.9p1.tar.gz
    -> Found linux-adjtimex.patch
    -> Found openntpd.tmpfiles
    -> Found openntpd.service
  ==> Validating source files with sha256sums...
      openntpd-3.9p1.tar.gz ... Passed
      linux-adjtimex.patch ... Passed
      openntpd.tmpfiles ... Passed
      openntpd.service ... Passed
  ==> Extracting sources...
    -> Extracting openntpd-3.9p1.tar.gz with bsdtar
  ==> Starting prepare()...
  patching file configure.ac
  patching file defines.h
  patching file openbsd-compat/Makefile.in
  patching file openbsd-compat/openbsd-compat.h
  The next patch would create the file openbsd-compat/port-linux.c,
  which already exists!  Skipping patch.
  1 out of 1 hunk ignored
  ==> ERROR: A failure occurred in prepare().
      Aborting...

compare with makepkg -ef:

  1060:0 > makepkg -f -e
  ==> Making package: openntpd 3.9p1-24 (Fri Apr 25 13:49:18 CEST 2014)
  ==> Checking runtime dependencies...
  ==> Checking buildtime dependencies...
  ==> WARNING: Using existing src/ tree
  ==> Starting build()...
