### PR TITLE
fixed typo in function name

### DIFF
--- a/build
+++ b/build
@@ -696,7 +696,7 @@ run_rsync() {
     fi
 }
 
-wipe_build_environement() {
+wipe_build_environment() {
     if test -n "$VM_TYPE"; then
 	vm_img_wipe
     else


### PR DESCRIPTION
switch --wipe cannot work because of typo in function name

wipe_build_environement -> wipe_build_environment