### PR TITLE
avoid failing with 'bad tempdir'

### DIFF
--- a/runservices
+++ b/runservices
@@ -100,6 +100,7 @@ if (@ARGV > 1 && $ARGV[0] eq '--buildroot') {
   shift @ARGV;
   $buildroot = shift @ARGV;
   $buildroot = '' if $buildroot && $buildroot eq '/';
+  $buildroot =~ s@//+@/@;      # or we may fail with 'bad tempdir' later. 
   die("bad buildroot\n") unless $buildroot eq '' || $buildroot =~ /^\//;
 }
 


### PR DESCRIPTION
In my case the buildroot has a double //, but the tempdir generated by $tempdir = File::Temp::tempdir('CLEANUP' => 1, 'DIR' => "$buildroot/tmp");
does not repeat the double //. This causes the subsequent 
die("bad tempdir\n") unless $tempdir =~ s/^\Q$buildroot\E//;

We better reduce and double // in the $buildroot to single / to be safe.