### PR TITLE
[build] add support for LXC 1.0 and 1.1 parameter calls

### DIFF
--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -51,8 +51,16 @@ vm_startup_lxc() {
 	mount --bind "$BUILD_ROOT" "$LXCROOTFS"
 	EOF
     chmod a+x "$LXCHOOK"
-    lxc-create -n "$LXCID" -t none -f "$LXCCONF" || cleanup_and_exit 1
-    lxc-start -n "$LXCID" -F "$vm_init_script"
+    case "$(lxc-create --version)" in
+        1.0*)
+           lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
+           lxc-start -n "$LXCID" "$vm_init_script"
+           ;;
+        *)
+           lxc-create -n "$LXCID" -f "$LXCCONF" -t none || cleanup_and_exit 1
+           lxc-start -n "$LXCID" -F "$vm_init_script"
+           ;;
+    esac
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"


### PR DESCRIPTION
Current LXC support works only for LXC 1.1. But LXC 1.1 does not work with OBS, so check now for the version and use 1.0 or 1.1 calls.