### PR TITLE
vc: prevent leading newline when using the just_edit mode

### DIFF
--- a/vc
+++ b/vc
@@ -132,7 +132,7 @@ set +e
 	elif [ ! $just_edit ]; then
 		echo "- "
 	fi
-	if [ -f "$changelog" ] && [ -s "$changelog" ]; then
+	if [ -f "$changelog" ] && [ -s "$changelog" ] && [ ! $just_edit ]; then
 		# Avoid double newlines at EOF on a new blank .changes file,
 		# but do provide enough spacing between preexisting log entries.
 		echo


### PR DESCRIPTION
when using vc in just_edit mode a newline is added at the beginning of the file.