### PR TITLE
Add support for debbuild's eval and .debmacros

### DIFF
--- a/build-recipe-debbuild
+++ b/build-recipe-debbuild
@@ -22,7 +22,11 @@
 ################################################################
 
 recipe_setup_debbuild() {
-    TOPDIR=/usr/src/debian
+    TOPDIR=`chroot $BUILD_ROOT su -c "debbuild --eval '%_topdir'" - $BUILD_USER`
+    if test -z "$TOPDIR"; then
+	echo "Error: TOPDIR empty"
+	cleanup_and_exit 1
+    fi
     test "$DO_INIT_TOPDIR" = false || rm -rf "$BUILD_ROOT$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR/OTHER"

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -42,6 +42,9 @@ recipe_prepare_spec() {
 	args=(--release "$RELEASE")
     fi
 
+    rpmmacros=.rpmmacros
+    test "$BUILDTYPE" = debbuild && rpmmacros=.debmacros
+
     # fixup specfile
     CHANGELOGARGS=
     test -n "$CHANGELOG" -a -f "$BUILD_ROOT/.build-changelog" && CHANGELOGARGS="--changelog $BUILD_ROOT/.build-changelog"
@@ -55,8 +58,8 @@ recipe_prepare_spec() {
     fi
 
     # extract macros from configuration
-    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/.rpmmacros
-    if test -n "$BUILD_DEBUG" ; then
+    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/$rpmmacros
+    if test -n "$BUILD_DEBUG" && test "$BUILDTYPE" != debbuild ; then
 	echo '
 %prep %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%prep
 %package %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%package
@@ -65,16 +68,16 @@ recipe_prepare_spec() {
 %undefine _enable_debug_packages \
 %debug_package
 
-' >> $BUILD_ROOT/root/.rpmmacros
+' >> $BUILD_ROOT/root/$rpmmacros
     fi
 
     if test -n "$BUILD_JOBS" ; then
-	cat >> $BUILD_ROOT/root/.rpmmacros <<-EOF
+	cat >> $BUILD_ROOT/root/$rpmmacros <<-EOF
 		%jobs $BUILD_JOBS
 		%_smp_mflags -j$BUILD_JOBS
 		EOF
     fi
-    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/.rpmmacros $BUILD_ROOT/home/abuild/.rpmmacros
+    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/$rpmmacros $BUILD_ROOT/home/abuild/$rpmmacros
 
     # extract optflags from configuration
     queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" optflags ${BUILD_DEBUG:+debug} > $BUILD_ROOT/root/.rpmrc

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -42,8 +42,8 @@ recipe_prepare_spec() {
 	args=(--release "$RELEASE")
     fi
 
-    rpmmacros=.rpmmacros
-    test "$BUILDTYPE" = debbuild && rpmmacros=.debmacros
+    rawcfgmacros=.rpmmacros
+    test "$BUILDTYPE" = debbuild && rawcfgmacros=.debmacros
 
     # fixup specfile
     CHANGELOGARGS=
@@ -58,7 +58,7 @@ recipe_prepare_spec() {
     fi
 
     # extract macros from configuration
-    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/$rpmmacros
+    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/$rawcfgmacros
     if test -n "$BUILD_DEBUG" && test "$BUILDTYPE" != debbuild ; then
 	echo '
 %prep %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%prep
@@ -68,16 +68,16 @@ recipe_prepare_spec() {
 %undefine _enable_debug_packages \
 %debug_package
 
-' >> $BUILD_ROOT/root/$rpmmacros
+' >> $BUILD_ROOT/root/$rawcfgmacros
     fi
 
     if test -n "$BUILD_JOBS" ; then
-	cat >> $BUILD_ROOT/root/$rpmmacros <<-EOF
+	cat >> $BUILD_ROOT/root/$rawcfgmacros <<-EOF
 		%jobs $BUILD_JOBS
 		%_smp_mflags -j$BUILD_JOBS
 		EOF
     fi
-    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/$rpmmacros $BUILD_ROOT/home/abuild/$rpmmacros
+    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/$rawcfgmacros $BUILD_ROOT/home/abuild/$rawcfgmacros
 
     # extract optflags from configuration
     queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" optflags ${BUILD_DEBUG:+debug} > $BUILD_ROOT/root/.rpmrc


### PR DESCRIPTION
With the latest version of debbuild from Andreas Scherer, `debbuild` is now capable of limited configuration similar to RPM.

The debug stuff definitely has to be guarded out for now, as debbuild doesn't support making debug subpackages.

[The required version of debbuild has been submitted in OBS](https://build.opensuse.org/request/show/356636). The submitted version *must* be accepted before the code in this PR is deployed to build.o.o. However, after the PR is merged and a version of OBS-build with this code is deployed, the macros.obs-override file can be removed in the submitted version.