### PR TITLE
deb: Force unsafe io when install packages

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -58,7 +58,7 @@ pkg_initdb_deb() {
 	rm -f $BUILD_ROOT/.init_b_cache/dpkg.deb
 	cp $BUILD_ROOT/.init_b_cache/rpms/dpkg.deb $BUILD_ROOT/.init_b_cache/dpkg.deb || cleanup_and_exit 1
     fi
-    deb_chroot $BUILD_ROOT dpkg --install --force-depends .init_b_cache/dpkg.deb >/dev/null 2>&1
+    deb_chroot $BUILD_ROOT dpkg --install --force-unsafe-io --force-depends .init_b_cache/dpkg.deb >/dev/null 2>&1
 }
 
 pkg_prepare_deb() {
@@ -66,7 +66,7 @@ pkg_prepare_deb() {
 }
 
 pkg_install_deb() {
-    ( deb_chroot $BUILD_ROOT dpkg --install --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --install --force-unsafe-io --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
     # ugly workaround for upstart system. some packages (procps) try
     # to start a service in their configure phase. As we don't have


### PR DESCRIPTION
As the worker roots are transient there is little point in syncing
everything to the filesystem, force dpkg to use unsafe-io.

unsafe-io has been present in dpkg 1.15.8.6, which is older then the
dpkg on any still supported debian or ubuntu release, so should be safe
to do unconditionally

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>