### PR TITLE
Add initial support for building inside Docker containers.

### DIFF
--- a/build
+++ b/build
@@ -283,7 +283,7 @@ Known Parameters:
 
   --vm-type TYPE
               Use virtual machine instead of chroot
-              TYPE is one of xen|kvm|uml|qemu|lxc|zvm|openstack|ec2
+              TYPE is one of xen|kvm|uml|qemu|lxc|zvm|openstack|ec2|docker
 
   --vm-worker GUEST
               GUEST is a z/VM build worker controlled by the controlling
@@ -980,9 +980,15 @@ if test -w /root ; then
 fi
 
 if test -z "$VM_IMAGE" -a -z "$LOGFILE" ; then
-    # lxc is special case: virtual machine shares logfile with host
-    if test -z "$RUNNING_IN_VM" -o "$VM_TYPE" != lxc; then
-        LOGFILE="$BUILD_ROOT/.build.log"
+    # lxc and docker are special cases: virtual machine shares logfile with host
+    if test -z "$RUNNING_IN_VM"; then
+        case "$VM_TYPE" in
+        lxc|docker)
+            ;;
+        *)
+            LOGFILE="$BUILD_ROOT/.build.log"
+            ;;
+        esac
     fi
 fi
 

--- a/build-vm
+++ b/build-vm
@@ -60,7 +60,7 @@ HUGETLBFSPATH=
 # emulator specific?
 EMULATOR_SCRIPT=
 
-for i in ec2 emulator kvm lxc openstack qemu uml xen zvm ; do
+for i in ec2 emulator kvm lxc openstack qemu uml xen zvm docker ; do
     . "$BUILD_DIR/build-vm-$i"
 done
 
@@ -132,7 +132,7 @@ vm_parse_options() {
 	needarg
 	VM_TYPE="$ARG"
 	case "$VM_TYPE" in
-	    lxc) ;;
+	    lxc|docker) ;;
 	    ec2|xen|kvm|uml|qemu|emulator|openstack|zvm)
 		test -z "$VM_IMAGE" && VM_IMAGE=1
 	    ;;
@@ -249,7 +249,7 @@ vm_shutdown() {
     fi
     exec >&0 2>&0	# so that the logging tee finishes
     sleep 1		# wait till tee terminates
-    test "$VM_TYPE" = lxc && exit $1
+    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && exit $1
     kill -9 -1        # goodbye cruel world
     if ! test -x /sbin/halt ; then
 	test -e /proc/sysrq-trigger || mount -n -tproc none /proc
@@ -432,7 +432,7 @@ vm_detect_2nd_stage() {
     fi
     RUNNING_IN_VM=true
     test -e /proc/version || mount -orw -n -tproc none /proc
-    if test "$VM_TYPE" != lxc ; then
+    if test "$VM_TYPE" != lxc -a "$VM_TYPE" != docker ; then
 	mount -n ${VMDISK_MOUNT_OPTIONS},remount,rw /
     fi
     umount /run >/dev/null 2>&1
@@ -440,6 +440,9 @@ vm_detect_2nd_stage() {
     if ! test -e /sys/block; then
 	mkdir -p /sys
 	mount -orw -n -tsysfs sysfs /sys
+        # Docker already has sysfs mounted ro elsewhere,
+        # need to remount rw explicitly.
+        mount -o remount,rw sysfs /sys
     fi
 # qemu inside of xen does not work, check again with kvm later before enabling this
 #    if test -e /dev/kqemu ; then
@@ -673,7 +676,7 @@ vm_first_stage() {
 	ppc|ppcle|s390) PERSONALITY=8 ;;	# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
 	aarch64) test "$BUILD_ARCH" != "${BUILD_ARCH#armv}" && PERSONALITY=8 ;; # workaround, to be removed
     esac
-    test "$VM_TYPE" = lxc && PERSONALITY=0
+    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && PERSONALITY=0
     echo "PERSONALITY='$PERSONALITY'" >> $BUILD_ROOT/.build/build.data
     echo "MYHOSTNAME='`hostname`'" >> $BUILD_ROOT/.build/build.data
     echo -n "definesnstuff=(" >> $BUILD_ROOT/.build/build.data

--- a/build-vm-docker
+++ b/build-vm-docker
@@ -1,0 +1,69 @@
+#
+# Docker specific functions
+#
+################################################################
+#
+# Copyright (c) 2015 Oleg Girko
+# Copyright (c) 2015 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+
+vm_verify_options_docker() {
+    VM_IMAGE=
+    VM_SWAP=
+}
+
+vm_startup_docker() {
+    local name="obsbuild.${BUILD_ROOT##*/}"
+    docker rm "$name" >/dev/null 2>&1 || true
+    docker run \
+        --rm --name "$name" --cap-add=sys_admin --net=none \
+        -v "$BUILD_ROOT:/mnt" busybox /usr/sbin/chroot /mnt "$vm_init_script"
+    BUILDSTATUS="$?"
+    test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
+    cleanup_and_exit "$BUILDSTATUS"
+}
+
+vm_kill_docker() {
+    local name="obsbuild.${BUILD_ROOT##*/}"
+    docker stop -t 2 "$name" || true
+}
+
+vm_fixup_docker() {
+    :
+}
+
+vm_attach_root_docker() {
+    :
+}
+
+vm_attach_swap_docker() {
+    :
+}
+
+vm_detach_root_docker() {
+    :
+}
+
+vm_detach_swap_docker() {
+    :
+}
+
+vm_cleanup_docker() {
+    :
+}
+


### PR DESCRIPTION
This change adds support for building inside lightweight Docker containers.

The following approach is used.
* Minimal busybox pre-built image is used
(downloaded from Docker Hub automatically on the first use).
* Docker container is started from this image.
* The container is configured with sys_admin capability granted
to allow second stage to mount "/proc" and "/sys".
* Build root is configured as a volume for this container, mounted at
"/mnt" directory inside the container.
* Second stage is started inside the container, chrooted in "/mnt" directory.

This convoluted approach is used for the following reasons.
* There's no way in Docker to mount container's root fs and populate it
(as with KVM build).
* You can only create containers from images, mount some host directories
to container's directories upon container creation
(no way to reconfigure these mounts later);
all further changes to container's filesystem can be done only by
running commands inside the container.
* Mounting build root as container's root (as with LXC build) is impossible.
There's empty pre-built image called scratch, but using it to create
container with build root directory mounted on container's root doesn't work:
scratch image can be used only as base for creating other images,
but not containers;
also, it's not allowed to mount host directories on container's root anyway.
* It's also possible to create an image for each build, but it's
too slow and space consuming: you have to populate build root,
then use its tar archive to build a new container,
and only after that create a container from this image
and run second stage inside it.
Also, retrieving build results from this container can be tricky.
Using Docker's lightweight layered image features is an idea
for further research.
