### PR TITLE
clean topdir before kiwi build

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -259,6 +259,7 @@ kiwi_post_unknown() {
 
 recipe_setup_kiwi() {
     TOPDIR=/usr/src/packages
+    rm -rf "$BUILD_ROOT$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR/OTHER"
     mkdir -p "$BUILD_ROOT$TOPDIR/SOURCES"


### PR DESCRIPTION
avoids recursive symlinks for repos