### PR TITLE
Double-check the debootstrap result

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -47,7 +47,11 @@ recipe_build_debootstrap() {
     rm -rf "$BUILD_ROOT/$myroot"
     set -- chroot $BUILD_ROOT debootstrap --no-check-gpg --variant=buildd --arch="${arch}" --include="$FULL_PKG_LIST" "$dist" "$myroot" file:///.build.binaries
     echo "running debootstrap..."
-    "$@"
+    if ! "$@" || ! chroot $BUILD_ROOT dpkg --configure -a; then
+        cat $BUILD_ROOT/debootstrap/debootstrap.log
+        echo "Failed to setup debootstrap chroot"
+        cleanup_and_exit 1
+    fi
 
     # adapt passwd
     if test $BUILD_USER = abuild ; then


### PR DESCRIPTION
Debootstrap sometimes fails to setup packages, especially when the
dependencies aren't available. In this case it helpfully reports success
as it's exit code. Checking in the chroot if everything was left
unconfigured (and whether configuring that fails) detects these cases.

Also in such a case output the debootstrap log so it's easier to analyse
the problem.