### PR TITLE
Update lxc-create and lxc-start options to work with newer lxc.

### DIFF
--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -51,8 +51,8 @@ vm_startup_lxc() {
 	mount --bind "$BUILD_ROOT" "$LXCROOTFS"
 	EOF
     chmod a+x "$LXCHOOK"
-    lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
-    lxc-start -n "$LXCID" "$vm_init_script"
+    lxc-create -n "$LXCID" -t none -f "$LXCCONF" || cleanup_and_exit 1
+    lxc-start -n "$LXCID" -F "$vm_init_script"
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"


### PR DESCRIPTION
There are changes in `lxc-create` and `lxc-start` options in lxc 1.1:
* `lxc-create` now requires `-t` option to specify template;
* `lxc-start` now defaults to run in daemon mode, needs `-F` option to override.