### PR TITLE
Cannot create arch linux chroot

### DIFF
--- a/build-pkg-arch
+++ b/build-pkg-arch
@@ -46,6 +46,9 @@ pkg_cumulate_arch() {
 }
 
 pkg_install_arch() {
+    # Pacman can't handle chroot
+    # https://bbs.archlinux.org/viewtopic.php?id=129661
+    (cd $BUILD_ROOT/etc && sed -i "s/^CheckSpace/#CheckSpace/g" pacman.conf)
     # -d -d disables deps checking
     ( cd $BUILD_ROOT && chroot $BUILD_ROOT pacman -U --force -d -d --noconfirm .init_b_cache/$PKG.$PSUF 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(warning: could not get filesystem information for |loading packages|looking for inter-conflicts|Targets |Total Installed Size: |Net Upgrade Size: |Proceed with installation|checking package integrity|loading package files|checking for file conflicts|checking keyring|Packages \(\d+\):|:: Proceed with installation|checking available disk space|installing |upgrading |warning:.*is up to date -- reinstalling|Optional dependencies for|    )/||/^$/||print'


### PR DESCRIPTION
This small fix for Arch-package building. Arch Pacman goes forward faster than one can understand but with this small fix it should make it work foreseeable future (fixes also issue #222 ):
    [    4s] [1/156] installing archlinux-keyring-20150605-1
    [    4s] looking for conflicting packages...
    [    4s] Packages (1) archlinux-keyring-20150605-1
    [    4s] error: could not determine root mount point /
    [    4s] error: not enough free disk space
    [    4s] error: failed to commit transaction (not enough free disk space)
    [    4s] Errors occurred, no packages were upgraded.
    [    4s] exit ...