### PR TITLE
[build]: added DoD for aarch64 repositories on Debian

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -42,6 +42,7 @@ my %obs2debian = (
   "armv7el" => "armel",
   "armv7l"  => "armhf",
   "armv7hl" => "armhf",
+  "aarch64" => "arm64",
 );
 
 sub basearch {


### PR DESCRIPTION
Added a mapping for aarch64 architecture which is called arm64 in the Debian meta data.