### PR TITLE
build-vm-kvm: fix check for presence of hw random device

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -178,7 +178,9 @@ vm_verify_options_kvm() {
     fi
 
     if test -n "$kvm_rng_device" ; then
-        if test -c /dev/hwrng ; then
+        if test -c /dev/hwrng &&
+	    test -f /sys/class/misc/hw_random/rng_current &&
+	    test "$(cat /sys/class/misc/hw_random/rng_current)" != none; then
             rng_dev="/dev/hwrng"
         else
             rng_dev="/dev/random"

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -72,7 +72,6 @@ vm_verify_options_kvm() {
 	    test -e /boot/zImage.guest && vm_kernel=/boot/zImage.guest
 	    test -e /boot/initrd.guest && vm_initrd=/boot/initrd.guest
 	    kvm_device=virtio-blk-device
-	    kvm_rng_device=virtio-rng-pci
 	    ;;
 	aarch64)
 	    kvm_bin="/usr/bin/qemu-system-aarch64"
@@ -178,12 +177,14 @@ vm_verify_options_kvm() {
         done
     fi
 
-    if test -c /dev/hwrng ; then
-        rng_dev="/dev/hwrng"
-    else
-        rng_dev="/dev/random"
+    if test -n "$kvm_rng_device" ; then
+        if test -c /dev/hwrng ; then
+            rng_dev="/dev/hwrng"
+        else
+            rng_dev="/dev/random"
+        fi
+        kvm_options="$kvm_options -object rng-random,filename=$rng_dev,id=rng0 -device $kvm_rng_device,rng=rng0"
     fi
-    kvm_options="$kvm_options -object rng-random,filename=$rng_dev,id=rng0 -device $kvm_rng_device,rng=rng0"
 }
 
 vm_startup_kvm() {


### PR DESCRIPTION
Even if /dev/hwrng exists there is no guarantee that a hw random device
exists.  If there is none it causes qemu to crash.

ERROR:backends/rng-random.c:47:entropy_available: assertion failed: (len != -1)