### PR TITLE
debootstrap: generate apt caches

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -72,6 +72,8 @@ recipe_build_debootstrap() {
     mkdir -p $BUILD_ROOT/$myroot/dev/shm
     mount -n -ttmpfs none $BUILD_ROOT/$myroot/dev/shm
 
+    chroot $BUILD_ROOT/$myroot apt-cache gencaches
+
     # move topdir over
     mv "$BUILD_ROOT/$TOPDIR" "$BUILD_ROOT/$myroot/${TOPDIR%/*}"
 


### PR DESCRIPTION
Some packages seemingly rely on apt-cache (with populated caches) being
available during build. This seems an ugly assumption, but it does work on
the Debian buildd infrastructure so make it work on OBS as well.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>