### PR TITLE
Build.pm: add support for auto-detecting Leap versions.

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -143,7 +143,7 @@ sub dist_canon($$) {
   } elsif ($rpmdist =~ /suse linux (\d+)\.(\d+)\.[4-9]\d/) {
     # alpha version
     $dist = "$1.".($2 + 1)."-$rpmdista";
-  } elsif ($rpmdist =~ /suse linux (\d+\.\d+)/) {
+  } elsif ($rpmdist =~ /suse linux (?:leap )?(\d+\.\d+)/) {
     $dist = "$1-$rpmdista";
   }
   return $dist;


### PR DESCRIPTION
With that change, obs-build should be able to automatically configure for OpenSuSE Leap versions without the need of hardcoding the version string.