### PR TITLE
Copy qemu linux user to chroot

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -588,10 +588,14 @@ else
 	    if test "$mmap_min_addr" != 0 ; then
 		echo "Warning: mmap_min_addr is != 0. If programs fail at mmap this could be the reason."
 	    fi
-	    # FIXME: be more clever on which qemu binaries we need
 	    echo "copying qemu-linux-user binaries to $BUILD_ROOT/usr/bin"
 	    mkdir -p $BUILD_ROOT/usr/bin
-	    cp -av /usr/bin/qemu-* $BUILD_ROOT/usr/bin
+	    for arch in `echo $BUILD_ARCH | tr ":" " "`; do
+		if [ -x /usr/bin/qemu-$arch-binfmt ]; then
+		    echo "  Copying qemu-$arch*"
+		    cp -av /usr/bin/qemu-$arch* $BUILD_ROOT/usr/bin
+		fi
+	    done
 	fi
     fi
 

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -588,6 +588,10 @@ else
 	    if test "$mmap_min_addr" != 0 ; then
 		echo "Warning: mmap_min_addr is != 0. If programs fail at mmap this could be the reason."
 	    fi
+	    # FIXME: be more clever on which qemu binaries we need
+	    echo "copying qemu-linux-user binaries to $BUILD_ROOT/usr/bin"
+	    mkdir -p $BUILD_ROOT/usr/bin
+	    cp -av /usr/bin/qemu-* $BUILD_ROOT/usr/bin
 	fi
     fi
 


### PR DESCRIPTION
When cross-compiling with a qemu-linux-user supported arch, the init_buildsystem script fails as soon as we chroot, because we registered de arch binformat to the qemu binaries in /usr/bin, and as soon as we chroot they are not there anymore

This simple fix just copies the needed qemu binaries for the arch we are building into $BUILD_ROOT/usr/bin