### PR TITLE
build-recipe-kiwi: make kiwi_profile local

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -457,7 +457,7 @@ perform_image_bundle() {
     local profile=$3
     local bundle_call
 
-    kiwi_profile=""
+    local kiwi_profile=""
     if [ "$profile" != "__not__set" ]; then
         kiwi_profile="${profile}-"
     fi


### PR DESCRIPTION
without this, the kiwi_profile in the calling function will
be modified, resulting in skipped builds for multiple <type/>
definitions in one build, only the first one will be built

I found this out by adding debug into the script, with the following result:
[   85s] debug:build_kiwi_appliance imgtype tbz kiwi_profile '__not__set'
[   85s] debug:build_kiwi_appliance prof '__not__set'
[  281s] debug:build_kiwi_appliance after perform_image_build
[  284s] debug:build_kiwi_appliance after perform_image_bundle: success
[  284s] debug:build_kiwi_appliance after perform_image_bundle: ???
[  284s] debug:build_kiwi_appliance after prof loop
[  284s] debug:build_kiwi_appliance imgtype docker kiwi_profile ''
[  284s] debug:build_kiwi_appliance after prof loop

imagetype is "tbz docker"
As you can see, after the  tbz was built, kiwi_profile was empty, causing the docker build to be never executed (the loop over the kiwi_profiles was never executed).