### PR TITLE
Force cpio(1) to extract files into symlinked directories

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -202,7 +202,7 @@ preinstall() {
 	TAR="/usr/bin/bsdtar -P --chroot -o --numeric-owner -x"
     else
 	unsafe_preinstall_check
-	CPIO="cpio --extract --unconditional --preserve-modification-time --make-directories --no-absolute-filenames --quiet"
+	CPIO="cpio --extract --unconditional --preserve-modification-time --make-directories --no-absolute-filenames --quiet --extract-over-symlinks"
 	TAR="tar -x"
     fi
     pkg_preinstall


### PR DESCRIPTION
A vulnerability[1] in cpio(1) has been reported in cpio which enables
directory traversal via symlinks. It has been patched and now
preinstalling RPM packages "over" the filesystem package which provides
/lib as a symlink to /usr/lib requires --extract-over-symlinks.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1197