### PR TITLE
configs/debian: add linux-libc-dev to Keep list

### DIFF
--- a/configs/debian.conf
+++ b/configs/debian.conf
@@ -25,6 +25,7 @@ Keep: binutils cpp cracklib file findutils gawk gcc gcc-ada gcc-c++
 Keep: gzip libada libstdc++ libunwind
 Keep: libunwind-devel libzio make mktemp pam-devel pam-modules
 Keep: patch perl rcs timezone
+Keep: linux-libc-dev
 
 Prefer: xorg-x11-libs libpng fam mozilla mozilla-nss xorg-x11-Mesa
 Prefer: unixODBC libsoup glitz java-1_4_2-sun gnome-panel


### PR DESCRIPTION
The Debian/Ubuntu kernel source package builds some userland tools
(perf, etc), so it needs linux-libc-dev. But since it is built from
the same source package, the dependency resolver blacklists it,
making it impossible to build Debian/Ubuntu kernel packages.
Add Keep: linux-libc-dev to the default config to avoid the
blacklisting.

Fixes: https://github.com/openSUSE/obs-build/issues/300