### PR TITLE
Reenable monitor mode for serial (stdin/out)

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -209,7 +209,7 @@ vm_startup_kvm() {
     if test -n "$kvm_serial_device" ; then
 	qemu_args=("${qemu_args[@]}" -device "$kvm_serial_device" -device virtconsole,chardev=virtiocon0 -chardev stdio,id=virtiocon0)
     else
-	qemu_args=("${qemu_args[@]}" -serial stdio)
+	qemu_args=("${qemu_args[@]}" -serial mon:stdio)
     fi
 
     if test -n "$BUILD_JOBS" -a "$icecream" = 0 -a -z "$BUILD_THREADS" ; then


### PR DESCRIPTION
The monitor mode is useful to debug hung build hosts and shouldn't
be a security concern as it requires access to the screen(1) of the
build worker, and when you have that you can do nasty things anyway.