### PR TITLE
build-vm-kvm: use virtio-rng-device also on aarch64

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -108,6 +108,7 @@ vm_verify_options_kvm() {
 		kvm_options+="-M virt"
 	    fi
 	    kvm_device=virtio-blk-device
+	    kvm_rng_device=virtio-rng-device
 	    ;;
 	ppc|ppcle|ppc64|ppc64le)
 	    kvm_bin="/usr/bin/qemu-system-ppc64"


### PR DESCRIPTION
This is needed so that it works with an armv7 guest.