### PR TITLE
Fixing issue:https://github.com/openSUSE/obs-build/issues/240

### DIFF
--- a/debtransform
+++ b/debtransform
@@ -295,6 +295,7 @@ if (!$tarfile || !@debtarfiles) {
     print "No DEBTRANSFORM-TAR line in the .dsc file.\n";
     print "Attempting automatic discovery of a suitable source archive.\n";
     @tars = grep {!/^debian\.tar(?:\.gz|\.bz2|\.xz)?$/} @tars;
+    @tars = grep {!/\.tar?$/} @tars;
     if (@debtarfiles) {
       my %debtarfiles = map {$_ => 1} @debtarfiles;
       @tars = grep {!$debtarfiles{$_}} @tars;


### PR DESCRIPTION
Sometime recompress fails to remove the original tar file. So debtransform should ignore all files ending in tar as there is no debian source format that supports files with only tar compression as source files.