### PR TITLE
[PKGBUILD] Try to fix an issue where if ``prepare()`` fails then the …

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -41,7 +41,7 @@ recipe_setup_arch() {
 
 recipe_prepare_arch() {
     echo "Preparing sources..."
-    _arch_recipe_makepkg -so "2>&1" ">/dev/null"
+    _arch_recipe_makepkg -so "2>&1" ">/dev/null" || exit 1
 }
 
 recipe_build_arch() {


### PR DESCRIPTION
[PKGBUILD] Try to fix an issue where if ``prepare()`` fails then the build would continue anyway.

This is really bad because the prepare step may contain a patching steps and if this only runs partially and then build continues then we have no idea if the source code is in the state we intended it to be in.

I'm not sure if this is the correct fix but you can test this by having a prepare function in your PKGBUILD that looks like

```
prepare() {
  return 1
}
```