### PR TITLE
fix su imposed path in build-recipe-spec for newer rhel variant builds

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -167,6 +167,18 @@ recipe_build_spec() {
     if test -n "$RUN_SHELL"; then
 	chroot $BUILD_ROOT su -
     else
+
+	# fix su imposed path for newer rhel variants
+	if [ -e "/etc/redhat-release" ];then
+	    min_ver="7"
+	    dist_version=`rpm -qf /etc/redhat-release --queryformat '%{Version}\n'`
+
+	    echo -e "${min_ver}\n${dist_version}" | sort -V | head -n 1 | grep -q "${min_ver}"
+	    if [ $? -eq 0 ];then
+		echo "ENV_PATH /usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin" >> $BUILD_ROOT/etc/login.defs
+	    fi
+	fi
+
 	chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
     fi
 }


### PR DESCRIPTION
Hi there,

We have a standalone OBS instance providing community package builds and have had a couple of users report unexpected path dependencies being encoded into RPMs for CentOS7.  Looking further, these tend to come up when a package shells out to determine a path to a particular interpreter (e.g. autoconf macro's that are looking for python, perl, etc).

The short version is that under OBS, these packages can embed dependencies under CentOS to things like `/bin/perl` or `/bin/python` instead of `/usr/bin/perl` and `/usr/bin/python`.  The gotcha users tend to encounter comes about when installing into minimalistic environments (e.g. containers) that don't have perl/python preinstalled. In those cases, the  resulting obs delivered packages are uninstallable since no package provides `/bin/perl` ( ie. `/bin` is a symlink to `/usr/bin` that is owned by the `filesystem` package on centos).

Digging further into the process, it appears the reason this occurs is related to the use of `su -` to spawn build jobs. In particular, the default setup for su includes `/bin` before `/usr/bin` which is problematic for the rhel case since a default login environment doesn't contain `/bin` at all.

To see this in action, we have a simple perl example that mimics the use case of a more complicated package in the public build service at:

https://build.opensuse.org/package/show/home:crbaird/perlme

Note that this example ends up embedding a Require for `/bin/perl`. 

This PR is a simple attempt to address this issue for rhel variants (rhel7 and newer) by removing `/bin` from the spawned `su` environment via creation of `$BUILD_ROOT/etc/login_defs` to override the default path provisioning. (many thanks to @e4t from SUSE and @adrianreber from Red Hat for helping me get to the bottom of this).

