### PR TITLE
Debian: fix conflict with Debian's osc and obs-build

### DIFF
--- a/dist/debian.control
+++ b/dist/debian.control
@@ -5,10 +5,13 @@ Maintainer: Adrian Schroeter <adrian@suse.de>
 Build-Depends: debhelper (>= 4)
 Standards-Version: 3.7.2
 
-Package: build
+Package: obs-build
 Architecture: all
 Depends: ${perl:Depends}, rpm
 Recommends: rpm2cpio
+Conflicts: build
+Replaces: build
+Provides: build
 Description: A script to build SUSE Linux RPMs
  This package provides a script for building RPMs for SUSE Linux
  in a chroot environment.

--- a/dist/debian.links
+++ b/dist/debian.links
@@ -1,0 +1,2 @@
+usr/bin/build usr/bin/obs-build
+usr/lib/build usr/lib/obs-build

--- a/dist/debian.rules
+++ b/dist/debian.rules
@@ -41,7 +41,7 @@ install: build
 	dh_testroot
 	dh_clean -k 
 	dh_installdirs
-	make DESTDIR=$(CURDIR)/debian/build install
+	make DESTDIR=$(CURDIR)/debian/obs-build install
 
 binary-arch: build install
 	dh_testdir


### PR DESCRIPTION
Debian ships build in a package named obs-build. Given the package names are different, but ship the same files, there is a conflict on the file system. This was sent via https://build.opensuse.org/request/show/450943 but it got lost when the files moved into git.

Also add symlinks so that build can work with Debian's version of osc out of the box.