### PR TITLE
Adding needed pacman dependency

### DIFF
--- a/configs/arch.conf
+++ b/configs/arch.conf
@@ -4,7 +4,7 @@ Preinstall: glibc bash perl sed grep coreutils pacman pacman-mirrorlist
 Preinstall: gawk gzip filesystem curl libidn acl gpgme libarchive
 Preinstall: openssl libssh2 zlib libassuan libgpg-error attr
 Preinstall: expat xz bzip2 readline lzo krb5 e2fsprogs keyutils
-Preinstall: ncurses
+Preinstall: ncurses lz4
 
 VMinstall: util-linux libutil-linux binutils pcre libcap
 


### PR DESCRIPTION
Without *lz4*, *pacman* can't work properely, making all builds fail.