### PR TITLE
debian: lintian should check generated binary and source package

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -93,7 +93,7 @@ dsc_build() {
 	chroot $buildroot su -c "export DEB_BUILD_OPTIONS=${DSC_BUILD_OPTIONS} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
 	if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
 	   DEB_CHANGESFILE=${RECIPEFILE%.dsc}_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes
-	   chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $DEB_SOURCEDIR/$DEB_DSCFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
+	   chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
 	fi
     fi
 }


### PR DESCRIPTION
Since commit 7e49410794f58316b3afaf5cf78c5ddc2fba9def the linitan call was
only covering the source Debian package. Since the build architecture is
gathered from the chroot it should be safe to use the changes file as
lintian input.