### PR TITLE
[armv7l] Unbreak random number device pass through

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -72,7 +72,7 @@ vm_verify_options_kvm() {
 	    test -e /boot/zImage.guest && vm_kernel=/boot/zImage.guest
 	    test -e /boot/initrd.guest && vm_initrd=/boot/initrd.guest
 	    kvm_device=virtio-blk-device
-	    kvm_rng_device=virtio-rng-pci
+	    kvm_rng_device=virtio-rng-device
 	    ;;
 	aarch64)
 	    kvm_bin="/usr/bin/qemu-system-aarch64"


### PR DESCRIPTION
The generic device name is virtio-rng-device which works for all
platforms. virtio-rng-pci is a specific implementation attached
tot he PCI bus. Unfortunately, ARMv7 does not have a PCI bus, so
everything fails with:

 No 'PCI' bus found for device 'virtio-rng-pci