### PR TITLE
Call cpio with --extract-over-symlinks, if present

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -203,6 +203,7 @@ preinstall() {
     else
 	unsafe_preinstall_check
 	CPIO="cpio --extract --unconditional --preserve-modification-time --make-directories --no-absolute-filenames --quiet"
+	cpio --help 2>/dev/null | grep -q -e --extract-over-symlinks && CPIO="$CPIO --extract-over-symlinks"
 	TAR="tar -x"
     fi
     pkg_preinstall


### PR DESCRIPTION
This is needed to do a local build against the Fedora:20 project:
Fedora 20 ships a filesystem rpm that symlinks /lib64 to /usr/lib64. Moreover, the libgcc rpm,
for example, ships a "/lib64/libgcc_s-4.8.2-20131017.so.1". Thus, openSUSE's cpio cannot
extract the archive (except --extract-over-symlinks is specified).