### PR TITLE
Allow AArch32 builds on AArch64 hosts

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -750,7 +750,7 @@ vm_first_stage() {
     test "$PERSONALITY" = -1 && PERSONALITY=0	# syscall failed?
     case $(uname -m) in
 	ppc|ppcle|s390) PERSONALITY=8 ;;	# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
-	aarch64) test "$BUILD_ARCH" != "${BUILD_ARCH#armv}" && PERSONALITY=8 ;; # workaround, to be removed
+	aarch64) [[ "$BUILD_ARCH" == armv[567]* ]] && PERSONALITY=8 ;; # workaround, to be removed
     esac
     test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && PERSONALITY=0
     echo "PERSONALITY='$PERSONALITY'" >> $BUILD_ROOT/.build/build.data

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -85,7 +85,12 @@ vm_verify_options_kvm() {
 	aarch64)
 	    kvm_bin="/usr/bin/qemu-system-aarch64"
 	    kvm_console=ttyAMA0
-	    kvm_options="-enable-kvm -cpu host "
+            if [ "$PERSONALITY" != 0 ]; then
+                # Running an armv7 kernel on aarch64
+                kvm_options="-enable-kvm -cpu host,aarch64=off "
+            else
+                kvm_options="-enable-kvm -cpu host "
+            fi
             # This option only exists with QEMU 2.5 or newer
             if $kvm_bin -machine 'virt,?' 2>&1 | grep -q gic-version ; then
                 # We want to use the host gic version in order to make use

--- a/common_functions
+++ b/common_functions
@@ -29,7 +29,9 @@ build_host_arch() {
 
 extend_build_arch() {
     case $BUILD_ARCH in
-      aarch64) BUILD_ARCH="aarch64:armv8l" ;;
+      aarch64) BUILD_ARCH="aarch64:armv8l"
+	       [ "$VM_TYPE" = kvm ] && BUILD_ARCH="$BUILD_ARCH:armv7hl:armv7l:armv6hl:armv6l:armv5tel"
+	       ;;
       armv8l) BUILD_ARCH="armv8l" ;; # armv8l is aarch64 in 32bit mode. not a superset of armv7
       armv7hl) BUILD_ARCH="armv7hl:armv7l:armv6hl:armv6l:armv5tel" ;;
       armv7l) BUILD_ARCH="armv7l:armv6l:armv5tel" ;;


### PR DESCRIPTION
Most AArch64 systems are able to run KVM VMs with AArch32 kernels. Allow
that combination and pass the correct parameters into qemu in that case.

To make sure we don't break armv8l builds that would get executed on an
AArch64 kernel, only map armv5/6/7.

Signed-off-by: Alexander Graf <agraf@suse.de>