### PR TITLE
fix macro expansion for macros without curly braces

### DIFF
--- a/Build/Rpm.pm
+++ b/Build/Rpm.pm
@@ -362,9 +362,9 @@ reexpand:
 	  if (defined($macros_args{$macname})) {
 	    # macro with args!
 	    if (!defined($macdata)) {
-	      $line =~ /^\s*([^\n]*).*?$/;
+	      $line =~ /^\s*([^\n]*).*$/;
 	      $macdata = $1;
-	      $line = $2;
+	      $line = '';
 	    }
 	    push @expandstack, ($expandedline, $line, $optmacros);
 	    $optmacros = adaptmacros(\%macros, $optmacros, grabargs($macname, $macros_args{$macname}, split(' ', $macdata)));


### PR DESCRIPTION
Parametrized macros without curly braces consume all remaining arguments
until end-of-line.

Fixes evaluation of e.g "%define foo() %1", which caused "Use of
initialized value $line in ..." due to dereference of uncaputured $2.