### PR TITLE
debootstrap: Enable dpkg unsafe io usage

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -45,6 +45,9 @@ recipe_build_debootstrap() {
     done
     FULL_PKG_LIST="${FULL_PKG_LIST#,}"
     rm -rf "$BUILD_ROOT/$myroot"
+    mkdir -p "$BUILD_ROOT/$myroot/etc/dpkg/dpkg.cfg.d"
+    echo force-unsafe-io > "$BUILD_ROOT/$myroot/etc/dpkg/dpkg.cfg.d/force-unsafe-io"
+
     set -- chroot $BUILD_ROOT debootstrap --keep-debootstrap-dir --no-check-gpg --variant=buildd --arch="${arch}" --include="$FULL_PKG_LIST" "$dist" "$myroot" file:///.build.binaries
     echo "running debootstrap..."
     if ! "$@" || ! chroot $BUILD_ROOT dpkg --configure -a; then


### PR DESCRIPTION
To speed up dpkg a little bit one can turn on usage of unsafe-io to
lower the amount of sync() like calls it does. Enable this early in the
debootstrap run.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>