### PR TITLE
[ArchLinux] Set up the default packager information

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -35,7 +35,8 @@ recipe_setup_arch() {
 	echo 'source /etc/makepkg.conf'
 	printf '%s=%s\n' \
 	    BUILDDIR $TOPDIR/BUILD \
-	    PKGDEST $TOPDIR/ARCHPKGS
+	    PKGDEST $TOPDIR/ARCHPKGS \
+	    PACKAGER "\"OpenSUSE Open Build Service <admin@opensuse.org>\""
     } > $BUILD_ROOT$TOPDIR/makepkg.conf
 }
 


### PR DESCRIPTION
Default is the OpenSUSE Open Build Server.
I wrote this unaware if the packager information are available somewhere as variable.