### PR TITLE
use fixed hash seed values for perl+python

### DIFF
--- a/build
+++ b/build
@@ -438,6 +438,8 @@ shellquote() {
 # through /bin/su -c
 toshellscript() {
     echo "#!/bin/sh -x"
+    echo "export PYTHONHASHSEED=42"
+    echo "export PERL_HASH_SEED=42"
     echo -n exec
     shellquote "$@"
     echo


### PR DESCRIPTION
to allow packages like
perl-Apache-SessionX and python3-jupyter_nbconvert-doc
that output unordered hash values into the rpm
to have reproducible results (to make build-compare happy)
without finding and patching each such package individually