### PR TITLE
Fix --no-checks with older rpmbuild

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -110,7 +110,11 @@ recipe_build_spec() {
     # XXX: move _srcdefattr to macro file?
     rpmbopts=("$BUILD_RPM_BUILD_STAGE" "--define" "_srcdefattr (-,root,root)")
     if test "$DO_CHECKS" != true ; then
-	rpmbopts[${#rpmbopts[@]}]="--nocheck"
+	if chroot "$BUILD_ROOT" rpmbuild --nocheck --help >/dev/null 2>&1; then
+	    rpmbopts[${#rpmbopts[@]}]="--nocheck"
+	else
+	    echo "warning: --nocheck is not supported by this rpmbuild version"
+	fi
     fi
     if test "$rpmbuild" == "rpmbuild" ; then
 	    # use only --nosignature for rpm v4


### PR DESCRIPTION
If the --nocheck rpmbuild option is not supported, disable at least the
post build checks. This happens e.g. on SLE11.