### PR TITLE
pass SOURCE_DATE_EPOCH into build env

### DIFF
--- a/build
+++ b/build
@@ -411,6 +411,8 @@ shellquote() {
 # through /bin/su -c
 toshellscript() {
     echo "#!/bin/sh -x"
+    SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH//[^0-9]/} # sanitize
+    echo "export SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
     echo -n exec
     shellquote "$@"
     echo


### PR DESCRIPTION
to allow reproducible builds

for this to work from osc build, you need to add SOURCE_DATE_EPOCH
to the Defaults env_keep line in /etc/sudoers