### PR TITLE
Bring back printing progress per package when initializing build root

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -902,7 +902,7 @@ for PKG in $MAIN_LIST ; do
 	read PKGID < $BUILD_ROOT/.init_b_cache/rpms/$PKG.id
 	read OLDPKGID < $BUILD_ROOT/.init_b_cache/alreadyinstalled/$PKG
 	if test "$PKGID" = "$OLDPKGID" ; then
-	    #echo "keeping ${PKGID%% *}"
+	    echo "keeping ${PKGID%% *}"
 	    rm -f $BUILD_ROOT/.init_b_cache/$PKG.$PSUF
 	    echo "$PKGID" > $BUILD_ROOT/installed-pkg/$PKG
 	    test -n "$PKG_HDRMD5" && echo "$PKG_HDRMD5 $PKGID" > $BUILD_ROOT/.preinstall_image/$PKG
@@ -919,7 +919,7 @@ for PKG in $MAIN_LIST ; do
 	    pkg_erase
 	else
 	    if test "$VERIFY_BUILD_SYSTEM" != true || pkg_verify_installed ; then
-		#echo "keeping ${PKGID%% *}"
+		echo "keeping ${PKGID%% *}"
 		echo "$PKGID" > $BUILD_ROOT/installed-pkg/$PKG
 		test -n "$PKG_HDRMD5" && echo "$PKG_HDRMD5 $PKGID" > $BUILD_ROOT/.preinstall_image/$PKG
 		continue


### PR DESCRIPTION
(This is a repost of the one unmerged commit from pull request #194 so it does not get lost.)

This reverts commit e2a3a2681057293a452938cb523783f8d88809e6.

That commit crippled progress reporting. Issue 1: It made the
"keeping" messages go away, but the progress indicator would still be
printed, so the commit only did half of the intent.

Issue 2: Since no newline was emitted (this was part of the "keeping"
message) and because stdout is line-buffered, the progress report
would only be sporadically emitted.

Furthermore, initializating a Debian root is slow compared to RPM, and
so there is a long time before any output is shown.

Show me my progress as it happens. Reinstate messages about kept
packages.