### PR TITLE
Only block .chroot archive config

### DIFF
--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -183,9 +183,9 @@ recipe_build_livebuild() {
     fi
 
     # Sanity check to not configure archives inside configuration
-    files=($BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/config/archives/*)
+    files=($BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/config/archives/*.chroot)
     if [ ${#files[@]} -gt 0 ]; then
-        cleanup_and_exit 1 "E: No configuration in config/archives/* allowed"
+        cleanup_and_exit 1 "E: No configuration in config/archives/*.chroot allowed"
     fi
 
     # TODO: Add the repository public key


### PR DESCRIPTION
.binary config seems reasonable to allow user to add, as it effect the
final live system.
.chroot is for the livebuild chroot, where there is no network access,
during build on OBS so blocking them seems reasonable.