### PR TITLE
build-mkbaselibs-sle: conflict with other providers of mkbaselibs

### DIFF
--- a/dist/build-mkbaselibs-sle.changes
+++ b/dist/build-mkbaselibs-sle.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 23 10:44:57 UTC 2017 - dimstar@opensuse.org
+
+- Conflict with other implementations of mkbaselibs (packages
+  conflict on file level).
+
+-------------------------------------------------------------------
 Wed Aug  2 14:58:59 UTC 2017 - lnussel@suse.de
 
 - Fix path to files

--- a/dist/build-mkbaselibs-sle.spec
+++ b/dist/build-mkbaselibs-sle.spec
@@ -24,6 +24,7 @@ Version:        20170720
 Release:        0
 #!BuildIgnore:  build-mkbaselibs
 Provides:       build-mkbaselibs
+Conflicts:      otherproviders(build-mkbaselibs)
 Source:         obs-build-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch


### PR DESCRIPTION
That should address the issues reported by repo-checker:

```
found conflict of build-mkbaselibs-20170804-1.1.noarch with build-mkbaselibs-sle-20170804-1.1.noarch:
  - /usr/lib/build/baselibs_global-deb.conf
  - /usr/lib/build/baselibs_global.conf
  - /usr/lib/build/mkbaselibs

found conflict of build-mkbaselibs-20170804-1.1.noarch with build-mkbaselibs-sle-20170804-1.1.noarch:
  - /usr/lib/build/baselibs_global-deb.conf
  - /usr/lib/build/baselibs_global.conf
  - /usr/lib/build/mkbaselibs
```
