### PR TITLE
Compatibility fixes for newer Linux Kernel versions related to mounts in chroots.

### DIFF
--- a/build
+++ b/build
@@ -1070,7 +1070,7 @@ if test -w /root ; then
     mkdir -p $BUILD_ROOT/sys
     mkdir -p $BUILD_ROOT/dev/pts
     mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" || true
-    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
+    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5,ptmxmode=0666 none "$BUILD_ROOT/dev/pts"
 fi
 
 if test -z "$VM_IMAGE" -a -z "$LOGFILE" ; then
@@ -1212,7 +1212,7 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	    fi
 	fi
 	mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" || true
-	mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
+	mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5,ptmxmode=0666 none "$BUILD_ROOT/dev/pts"
 
 	copy_oldpackages
     fi
@@ -1303,7 +1303,7 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
     fi
 
     mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2> /dev/null
-    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts" 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5,ptmxmode=0666 none "$BUILD_ROOT/dev/pts" 2> /dev/null
     # needed for POSIX semaphores
     test -d $BUILD_ROOT/dev/shm || rm -f $BUILD_ROOT/dev/shm
     mkdir -p $BUILD_ROOT/dev/shm

--- a/build
+++ b/build
@@ -571,7 +571,7 @@ create_baselibs() {
 	pkgs=($RPMS)
     fi
 
-    mount -n -tproc none $BUILD_ROOT/proc 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2> /dev/null
     # don't use -R as extracted sources, build root etc might be below $TOPDIR
     chown "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT$TOPDIR"/* "$BUILD_ROOT$TOPDIR"/RPMS/* || true
 
@@ -1069,8 +1069,8 @@ if test -w /root ; then
     mkdir -p $BUILD_ROOT/proc
     mkdir -p $BUILD_ROOT/sys
     mkdir -p $BUILD_ROOT/dev/pts
-    mount -n -tproc none $BUILD_ROOT/proc || true
-    mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/dev/pts
+    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" || true
+    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
 fi
 
 if test -z "$VM_IMAGE" -a -z "$LOGFILE" ; then
@@ -1211,8 +1211,8 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 		cleanup_and_exit 1 "build does not work on a completely full filesystem"
 	    fi
 	fi
-	mount -n -tproc none $BUILD_ROOT/proc || true
-	mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/dev/pts
+	mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" || true
+	mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
 
 	copy_oldpackages
     fi
@@ -1302,12 +1302,12 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	fi
     fi
 
-    mount -n -tproc none $BUILD_ROOT/proc 2> /dev/null
-    mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/dev/pts 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts" 2> /dev/null
     # needed for POSIX semaphores
     test -d $BUILD_ROOT/dev/shm || rm -f $BUILD_ROOT/dev/shm
     mkdir -p $BUILD_ROOT/dev/shm
-    mount -n -ttmpfs none $BUILD_ROOT/dev/shm 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/dev/shm" || mount -n -ttmpfs none "$BUILD_ROOT/dev/shm" 2> /dev/null
 
     if test -n "$RUNNING_IN_VM" ; then
 	vm_setup_network
@@ -1414,7 +1414,7 @@ if test -n "$RPMS" -a -d "$BUILD_ROOT/usr/lib/build/checks" ; then
     for SRPM in $BUILD_ROOT/$TOPDIR/SRPMS/*src.rpm ; do
 	test -f "$SRPM" && PNAME=`rpm --nodigest --nosignature -qp --qf "%{NAME}" $SRPM`
     done
-    mount -n -tproc none $BUILD_ROOT/proc 2> /dev/null
+    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2> /dev/null
     for CHECKSCRIPT in $BUILD_ROOT/usr/lib/build/checks/* ; do
 	echo "... running ${CHECKSCRIPT##*/}"
 	$CHECKSCRIPT || cleanup_and_exit 1

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -177,8 +177,8 @@ clean_build_root() {
 	mkdir -p "$BUILD_ROOT/proc"
 	mkdir -p "$BUILD_ROOT/dev/pts"
 	if test "$UID" = 0 ; then
-	    mount -n -tproc none "$BUILD_ROOT/proc"
-	    mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
+	    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc"
+	    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
 	fi
     fi
 }
@@ -820,8 +820,8 @@ fi
 
 mkdir -p $BUILD_ROOT/proc
 mkdir -p $BUILD_ROOT/dev/pts
-mount -n -tproc none $BUILD_ROOT/proc 2>/dev/null || true
-mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/dev/pts 2>/dev/null || true
+mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2>/dev/null || true
+mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts" 2>/dev/null || true
 
 #
 # create .build.binaries directory if requested

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -178,7 +178,7 @@ clean_build_root() {
 	mkdir -p "$BUILD_ROOT/dev/pts"
 	if test "$UID" = 0 ; then
 	    mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc"
-	    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts"
+	    mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5,ptmxmode=0666 none "$BUILD_ROOT/dev/pts"
 	fi
     fi
 }
@@ -821,7 +821,7 @@ fi
 mkdir -p $BUILD_ROOT/proc
 mkdir -p $BUILD_ROOT/dev/pts
 mountpoint -q -- "$BUILD_ROOT/proc" || mount -n -tproc none "$BUILD_ROOT/proc" 2>/dev/null || true
-mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5 none "$BUILD_ROOT/dev/pts" 2>/dev/null || true
+mountpoint -q -- "$BUILD_ROOT/dev/pts" || mount -n -tdevpts -omode=0620,gid=5,ptmxmode=0666 none "$BUILD_ROOT/dev/pts" 2>/dev/null || true
 
 #
 # create .build.binaries directory if requested


### PR DESCRIPTION
See the per-commit descriptions.

This fixes the issue of dangling mount when using `obs-build` with chroots on systems with a relatively recent Linux Kernel version.