### PR TITLE
[build] fixed typo from commit ebd4695389eb281d22cc394bcf8a2315312984…

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -265,9 +265,9 @@ recipe_setup_kiwi() {
     mkdir -p "$BUILD_ROOT$TOPDIR/SOURCES"
     mkdir -p "$BUILD_ROOT$TOPDIR/KIWI"
     # compat, older build versions did not clean TOPDIR ...
-    mkdir -p "$BUILD_ROOT$TOPDIR/BUILD
-    mkdir -p "$BUILD_ROOT$TOPDIR/RPMS
-    mkdir -p "$BUILD_ROOT$TOPDIR/SRPMS
+    mkdir -p "$BUILD_ROOT$TOPDIR/BUILD"
+    mkdir -p "$BUILD_ROOT$TOPDIR/RPMS"
+    mkdir -p "$BUILD_ROOT$TOPDIR/SRPMS"
     
     chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT$TOPDIR"
     if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then 


### PR DESCRIPTION
this typo causes build-recipe-kiwi to fail since commit ebd4695389eb281d22cc394bcf8a2315312984f6 , 3 closing shell quotes missing.