### PR TITLE
changelog2spec: prefer _service:.*:.*.changes

### DIFF
--- a/changelog2spec
+++ b/changelog2spec
@@ -75,11 +75,11 @@ if (@ARGV == 2 && $ARGV[0] eq '--file') {
   opendir(D, $dir) || die("$dir: $!\n");
   my @changes = grep {/\.changes$/} readdir(D);
   closedir(D);
+  @changes = sort {length($a) <=> length($b) || $a cmp $b} @changes;
   # support _service: prefixes, they need to be stripped
   $file =~ s/^_service:.*://;
   my %changes = map {/^((?:_service:.*:)?(.*?))$/ ? ($2, $1) : ($_, $_)} @changes;
   @changes = keys %changes;
-  @changes = sort {length($a) <=> length($b) || $a cmp $b} @changes;
   exit(1) unless @changes;	# nothing to do
   if (@changes > 1) {
     while ($file ne '') {


### PR DESCRIPTION
without this,. "foo.changes" will be preferred over
"_service:obs_scm:foo.changes" which means --generatechanges in obs_scm
has no effect.

Debug code put in there (Data::Dumper \@changes and %changes):
old:
```
$VAR1 = [
          '_service:obs_scm:foo.changes',
          'foo.changes',
          'foo-bar.changes'
        ];
$VAR1 = {
          'foo.changes' => 'foo.changes',
          'foo-bar.changes' => 'foo-bar.changes'
        };
```
(it is actually random, depending on the order, readdir() returns the entries)

new:
```
$VAR1 = [
          'foo.changes',
          'foo-bar.changes',
          '_service:obs_scm:foo.changes'
        ];
$VAR1 = {
          'foo.changes' => '_service:obs_scm:foo.changes',
          'foo-bar.changes' => 'foo-bar.changes'
        };
```

I guess the _service handling code was inserted at the wrong place accidentally in commit e67b39088c887573c79997b41b22ffab680d8f38