### PR TITLE
Speed up debian packaging with parallel builds and deferred pkg trigger processing

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -58,7 +58,7 @@ pkg_initdb_deb() {
 	rm -f $BUILD_ROOT/.init_b_cache/dpkg.deb
 	cp $BUILD_ROOT/.init_b_cache/rpms/dpkg.deb $BUILD_ROOT/.init_b_cache/dpkg.deb || cleanup_and_exit 1
     fi
-    deb_chroot $BUILD_ROOT dpkg --install --force-unsafe-io --force-depends .init_b_cache/dpkg.deb >/dev/null 2>&1
+    deb_chroot $BUILD_ROOT dpkg --install --no-triggers --force-unsafe-io --force-depends .init_b_cache/dpkg.deb >/dev/null 2>&1
 }
 
 pkg_prepare_deb() {
@@ -66,7 +66,7 @@ pkg_prepare_deb() {
 }
 
 pkg_install_deb() {
-    ( deb_chroot $BUILD_ROOT dpkg --install --force-unsafe-io --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --install --no-triggers --force-unsafe-io --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
     # ugly workaround for upstart system. some packages (procps) try
     # to start a service in their configure phase. As we don't have
@@ -114,6 +114,11 @@ pkg_finalize_deb() {
     # configure all packages after complete installation, not for each package like rpm does
     # We need to run this twice, because of cyclic dependencies as it does not succeed on most
     # debian based distros in the first attempt.
+    if ! deb_chroot $BUILD_ROOT dpkg --triggers-only --pending  2>&1; then
+         echo "first trigger-processing attempt failed, trying again..."
+         deb_chroot $BUILD_ROOT dpkg --triggers-only --pending  2>&1 || cleanup_and_exit 1
+    fi
+
     if ! deb_chroot $BUILD_ROOT dpkg --configure --pending  2>&1; then
          echo "first configure attempt failed, trying again..."
          deb_chroot $BUILD_ROOT dpkg --configure --pending  2>&1 || cleanup_and_exit 1

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -95,7 +95,12 @@ dsc_build() {
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+    if test -z "$DSC_BUILD_CMD" ; then
+        DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+        if test -n "$BUILD_JOBS" ; then
+            DSC_BUILD_CMD="$DSC_BUILD_CMD -j$BUILD_JOBS"
+        fi
+    fi
     if test -e $buildroot/$TOPDIR/SOURCES/build.script ; then
 	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -6,9 +6,9 @@ Release: lp150.<CI_CNT>.<B_CNT>
 Prefer: -libstdc++6-gcc7 -libtsan0-gcc7 -libgomp1-gcc7 -libgcc_s1-gcc7 -libatomic1-gcc7 -libcilkrts5-gcc7 -libitm1-gcc7
 Prefer: -liblsan0-gcc7 -libmpx2-gcc7 -libubsan0-gcc7
 
-# kiwi-desc-isoboot pulls in a good set of packages also needed for instsource media (where we have no extra -requires for)
-Substitute: kiwi-packagemanager:instsource kiwi-desc-isoboot-requires kiwi-instsource kiwi-instsource-plugins-openSUSE-13-2
-Substitute: kiwi-setup:image kiwi createrepo tar -kiwi-desc-isoboot-requires -kiwi-desc-oemboot-requires -kiwi-desc-netboot-requires -kiwi-desc-vmxboot-requires -kiwi-desc-xenboot-requires
+Substitute: kiwi-packagemanager:instsource product-builder-plugin-Tumbleweed
+Substitute: system-packages:kiwi-product product-builder
+Substitute: kiwi-packagemanager: kiwi-packagemanager:zypper
 
 Prefer: installation-images-openSUSE installation-images-debuginfodeps-openSUSE
 
@@ -53,37 +53,7 @@ Prefer: libdb-4_8-devel
 Prefer: cdrkit-cdrtools-compat genisoimage
 VMinstall: util-linux libmount1 perl-base libdb-4_8 libsepol1 libblkid1 libuuid1 libsmartcols1
 VMinstall: kernel-obs-build
-#VMInstall: iproute2
-# we need either ip or ifconfig in the build root. net-tools is in Ring0
-# anyways, so use that one
 VMInstall: net-tools-deprecated
-
-
-ExportFilter: \.x86_64\.rpm$ x86_64
-ExportFilter: \.ia64\.rpm$ ia64
-ExportFilter: \.s390x\.rpm$ s390x
-ExportFilter: \.ppc64\.rpm$ ppc64
-ExportFilter: \.ppc64le\.rpm$ ppc64le
-ExportFilter: \.ppc\.rpm$ ppc
-ExportFilter: -ia32-.*\.rpm$
-ExportFilter: -32bit-.*\.sparc64\.rpm$
-ExportFilter: -64bit-.*\.sparcv9\.rpm$
-ExportFilter: -64bit-.*\.aarch64_ilp32\.rpm$
-ExportFilter: \.armv7l\.rpm$ armv7l
-ExportFilter: \.armv7hl\.rpm$ armv7l
-ExportFilter: ^glibc(?:-devel)?-32bit-.*\.sparc64\.rpm$ sparc64
-ExportFilter: ^glibc(?:-devel)?-64bit-.*\.sparcv9\.rpm$ sparcv9
-# it would be a great idea to have, but sometimes installation-images wants to build debuginfos in
-#ExportFilter: -debuginfo-.*\.rpm$
-#ExportFilter: -debugsource-.*\.rpm$
-#ExportFilter: ^master-boot-code.*\.i586.rpm$ . x86_64
-ExportFilter: ^acroread.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.ppc.rpm$ . ppc64
-ExportFilter: ^avmailgate.*\.s390.rpm$ . s390x
-ExportFilter: ^flash-player.*\.i586.rpm$ . x86_64
-ExportFilter: ^novell-messenger-client.*\.i586.rpm$ . x86_64
-ExportFilter: ^openCryptoki-32bit.*\.s390.rpm$ . s390x
 
 Required: rpm-build
 # Build all packages with -pie enabled
@@ -836,11 +806,8 @@ Target: armv6hl-suse-linux
 Target: armv7hl-suse-linux
 %endif
 
-
-#Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables
 Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables
 
-# 13.3 does not exist !
 %define suse_version 1500
 %define is_opensuse 1
 

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -823,7 +823,6 @@ Macros:
 %kernel_module_package_buildreqs kmod-compat kernel-syms
 
 %sles_version 0
-%ul_version 0
 %do_profiling 1
 %_vendor suse
 
@@ -855,3 +854,4 @@ Macros:
 %info_del(:-:) test -x /sbin/install-info -a ! -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --quiet --delete --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
 %{nil}
 :Macros
+

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -856,6 +856,21 @@ if test -n "$CREATE_BUILD_BINARIES" ; then
 fi
 
 #
+# defer Debian trigger processing
+#
+if test -d $BUILD_ROOT/etc/apt/apt.conf.d && ! test -f $BUILD_ROOT/etc/apt/apt.conf.d/triggers ; then
+    # https://raphaelhertzog.com/2011/05/30/trying-to-make-dpkg-triggers-more-useful-and-less-painful/
+    echo -n 'deferring Debian package trigger processing...'
+    cat > "$BUILD_ROOT/etc/apt/apt.conf.d/triggers" << EOF
+// Trigger deferred
+DPkg::NoTriggers "true";
+PackageManager::Configure "smart";
+DPkg::ConfigurePending "true";
+DPkg::TriggersPending "true";
+EOF
+fi
+
+#
 # reorder packages (already done in vm continuation)
 #
 if ! test -e $BUILD_ROOT/.build/init_buildsystem.data ; then


### PR DESCRIPTION
Parallel: older compat-level packages do not default to parallel builds and should be nudged, both in the `dpkg*` command call and in the rules-file. So far this is a valid use-case for some on-premise deployments and projects that should support older debian-like distributions.

Deferred trigger - mainly man-db is a single big offender in our setups instantiating of the build root. Doing it once, rather than for every other package during its installation (takes 3-6 sec each on our ARM workers) gives noticeable benefit since this process is forked off a lot less, at least (does take a minute for the single chunk of more to process in one bite, though).