### PR TITLE
Fix 32bit ARM build on AArch64

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -645,7 +645,9 @@ vm_first_stage() {
     PERSONALITY=0
     test -n "$PERSONALITY_SYSCALL" && PERSONALITY=`perl -e 'print syscall('$PERSONALITY_SYSCALL', 0)."\n"'`
     case $(uname -m) in
-	ppc|ppcle|s390) PERSONALITY=8		# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
+	# ppc/aarch64/s390 kernel never tells us if a 32bit personality is
+	# active, assume we run on 64bit
+	ppc|ppcle|s390|aarch64) PERSONALITY=8
     esac
     test "$VM_TYPE" = lxc && PERSONALITY=0
     echo "PERSONALITY='$PERSONALITY'" >> $BUILD_ROOT/.build/build.data


### PR DESCRIPTION
On AArch64 the personality syscall doesn't tell us that we're running in
64bit mode. However, it does implicitly by telling us that it's aarch64.

So treat it the same way we already treat ppc and s390.

Signed-off-by: Alexander Graf agraf@suse.de
