### PR TITLE
Run initscripts during debian setup

### DIFF
--- a/configs/debian.conf
+++ b/configs/debian.conf
@@ -5,7 +5,7 @@ Preinstall: libc6 libncurses5 libacl1 libattr1
 Preinstall: libreadline4 tar gawk dpkg
 Preinstall: sysv-rc gzip base-files
 
-Runscripts: base-files
+Runscripts: base-files initscripts
 
 VMinstall: util-linux binutils libblkid1 libuuid1 libdevmapper1.02 mount
 


### PR DESCRIPTION
Building some packages have dependencies related to auto testing.
We need initscripts to be run so that the startup scripts are correctly
linked for later use by postinst scripts from packages like cgmanager.