### PR TITLE
[backend] Allow lintian to break the build

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -91,9 +91,9 @@ dsc_build() {
 	chroot $buildroot su -
     else
 	chroot $buildroot su -c "export DEB_BUILD_OPTIONS=${DSC_BUILD_OPTIONS} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
-	if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false"; then
+	if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
 	   DEB_CHANGESFILE=${RECIPEFILE%.dsc}_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes
-	   chroot $buildroot su -c "which lintian > /dev/null && cd $TOPDIR && echo Running lintian && (set -x && lintian -i $DEB_SOURCEDIR/$DEB_DSCFILE)" - $BUILD_USER < /dev/null
+	   chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $DEB_SOURCEDIR/$DEB_DSCFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
 	fi
     fi
 }


### PR DESCRIPTION
From the lintian manpage:

 EXIT STATUS
       0   No policy violations or major errors detected.  (There may have
           been warnings, though.)

       1   Policy violations or major errors detected.


What policy is applied depends on the lintian profiles installed. See also
the "Lintian User's Manual" section on "Vendor Profiles":
https://lintian.debian.org/manual/section-2.5.html