### PR TITLE
Correct debootstrap log path

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -48,7 +48,7 @@ recipe_build_debootstrap() {
     set -- chroot $BUILD_ROOT debootstrap --keep-debootstrap-dir --no-check-gpg --variant=buildd --arch="${arch}" --include="$FULL_PKG_LIST" "$dist" "$myroot" file:///.build.binaries
     echo "running debootstrap..."
     if ! "$@" || ! chroot $BUILD_ROOT dpkg --configure -a; then
-        cat $BUILD_ROOT/debootstrap/debootstrap.log
+        cat $BUILD_ROOT/$myroot/debootstrap/debootstrap.log
         cleanup_and_exit 1 "Failed to setup debootstrap chroot"
     fi
 


### PR DESCRIPTION
Debootstrap logs into the the debootstrapped root, so pull the log from
there rather then the build root.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>