### PR TITLE
[build] add support for LXC 1.0.8

### DIFF
--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -52,13 +52,13 @@ vm_startup_lxc() {
 	EOF
     chmod a+x "$LXCHOOK"
     case "$(lxc-create --version)" in
-        1.0*)
-           lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
-           lxc-start -n "$LXCID" "$vm_init_script"
-           ;;
-        *)
+        1.0.8|1.1.*)
            lxc-create -n "$LXCID" -f "$LXCCONF" -t none || cleanup_and_exit 1
            lxc-start -n "$LXCID" -F "$vm_init_script"
+           ;;
+        1.0.*)
+           lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
+           lxc-start -n "$LXCID" "$vm_init_script"
            ;;
     esac
     BUILDSTATUS="$?"


### PR DESCRIPTION
The new LXC 1.0.8 uses the same call parameters as LXC 1.1 and not as the old 1.0 branch.