### PR TITLE
vc: create changelog file only in case of a change

### DIFF
--- a/vc
+++ b/vc
@@ -106,6 +106,7 @@ if [ -z "$changelog" ]; then
 fi
 
 if [ ! -e "$changelog" ]; then
+	created_new_changelog=true
 	touch $changelog
 fi
 
@@ -144,6 +145,9 @@ if [ -z "$message" ]; then
 	set -- `md5sum "$tmpfile"`
 	if [ -z "$content" -a "$chksum" == "$1" ]; then
 		echo "no changes made"
+		if [ "$created_new_changelog" = true ]; then
+			rm -f "$changelog"
+		fi
 		exit 0
 	fi
 fi


### PR DESCRIPTION
In case vc created a new changelog file (via touch) but nothing got
added the empty file still remained. Since it's empty and the user
"aborted" creating one, it should get deleted.