### PR TITLE
Fixing UTC symlink resolving when setting localtime

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -1014,7 +1014,7 @@ done
 
 if test -e $BUILD_ROOT/usr/share/zoneinfo/UTC ; then
     for PROG in /usr/sbin/zic /usr/bin/zic /bin/zic /sbin/zic ; do
-        test -x $BUILD_ROOT/$PROG  && chroot $BUILD_ROOT bash -c "$PROG -l $(readlink -f /usr/share/zoneinfo/UTC)"
+        test -x $BUILD_ROOT/$PROG  && chroot $BUILD_ROOT bash -c "$PROG -l \$(readlink -f /usr/share/zoneinfo/UTC)"
     done
 fi
 


### PR DESCRIPTION
The readlink command substitution should be escaped. Otherwise we are getting the path in the host env instead of the chroot env.