### PR TITLE
Fix support for building inside LXC containers.

### DIFF
--- a/build
+++ b/build
@@ -980,7 +980,10 @@ if test -w /root ; then
 fi
 
 if test -z "$VM_IMAGE" -a -z "$LOGFILE" ; then
-    LOGFILE="$BUILD_ROOT/.build.log"
+    # lxc is special case: virtual machine shares logfile with host
+    if test -z "$RUNNING_IN_VM" -o "$VM_TYPE" != lxc; then
+        LOGFILE="$BUILD_ROOT/.build.log"
+    fi
 fi
 
 if test -n "$LOGFILE" -a -z "$RUN_SHELL" ; then

--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -21,22 +21,36 @@
 #
 ################################################################
 
+lxc_get_id() {
+    LXCID="obsbuild:${BUILD_ROOT##*/}"
+}
+
 vm_verify_options_lxc() {
     VM_IMAGE=
     VM_SWAP=
 }
 
 vm_startup_lxc() {
+    lxc_get_id
+    LXCDIR="`lxc-config lxc.lxcpath`/$LXCID"
+    LXCROOTFS="$LXCDIR/rootfs"
+    LXCHOOK="$LXCDIR/pre-mount.hook"
     LXCCONF="$BUILD_ROOT/.build.lxc.conf"
     rm -f "$LXCCONF"
     cat $BUILD_DIR/lxc.conf > "$LXCCONF"
     cat >> "$LXCCONF" <<-EOF
-	lxc.rootfs = $BUILD_ROOT
+	lxc.rootfs = $LXCROOTFS
+	lxc.hook.pre-mount = $LXCHOOK
 	EOF
     # XXX: do this always instead of leaking the hosts' one?
     echo "rootfs / rootfs rw 0 0" > $BUILD_ROOT/etc/mtab
-    LXCID=${BUILD_ROOT##*/}
     lxc-destroy -n "$LXCID" >/dev/null 2>&1 || true
+    mkdir -p "$LXCROOTFS"
+    cat > "$LXCHOOK" <<-EOF
+	#!/bin/sh
+	mount --bind "$BUILD_ROOT" "$LXCROOTFS"
+	EOF
+    chmod a+x "$LXCHOOK"
     lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
     lxc-start -n "$LXCID" "$vm_init_script"
     BUILDSTATUS="$?"
@@ -45,9 +59,8 @@ vm_startup_lxc() {
 }
 
 vm_kill_lxc() {
-    LXCID=${BUILD_ROOT##*/}
+    lxc_get_id
     lxc-stop -n "$LXCID" || true
-    lxc-destroy -n "$LXCID"
 }
 
 vm_fixup_lxc() {
@@ -71,6 +84,9 @@ vm_detach_swap_lxc() {
 }
 
 vm_cleanup_lxc() {
-    :
+    if test $$ -ne 1 && test $$ -ne 2 ; then
+        lxc_get_id
+        lxc-destroy -n "$LXCID"
+    fi
 }
 

--- a/lxc.conf
+++ b/lxc.conf
@@ -13,3 +13,6 @@ lxc.cgroup.devices.allow = c 1:9 rw
 lxc.cgroup.devices.allow = c 5:0 rw
 # ptmx
 lxc.cgroup.devices.allow = c 5:2 rw
+# console
+lxc.console = none
+lxc.console.logfile = /dev/stdout


### PR DESCRIPTION
This change adds proper support for building inside lightweight
LXC containers, improving security without using heavyweight virtual machine.

Now LXC container is properly created on startup and destroyed on cleanup.
No need to destroy container when killing build process,
cleanup is following anyway.

Now LXC container has its private rootfs distinct from buld root.
Build root is bind mounted on LXC container's rootfs
inside container's namespace during container startup
(and unmounted automatically when build inside container finished).
This is needed to prevent destruction of build root by lxc-destroy
which removes container's rootfs recursively.

Logging has been fixed for LXC.
LXC is a special case because virtualised process shares its build root
and log file with host system,
so a check has been added to prevent re-creating log file by second stage.
Also, LXC container had to be specially configured to log its console output
to stdout of lxc-start process.

Also, container name is now prefixed with "obsbuild:" to prevent
name clashes with other LXC containers on the same host.

Signed-off-by: Oleg Girko <ol@infoserver.lv>