### PR TITLE
Add the dpkg way of noscripts removal

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -68,8 +68,22 @@ pkg_install_deb() {
 pkg_erase_deb() {
     export DEBIAN_FRONTEND=noninteractive
     export DEBIAN_PRIORITY=critical
-    ( cd $BUILD_ROOT && chroot $BUILD_ROOT dpkg --purge --force all $PKG 2>&1 || touch $BUILD_ROOT/exit ) | \
-	perl -ne '$|=1;/^(\(Reading database|Removing |Purging configuration files for )/||/^$/||print'
+    cd $BUILD_ROOT && chroot $BUILD_ROOT dpkg --purge --force all $PKG 2>&1 | {
+      local retry
+      while read line; do
+          case "$line" in
+              subprocess\ installed\ *script\ returned\ error\ exit\ status*)
+                 chroot $BUILD_ROOT rm -f /var/lib/dpkg/info/$PKG.{pre,post}rm
+                 retry=1
+              ;;
+              *) echo "$line" ;;
+          esac
+      done
+      if test -n "$retry"; then
+          echo "re-try deleting $PKG without post/pre remove scripts"
+          chroot $BUILD_ROOT dpkg --purge --force all $PKG 2>&1 || touch $BUILD_ROOT/exit
+      fi
+    } | perl -ne '$|=1;/^(\(Reading database|Removing |Purging configuration files for )/||/^$/||print'
 }
 
 pkg_cumulate_deb() {


### PR DESCRIPTION
Required since --force all doesn't prevent that post/pre remove
scripts get called. Required since init_buildsystem is removing
package without honoring dependencies. (e.g. libexpt1 get removed
before python3 => python3 prerm scripts fail. Deinstallation fails.
osc build fails.)