### PR TITLE
Allow AArch32 builds on AArch64 hosts

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -750,7 +750,7 @@ vm_first_stage() {
     test "$PERSONALITY" = -1 && PERSONALITY=0	# syscall failed?
     case $(uname -m) in
 	ppc|ppcle|s390) PERSONALITY=8 ;;	# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
-	aarch64) test "$BUILD_ARCH" != "${BUILD_ARCH#armv}" && PERSONALITY=8 ;; # workaround, to be removed
+	aarch64) [[ "$BUILD_ARCH" == armv[567]* ]] && PERSONALITY=8 ;; # workaround, to be removed
     esac
     test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && PERSONALITY=0
     echo "PERSONALITY='$PERSONALITY'" >> $BUILD_ROOT/.build/build.data

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -85,21 +85,28 @@ vm_verify_options_kvm() {
 	aarch64)
 	    kvm_bin="/usr/bin/qemu-system-aarch64"
 	    kvm_console=ttyAMA0
-	    kvm_options="-enable-kvm -cpu host "
-            # This option only exists with QEMU 2.5 or newer
-            if $kvm_bin -machine 'virt,?' 2>&1 | grep -q gic-version ; then
-                # We want to use the host gic version in order to make use
-                # of all available features (e.g. more than 8 CPUs) and avoid
-                # the emulation overhead of vGICv2 on a GICv3 host.
-                kvm_options+="-M virt,gic-version=host"
-            else
-                kvm_options+="-M virt"
-            fi
 	    vm_kernel=/boot/Image
 	    vm_initrd=/boot/initrd
-	    # prefer the guest kernel/initrd
-	    test -e /boot/Image.guest && vm_kernel=/boot/Image.guest
-	    test -e /boot/initrd.guest && vm_initrd=/boot/initrd.guest
+	    if [ "$PERSONALITY" != 0 ]; then
+		# Running an armv7 kernel on aarch64
+		kvm_options="-enable-kvm -cpu host,aarch64=off "
+		# prefer the guest kernel/initrd
+		test -e /boot/Image.guest32 && vm_kernel=/boot/Image.guest32
+		test -e /boot/initrd.guest32 && vm_initrd=/boot/initrd.guest32
+	    else
+		kvm_options="-enable-kvm -cpu host "
+		test -e /boot/Image.guest && vm_kernel=/boot/Image.guest
+		test -e /boot/initrd.guest && vm_initrd=/boot/initrd.guest
+	    fi
+	    # This option only exists with QEMU 2.5 or newer
+	    if $kvm_bin -machine 'virt,?' 2>&1 | grep -q gic-version ; then
+		# We want to use the host gic version in order to make use
+		# of all available features (e.g. more than 8 CPUs) and avoid
+		# the emulation overhead of vGICv2 on a GICv3 host.
+		kvm_options+="-M virt,gic-version=host"
+	    else
+		kvm_options+="-M virt"
+	    fi
 	    kvm_device=virtio-blk-device
 	    ;;
 	ppc|ppcle|ppc64|ppc64le)

--- a/common_functions
+++ b/common_functions
@@ -29,7 +29,11 @@ build_host_arch() {
 
 extend_build_arch() {
     case $BUILD_ARCH in
-      aarch64|aarch64_ilp32) BUILD_ARCH="aarch64:aarch64_ilp32:armv8l" ;;
+      aarch64|aarch64_ilp32)
+	BUILD_ARCH="aarch64:aarch64_ilp32:armv8l"
+	# With KVM we can also run AArch32 builds
+	[ "$VM_TYPE" = kvm ] && BUILD_ARCH="$BUILD_ARCH:armv7hl:armv7l:armv6hl:armv6l:armv5tel"
+	;;
       armv8l) BUILD_ARCH="armv8l" ;; # armv8l is aarch64 in 32bit mode. not a superset of armv7
       armv7hl) BUILD_ARCH="armv7hl:armv7l:armv6hl:armv6l:armv5tel" ;;
       armv7l) BUILD_ARCH="armv7l:armv6l:armv5tel" ;;


### PR DESCRIPTION
Most AArch64 systems are able to run KVM VMs with AArch32 kernels. Allow
that combination and pass the correct parameters into qemu in that case.

To make sure we don't break armv8l builds that would get executed on an
AArch64 kernel, only map armv5/6/7.

Signed-off-by: Alexander Graf <agraf@suse.de>