### PR TITLE
create /.dockerenv in a $BUILD_ROOT

### DIFF
--- a/build-vm-docker
+++ b/build-vm-docker
@@ -29,6 +29,7 @@ vm_verify_options_docker() {
 
 vm_startup_docker() {
     local name="obsbuild.${BUILD_ROOT##*/}"
+    touch $BUILD_ROOT/.dockerenv
     docker rm "$name" >/dev/null 2>&1 || true
     docker run \
         --rm --name "$name" --cap-add=sys_admin --net=none \


### PR DESCRIPTION
Sometimes we need to distinguish if we running build in a container.
/.dockerenv is a file exists in all images. Let's pretend we run a
propper image

Signed-off-by: Dinar Valeev <k0da@opensuse.org>