### PR TITLE
dsc: Generate .changes files when building deb packages.

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -80,7 +80,7 @@ dsc_build() {
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -v${DEBVERSION}~0 -us -uc"
     if test -e $buildroot/$TOPDIR/SOURCES/build.script ; then
 	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"


### PR DESCRIPTION
Include the changelog from the previous versions.
Add ~0 to use the current version in the changelog as well.