### PR TITLE
Fix logging for building with lxc and docker.

### DIFF
--- a/build
+++ b/build
@@ -983,8 +983,10 @@ if test -w /root ; then
 fi
 
 if test -z "$VM_IMAGE" -a -z "$LOGFILE" ; then
-    # lxc and docker are special cases: virtual machine shares logfile with host
     if test -z "$RUNNING_IN_VM"; then
+        LOGFILE="$BUILD_ROOT/.build.log"
+    else
+        # lxc and docker are special cases: vm shares logfile with host
         case "$VM_TYPE" in
         lxc|docker)
             ;;


### PR DESCRIPTION
This change fixes a bug intruduced when adding support for Docker.
LOGFILE should be initialised outside of vm regardless of vm type;
lxc and docker are special cases only inside vm.

Signed-off-by: Oleg Girko <ol@infoserver.lv>