### PR TITLE
determine command to start a shell in kvm / docker

### DIFF
--- a/build-vm-docker
+++ b/build-vm-docker
@@ -33,6 +33,18 @@ vm_startup_docker() {
     docker run \
         --rm --name "$name" --cap-add=sys_admin --cap-add=MKNOD --net=none \
         -v "$BUILD_ROOT:/mnt" busybox /bin/chroot /mnt "$vm_init_script"
+
+    toshellscript "docker" "run" \
+                  "-it" "--rm" \
+                  "--name" "$name" \
+                  "--cap-add=sys_admin" \
+                  "--cap-add=MKNOD" \
+                  "--net=none" \
+                  "-v" "$BUILD_ROOT:/mnt" "busybox" \
+                  "/bin/chroot" "/mnt" \
+                  "/bin/bash" \
+      > $BUILD_ROOT/.get_shell_docker
+
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -279,6 +279,22 @@ vm_startup_kvm() {
 	${VM_MEMSIZE:+-m $VM_MEMSIZE} \
 	"${qemu_args[@]}"
 
+    toshellscript $qemu_bin \
+                  "-nodefaults" \
+                  "-no-reboot" \
+                  "-nographic" \
+                  "-vga" "none" \
+                  $kvm_options \
+                  "-kernel" \
+                  "$vm_kernel" \
+                  "-initrd" \
+                  "$vm_initrd" \
+                  "-append" \
+                  "${qemu_append/.build\/build/bin\/bash}" \
+                  ${VM_MEMSIZE:+-m $VM_MEMSIZE} \
+                  "${qemu_args[@]}" \
+        > $BUILD_ROOT/.get_shell_kvm
+
     if test "$PERSONALITY" != 0 ; then
 	# have to switch back to PER_LINUX to make qemu work
 	set -- linux64 "$@"


### PR DESCRIPTION
determine command to start a shell in kvm / docker and write it into the buildroot. 

The command is written to:

- .get_shell_docker for docker
- .get_shell_kvm for qemu / kvm 
- more to follow

These files will later be used to provide a shell in the desired build container.