### PR TITLE
livebuild: Use recipefile basename as default live image name

### DIFF
--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -148,6 +148,7 @@ recipe_build_livebuild() {
 	LB_MIRROR_BINARY_SECURITY="file:/.build.binaries/"
 	LB_MIRROR_DEBIAN_INSTALLER="file:/.build.binaries/"
 	LB_APT_SECURE="false"
+	LIVE_IMAGE_NAME="${RECIPEFILE%.livebuild}"
 	EOF
 
     # Expand live-build configuration to $TOPDIR/$LIVEBUILD_ROOT


### PR DESCRIPTION
If the upstream default "live-image" is used in OBS this will result in
the problem that build results overwrite each other in the repository.
Therefore lets provide a better default that is based on the recipe name.