### PR TITLE
dsc: Keep everything

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -537,7 +537,9 @@ sub get_build {
     @directdepsend = grep {!/^-/} splice(@directdepsend, @deps + 1);
   }
   my @extra = (@{$config->{'required'}}, @{$config->{'support'}});
-  if (@{$config->{'keep'} || []}) {
+  if ($config->{'type'} eq 'dsc') {
+	  ;
+  } elsif (@{$config->{'keep'} || []}) {
     my %keep = map {$_ => 1} (@deps, @{$config->{'keep'} || []}, @{$config->{'preinstall'}});
     for (@{$subpacks || []}) {
       next if $keep{$_};


### PR DESCRIPTION
Debian package build dependencies allow for direct or indirect build
cycles, when doing a full distribution build in OBS this means keeping
the keep list gets very tedious very quickly.

Adjust the default keep processing such that for Debian (dsc) builds
everything is kept by default

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>

--

This feels like a bit of hack and changes how OBS looks at dsc build type quite a bit. Another option would be to introduce a new configuration item to enable this mode specifically.