### PR TITLE
vc: fixed chown call to support a user/group with whitespaces

### DIFF
--- a/vc
+++ b/vc
@@ -148,7 +148,7 @@ if [ -z "$message" ]; then
 	fi
 fi
 mode=`stat -c "%a" "$changelog"`
-user=`stat -c "%U:%G" "$changelog"`
+user=`stat -c "%u:%g" "$changelog"`
 mv "$tmpfile" "$changelog"
 chmod $mode "$changelog"
 chown $user "$changelog"


### PR DESCRIPTION
This fixes https://github.com/openSUSE/osc/issues/118
