### PR TITLE
untested fix for crazy GNU "chroot /" behavior

### DIFF
--- a/build-pkg-arch
+++ b/build-pkg-arch
@@ -36,7 +36,7 @@ pkg_cumulate_arch() {
 
 pkg_install_arch() {
     # -d -d disables deps checking
-    ( chroot $BUILD_ROOT pacman -U --force -d -d --noconfirm .init_b_cache/$PKG.$PSUF 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( chroot $BUILD_ROOT pacman -U --force -d -d --noconfirm /.init_b_cache/$PKG.$PSUF 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(warning: could not get filesystem information for |loading packages|looking for inter-conflicts|Targets |Total Installed Size: |Net Upgrade Size: |Proceed with installation|checking package integrity|loading package files|checking for file conflicts|checking keyring|Packages \(\d+\):|:: Proceed with installation|checking available disk space|installing |upgrading |warning:.*is up to date -- reinstalling|Optional dependencies for|    )/||/^$/||print'
 }
 
@@ -47,8 +47,8 @@ pkg_finalize_arch() {
 pkg_preinstall_arch() {
     $TAR -f "$BUILD_ROOT/.init_b_cache/rpms/$PKG.arch"
     if test -f .INSTALL ; then
-	cat .INSTALL > ".init_b_cache/scripts/$PKG.post"
-	echo 'type post_install >/dev/null 2>&1 && post_install' >> ".init_b_cache/scripts/$PKG.post"
+	cat .INSTALL > "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post"
+	echo 'type post_install >/dev/null 2>&1 && post_install' >> "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post"
     fi
     rm -f .PKGINFO .INSTALL
 }
@@ -56,7 +56,7 @@ pkg_preinstall_arch() {
 pkg_runscripts_arch() {
     if test -e "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post" ; then
 	echo "running $PKG postinstall script"
-	chroot $BUILD_ROOT ".init_b_cache/scripts/$PKG.post" < /dev/null
+	chroot $BUILD_ROOT "/.init_b_cache/scripts/$PKG.post" < /dev/null
 	rm -f "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post"
     fi
 }

--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -22,7 +22,7 @@ pkg_initdb_deb() {
 	rm -f $BUILD_ROOT/.init_b_cache/dpkg.deb
 	cp $BUILD_ROOT/.init_b_cache/rpms/dpkg.deb $BUILD_ROOT/.init_b_cache/dpkg.deb || cleanup_and_exit 1
     fi
-    chroot $BUILD_ROOT dpkg -i --force all .init_b_cache/dpkg.deb >/dev/null 2>&1
+    chroot $BUILD_ROOT dpkg -i --force all /.init_b_cache/dpkg.deb >/dev/null 2>&1
 }
 
 pkg_get_installed_deb() {
@@ -38,7 +38,7 @@ pkg_set_packageid_deb() {
 pkg_install_deb() {
     export DEBIAN_FRONTEND=noninteractive
     export DEBIAN_PRIORITY=critical
-    ( chroot $BUILD_ROOT dpkg --install --force all .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( chroot $BUILD_ROOT dpkg --install --force all /.init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg)/||/^$/||print'
     check_exit
     # ugly workaround for upstart system. some packages (procps) try
@@ -100,12 +100,12 @@ pkg_runscripts_deb() {
     fi
     if test -e "$BUILD_ROOT/.init_b_cache/scripts/$PKG.pre" ; then
 	echo "running $PKG preinstall script"
-	chroot $BUILD_ROOT ".init_b_cache/scripts/$PKG.pre" install < /dev/null
+	chroot $BUILD_ROOT "/.init_b_cache/scripts/$PKG.pre" install < /dev/null
 	rm -f "$BUILD_ROOT/.init_b_cache/scripts/$PKG.pre"
     fi
     if test -e "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post" ; then
 	echo "running $PKG postinstall script"
-	chroot $BUILD_ROOT ".init_b_cache/scripts/$PKG.post" configure '' < /dev/null
+	chroot $BUILD_ROOT "/.init_b_cache/scripts/$PKG.post" configure '' < /dev/null
 	rm -f "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post"
     fi
 }

--- a/build-pkg-rpm
+++ b/build-pkg-rpm
@@ -118,7 +118,7 @@ pkg_install_rpm() {
 	done
     fi
     ( chroot $BUILD_ROOT rpm --ignorearch --nodeps -U --oldpackage --ignoresize $RPMCHECKOPTS \
-		$ADDITIONAL_PARAMS .init_b_cache/$PKG.rpm 2>&1 || \
+		$ADDITIONAL_PARAMS /.init_b_cache/$PKG.rpm 2>&1 || \
 	  touch $BUILD_ROOT/exit ) | \
 	      grep -v "^warning:.*saved as.*rpmorig$"
 }
@@ -134,7 +134,7 @@ pkg_finalize_rpm() {
 	    cp $BUILD_ROOT/.init_b_cache/rpms/$PKG $BUILD_ROOT/${CUMULATED_LIST[$num]} || cleanup_and_exit 1
 	done > $BUILD_ROOT/.init_b_cache/manifest
 	chroot $BUILD_ROOT rpm --ignorearch --nodeps -Uh --oldpackage --ignoresize --verbose $RPMCHECKOPTS \
-		$ADDITIONAL_PARAMS .init_b_cache/manifest 2>&1 || touch $BUILD_ROOT/exit
+		$ADDITIONAL_PARAMS /.init_b_cache/manifest 2>&1 || touch $BUILD_ROOT/exit
 	for ((num=0; num<=cumulate; num++)) ; do
 	    rm -f $BUILD_ROOT/${CUMULATED_LIST[$num]}
 	done
@@ -190,12 +190,12 @@ pkg_preinstall_rpm() {
 pkg_runscripts_rpm() {
     if test -e "$BUILD_ROOT/.init_b_cache/scripts/$PKG.pre" ; then
 	echo "running $PKG preinstall script"
-	chroot $BUILD_ROOT sh ".init_b_cache/scripts/$PKG.pre" 0
+	chroot $BUILD_ROOT sh "/.init_b_cache/scripts/$PKG.pre" 0
 	rm -f "$BUILD_ROOT/.init_b_cache/scripts/$PKG.pre"
     fi
     if test -e "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post" ; then
 	echo "running $PKG postinstall script"
-	chroot $BUILD_ROOT sh ".init_b_cache/scripts/$PKG.post" 1
+	chroot $BUILD_ROOT sh "/.init_b_cache/scripts/$PKG.post" 1
 	rm -f "$BUILD_ROOT/.init_b_cache/scripts/$PKG.post"
     fi
 }


### PR DESCRIPTION
see http://marc.info/?t=140655718900007&r=1&w=2

arch broke with the attempt to teach it preinstall images:

  init_buildsystem --configdir /.build/configs --cachedir /var/cache/build /.build-srcdir/PKGBUILD build rpmlint-Factory ...
  [1/91] installing archlinux-keyring
  error: '.init_b_cache/archlinux-keyring.arch': could not find or read package
  [2/91] installing iana-etc
  error: '.init_b_cache/iana-etc.arch': could not find or read package
  ...

according to [0], it might be a GNU chroot(1) bug[1]

[0] http://marc.info/?l=opensuse-buildservice&m=140655932513048&w=2
[1] http://bugs.gnu.org/18062
