### PR TITLE
Profiled bundle

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -463,7 +463,7 @@ perform_image_bundle() {
     fi
 
     rm -rf "/$TOPDIR/KIWI.bundle"
-    if [ "$legacy" = "true" ]; then    
+    if [ "$legacy" = "true" ]; then
         bundle_call="/usr/sbin/kiwi --bundle-build $TOPDIR/KIWI-$imgtype"
         bundle_call="$bundle_call -d /$TOPDIR/KIWI.bundle/"
         bundle_call="$bundle_call --bundle-id ${kiwi_profile}Build$RELEASE"

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -469,7 +469,7 @@ perform_image_bundle() {
     else
         bundle_call="LANG=en_US.UTF-8 /usr/bin/kiwi result bundle"
         bundle_call="$bundle_call --target-dir $TOPDIR/KIWI-$imgtype"
-        bundle_call="$bundle_call --id Build$RELEASE"
+        bundle_call="$bundle_call --id ${kiwi_profile}Build$RELEASE"
         bundle_call="$bundle_call --bundle-dir /$TOPDIR/KIWI.bundle/"
     fi
     echo "$bundle_call"

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -457,12 +457,13 @@ perform_image_bundle() {
     local profile=$3
     local bundle_call
 
+    kiwi_profile=""
+    if [ "$profile" != "__not__set" ]; then
+        kiwi_profile="${profile}-"
+    fi
+
     rm -rf "/$TOPDIR/KIWI.bundle"
-    if [ "$legacy" = "true" ]; then
-        kiwi_profile=""
-        if [ "$profile" != "__not__set" ]; then
-            kiwi_profile="${profile}-"
-        fi
+    if [ "$legacy" = "true" ]; then    
         bundle_call="/usr/sbin/kiwi --bundle-build $TOPDIR/KIWI-$imgtype"
         bundle_call="$bundle_call -d /$TOPDIR/KIWI.bundle/"
         bundle_call="$bundle_call --bundle-id ${kiwi_profile}Build$RELEASE"


### PR DESCRIPTION
This PR is done to make sure profiled kiwi builds can be done also for the lasted kiwi version (kiwi v8). The profile name should be added in the ID also for kiwi v8 commands, otherwise building multiple profile ends up in multiple images that are named the same, resulting in a failure due to files overlap.