### PR TITLE
Don't use fakeroot-tcp by default for *.dsc builds

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -54,9 +54,9 @@ recipe_build_dsc() {
     #           DSC_BUILD_JOBS="-j$BUILD_JOBS"
     #       fi
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc -rfakeroot-tcp $DSC_BUILD_JOBS"
+    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc $DSC_BUILD_JOBS"
     if test -e $BUILD_ROOT/$TOPDIR/SOURCES/build.script ; then
-	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc -rfakeroot-tcp'"
+	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"
 	chmod +x $BUILD_ROOT/$TOPDIR/SOURCES/build.script
     fi


### PR DESCRIPTION
Using the non-default gainroot command fakeroot-tcp is eating a lot of performance. The *.dsc build command can be configured through setting dsc:build_cmd for users that require fakeroot-tcp.
