### PR TITLE
Setup environment variables for Arch packages

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -36,5 +36,5 @@ recipe_resultdirs_arch() {
 }
 
 _arch_recipe_makepkg() {
-    chroot $BUILD_ROOT su -lc "cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf $*" $BUILD_USER
+    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf $*" $BUILD_USER
 }


### PR DESCRIPTION
login shells started with "su -l" behave differently on Arch
(/etc/profile not executed):
https://github.com/openSUSE/open-build-service/issues/713
