### PR TITLE
Problem: simpleimage is built even if integration script fails

### DIFF
--- a/build-recipe-simpleimage
+++ b/build-recipe-simpleimage
@@ -32,7 +32,7 @@ recipe_build_simpleimage() {
     [ -x $BUILD_ROOT/bin/bash ] && SHELL="/bin/bash"
     if [ "`grep '^%build$' $BUILD_ROOT$TOPDIR/SOURCES/simpleimage`" ]; then
       echo "Running integration script..."
-      sed -n '/%build/,$ p' $BUILD_ROOT$TOPDIR/SOURCES/simpleimage | tail -n +2 | chroot $BUILD_ROOT $SHELL -x
+      sed -n '/%build/,$ p' $BUILD_ROOT$TOPDIR/SOURCES/simpleimage | tail -n +2 | chroot $BUILD_ROOT $SHELL -x || cleanup_and_exit 1
       echo "Integration script finished."
     fi
 


### PR DESCRIPTION
Solution: call cleanup_and_exit 1 if it fail