### PR TITLE
deb: Don't create an empty rcS

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -48,7 +48,6 @@ deb_setup() {
     :>> $BUILD_ROOT/var/lib/dpkg/available
     :>> $BUILD_ROOT/var/log/dpkg.log
     :>> $BUILD_ROOT/etc/ld.so.conf
-    :>> $BUILD_ROOT/etc/default/rcS
 }
 
 pkg_initdb_deb() {


### PR DESCRIPTION
rcS is a configuration file created by initscripts, not entirely clear
why obs-build tries to create it. But if it does initscripts will ask
whether to keep/replace it interactively blocking the build.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>