### PR TITLE
[build] for KVM builds make sure loop and dm modules are preloaded

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -226,7 +226,7 @@ vm_startup_kvm() {
     set -- $qemu_bin -nodefaults -no-reboot -nographic -vga none $kvm_options \
 	-kernel $vm_kernel \
 	-initrd $vm_initrd \
-	-append "root=$qemu_rootdev $qemu_rootfstype $qemu_rootflags panic=1 quiet no-kvmclock nmi_watchdog=0 rw rd.driver.pre=binfmt_misc elevator=noop console=$kvm_console init=$vm_init_script" \
+	-append "root=$qemu_rootdev $qemu_rootfstype $qemu_rootflags panic=1 quiet no-kvmclock nmi_watchdog=0 rw rd.driver.pre=binfmt_misc rd.driver.pre=loop rd.driver.pre=dm-mod elevator=noop console=$kvm_console init=$vm_init_script" \
 	${VM_MEMSIZE:+-m $VM_MEMSIZE} \
 	"${qemu_args[@]}"
 


### PR DESCRIPTION
These modules are needed for example by KIWI and may not be in the initrd on some build targets, for example non SUSE distributions.