### PR TITLE
build-recipe-kiwi: export RELEASE to kiwi build

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -409,7 +409,7 @@ perform_image_build() {
 	echo "running kiwi --prepare for $imgtype..."
     fi
     # Do not use $BUILD_USER here, since we always need root permissions
-    prepare_call="cd $TOPDIR/SOURCES && rm -rf $TOPDIR/KIWIROOT-$imgtype"
+    prepare_call="export RELEASE=$RELEASE; cd $TOPDIR/SOURCES && rm -rf $TOPDIR/KIWIROOT-$imgtype"
     if [ "$legacy" = "true" ]; then
         prepare_call="$prepare_call && /usr/sbin/kiwi --logfile terminal"
     else
@@ -432,7 +432,7 @@ perform_image_build() {
 	echo "running kiwi --create for $imgtype..."
     fi
     mkdir -p $BUILD_ROOT/$TOPDIR/KIWI-$imgtype
-    create_call="cd $TOPDIR/SOURCES"
+    create_call="export RELEASE=$RELEASE; cd $TOPDIR/SOURCES"
     if [ "$legacy" = "true" ]; then
         create_call="$create_call && LANG=en_US.UTF-8 /usr/sbin/kiwi"
         create_call="$create_call --logfile terminal"


### PR DESCRIPTION
Make RELEASE variable available to the KIWI build environment.
This can be used in build.sh/images.sh like this:
  cp -a /image/.profile /kiwi-deploy/profile
  echo "kiwi_obsrelease=Build$RELEASE" >> /kiwi-deploy/profile
and made available to the installed image.

Of course a much better solution would be:
* add a KIWI option --release
* use that KIWI option to obs-build.
But this is a low-tech, yet working alternative which has no other dependencies.
If deemed useful, I can try to work with kiwi upstream to implement that as a long-term solution.