### PR TITLE
fix build with vm-type lxc

### DIFF
--- a/lxc.conf
+++ b/lxc.conf
@@ -1,3 +1,5 @@
+lxc.aa_profile = unconfined
+
 lxc.cgroup.devices.deny = a
 # null
 lxc.cgroup.devices.allow = c 1:3 rw

--- a/lxc.conf
+++ b/lxc.conf
@@ -1,4 +1,4 @@
-lxc.aa_profile = unconfined
+lxc.aa_profile = lxc-default-with-mounting
 
 lxc.cgroup.devices.deny = a
 # null


### PR DESCRIPTION
tested successfully on Tumbleweed, 42.1, 42.2 and SLES-12-SP2
with lxc versions from 1.1.2 to 2.0.4

lxc is looking for a default apparmor profile, but none are installed in the build environment,
so we tell it to not use any.