### PR TITLE
Additional support for kvm options of -net, -netdev, -device

### DIFF
--- a/build
+++ b/build
@@ -324,6 +324,12 @@ Known Parameters:
   --vm-initrd FILE
               Kernel and initrd to use for VM (kvm and qemu only)
 
+  --vm-net OPTION
+  --vm-netdev OPTION
+  --vm-device OPTION
+              KVM only: Attach kvm option
+              Available options are -net, -netdev, -device
+	      (This options in kvm can not guarantee reproducible builds)
   --debug
               Enable creation of a debuginfo package
 

--- a/build-vm
+++ b/build-vm
@@ -45,6 +45,9 @@ VM_INITRD=
 VM_WORKER=
 VM_SERVER=
 VM_MEMSIZE=
+VM_NETOPT=()
+VM_NETDEVOPT=()
+VM_DEVICEOPT=()
 VMDISK_ROOTSIZE=4096
 VMDISK_SWAPSIZE=1024
 VMDISK_FILESYSTEM=
@@ -226,6 +229,21 @@ vm_parse_options() {
       ;;
       -vm-watchdog)
 	VM_WATCHDOG=true
+      ;;
+      -vm-net)
+        needarg
+        VM_NETOPT+=("$ARG")
+        shift
+      ;;
+      -vm-netdev)
+        needarg
+        VM_NETDEVOPT+=("$ARG")
+        shift
+      ;;
+      -vm-device)
+        needarg
+        VM_DEVICEOPT+=("$ARG")
+        shift
       ;;
       -*)
 	return 1

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -154,6 +154,25 @@ vm_verify_options_kvm() {
 	    VM_SWAPDEV=/dev/sdb
 	    ;;
     esac
+
+    if test -n "$VM_NETOPT" -o -n "$VM_NETDEVOPT" ; then
+        if test -n "$VM_NETOPT" ; then
+           for item in "${VM_NETOPT[@]}" ; do
+              kvm_options="$kvm_options -net $item"
+           done
+        fi
+        if test -n "$VM_NETDEVOPT" ; then
+           for item in "${VM_NETDEVOPT[@]}" ; do
+              kvm_options="$kvm_options -netdev $item"
+           done
+        fi
+    fi
+
+    if test -n "$VM_DEVICEOPT" ; then
+        for item in "${VM_DEVICEOPT[@]}" ; do
+            kvm_options="$kvm_options -device $item"
+        done
+    fi
 }
 
 vm_startup_kvm() {
@@ -187,7 +206,10 @@ vm_startup_kvm() {
     if test -n "$VMDISK_MOUNT_OPTIONS" ; then
         qemu_rootflags="rootflags=${VMDISK_MOUNT_OPTIONS#-o }"
     fi
-    set -- $qemu_bin -nodefaults -no-reboot -nographic -vga none -net none $kvm_options \
+    if test -z "$VM_NETOPT" -a -z "$VM_NETDEVOPT"; then
+        kvm_options="$kvm_options -net none"
+    fi
+    set -- $qemu_bin -nodefaults -no-reboot -nographic -vga none $kvm_options \
 	-kernel $vm_kernel \
 	-initrd $vm_initrd \
 	-append "root=$qemu_rootdev $qemu_rootfstype $qemu_rootflags panic=1 quiet no-kvmclock nmi_watchdog=0 rw rd.driver.pre=binfmt_misc elevator=noop console=$kvm_console init=$vm_init_script" \


### PR DESCRIPTION
KVM build type need additional options.

For network: When build a commercial program, connect license server to get certification during the build.
For disk: cache disk is a shared disk, etc

There was no option to crash when I check.