### PR TITLE
avoid watchdog getting fooled by binary junk in logfile

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -341,7 +341,7 @@ background_watchdog() {
     WATCHDOG_START=
     WATCHDOG_TIMEOUT=300
     while sleep 5 ; do
-	WATCH=`grep "### WATCHDOG MARKER" "$LOGFILE" | tail -n 1`
+	WATCH=`grep -a "### WATCHDOG MARKER" "$LOGFILE" | tail -n 1`
 	case $WATCH in
 	    *WATCHDOG\ MARKER\ START*) test -n "$WATCHDOG_START" || WATCHDOG_START=`date +%s` ;;
 	    *WATCHDOG\ MARKER\ END*) WATCHDOG_START= ;;


### PR DESCRIPTION
If grep thinks the file is binary it only prints "Binary file ... matches"
