### PR TITLE
vc - do not break hardlinks

### DIFF
--- a/vc
+++ b/vc
@@ -155,6 +155,6 @@ if [ -z "$message" ]; then
 fi
 mode=`stat -c "%a" "$changelog"`
 user=`stat -c "%u:%g" "$changelog"`
-mv "$tmpfile" "$changelog"
+cat "$tmpfile" > "$changelog"
 chmod $mode "$changelog"
 chown $user "$changelog"


### PR DESCRIPTION
some packages like kernel use hardlinks for changelogs

vc breaks it - this patch address it