### PR TITLE
Fix Build::Zypp:parsecfg expected full config file name.

### DIFF
--- a/Build/Zypp.pm
+++ b/Build/Zypp.pm
@@ -8,7 +8,7 @@ sub parsecfg {
   my ($repocfg, $reponame) = @_;
 
   local *REPO;
-  open(REPO, '<', "$root/etc/zypp/repos.d/$repocfg.repo") or return undef;
+  open(REPO, '<', "$root/etc/zypp/repos.d/$repocfg") or return undef;
   my $name;
   my $repo = {};
   while (<REPO>) {


### PR DESCRIPTION
Fixes #135

Signed-off-by: Dimitri John Ledkov dimitri.j.ledkov@intel.com
