### PR TITLE
Speed up NFS-backed builds by ability to tell the stronger server to do I/O heavylifting

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -18,16 +18,6 @@
 #
 ################################################################
 
-# TODO:
-# - parse Dockerfile and extract dependecies
-# - start docker daemon
-# - import base image to the docker daemon
-# - setup the dependencies directory
-# - setup a zypper repository that will serve the dependecies directory
-# - inject this repository as and ARG in the Dockerfile
-# - build the Dockerfile
-# - export the image tarball [OPTIONAL]
-
 package Build::Docker;
 
 use Build::SimpleXML;
@@ -246,7 +236,7 @@ sub showcontainerinfo {
 }
 
 sub showtags {
-  my ($fn, $image) = @ARGV;
+  my ($fn) = @ARGV;
   local $Build::Kiwi::urlmapper = sub { return $_[0] };
   my $d = {};
   $d = parse({}, $fn) if $fn;

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -2,8 +2,6 @@
 #
 # Docker specific functions.
 #
-# Author: TODO
-#
 ################################################################
 #
 # Copyright (c) 2017 SUSE Linux Products GmbH

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -83,7 +83,7 @@ recipe_build_docker() {
         chroot $BUILD_ROOT docker load --input $TOPDIR/SOURCES/$base_image_path
     else
         echo "Filesystem image found"
-        desired_tag=$(grep "^\s*FROM" Dockerfile | cut -d" " -f2)
+        desired_tag=$(grep "^\s*FROM" "$RECIPEFILE" | cut -d" " -f2)
         chroot $BUILD_ROOT docker import $TOPDIR/SOURCES/$base_image_path "$desired_tag"
     fi
 
@@ -95,40 +95,52 @@ recipe_build_docker() {
 	chroot $BUILD_ROOT bash -c "cd $TOPDIR/SOURCES/repos && dpkg-scanpackages -m . | gzip > Packages.gz"
     fi
 
-    # Find name and tag
-    IMAGE_NAME=
-    TAG=
-    if [ -f "TAG" ] && [ $(cat TAG | grep ":") ]; then
-        IMAGE_NAME=$(cat TAG | cut -d":" -f1)
-        TAG=$(cat TAG | cut -d":" -f2)
+    # Find tags
+    FIRSTTAG=
+    ALLTAGS=
+    for t in $(perl -I$BUILD_DIR -MBuild::Docker -e Build::Docker::showtags "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE") ; do
+	test -n "$FIRSTTAG" || FIRSTTAG="$t"
+        ALLTAGS="$ALLTAGS $t"
+    done
+    if test -z "$FIRSTTAG" -a -f TAG ; then
+	for t in $(egrep -v '^#' TAG) ; do
+	    test -n "$FIRSTTAG" || FIRSTTAG="$t"
+	    ALLTAGS="$ALLTAGS $t"
+	done
     fi
+    if test -z "$FIRSTTAG" ; then
+        cleanup_and_exit 1 "please specify a tag for the container"
+    fi
+    ALLTAGS="${ALLTAGS# }"
 
-    if [ -z "$IMAGE_NAME" ] || [ -z "$TAG" ]; then
-        cleanup_and_exit 1 "TAG file missing of contents invalid (use image_name:tag format)"
-    fi
+    tagargs=()
+    for t in $ALLTAGS; do
+	tagargs[${#tagargs[@]}]='-t'
+	tagargs[${#tagargs[@]}]="$t"
+    done
 
     # patch in obs-docker-support helper
-    sed -i '/^[ 	]*[fF][rR][oO][mM]/a COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install' $BUILD_ROOT/$TOPDIR/SOURCES/Dockerfile
-    echo >> $BUILD_ROOT/$TOPDIR/SOURCES/Dockerfile
-    echo 'RUN obs-docker-support --uninstall' >> $BUILD_ROOT/$TOPDIR/SOURCES/Dockerfile
+    sed -i '/^[ 	]*[fF][rR][oO][mM]/a COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install' $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
+    echo >> $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
+    echo 'RUN obs-docker-support --uninstall' >> $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
 
     # now do the build
-    echo "Building image"
-    if ! chroot $BUILD_ROOT docker build --network=host -t "$IMAGE_NAME:$TAG" $TOPDIR/SOURCES/ ; then
+    echo "Building image $ALLTAGS"
+    if ! chroot $BUILD_ROOT docker build --network=host "${tagargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
         cleanup_and_exit 1 "Docker build command failed"
     fi
 
     # Save the resulting image to a tarball. Use tag for generating the file name.
-    echo "Saving image"
+    echo "Saving image $FIRSTTAG"
     mkdir -p $BUILD_ROOT$TOPDIR/DOCKER
-    FILENAME="$IMAGE_NAME:$TAG"
+    FILENAME="$FIRSTTAG"
     FILENAME="${FILENAME//[\/:]/-}"
-    if ! chroot $BUILD_ROOT docker save --output "$TOPDIR/DOCKER/$FILENAME.tar" "$IMAGE_NAME:$TAG" ; then
+    if ! chroot $BUILD_ROOT docker save --output "$TOPDIR/DOCKER/$FILENAME.tar" "$FIRSTTAG" ; then
         cleanup_and_exit 1 "Docker save command failed"
     fi
     
     # Create containerinfo
-    perl -I$BUILD_DIR -MBuild::Docker -e Build::Docker::showcontainerinfo "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" "$FILENAME.tar" "$IMAGE_NAME:$TAG" containers/annotation> "$BUILD_ROOT$TOPDIR/DOCKER/$FILENAME.containerinfo"
+    perl -I$BUILD_DIR -MBuild::Docker -e Build::Docker::showcontainerinfo "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" "$FILENAME.tar" "$ALLTAGS" containers/annotation> "$BUILD_ROOT$TOPDIR/DOCKER/$FILENAME.containerinfo"
 
     # We're done. Clean up.
     recipe_cleanup_docker

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -6,9 +6,9 @@ Release: lp150.<CI_CNT>.<B_CNT>
 Prefer: -libstdc++6-gcc7 -libtsan0-gcc7 -libgomp1-gcc7 -libgcc_s1-gcc7 -libatomic1-gcc7 -libcilkrts5-gcc7 -libitm1-gcc7
 Prefer: -liblsan0-gcc7 -libmpx2-gcc7 -libubsan0-gcc7
 
-# kiwi-desc-isoboot pulls in a good set of packages also needed for instsource media (where we have no extra -requires for)
-Substitute: kiwi-packagemanager:instsource kiwi-desc-isoboot-requires kiwi-instsource kiwi-instsource-plugins-openSUSE-13-2
-Substitute: kiwi-setup:image kiwi createrepo tar -kiwi-desc-isoboot-requires -kiwi-desc-oemboot-requires -kiwi-desc-netboot-requires -kiwi-desc-vmxboot-requires -kiwi-desc-xenboot-requires
+Substitute: kiwi-packagemanager:instsource product-builder-plugin-Tumbleweed
+Substitute: system-packages:kiwi-product product-builder
+Substitute: kiwi-packagemanager: kiwi-packagemanager:zypper
 
 Prefer: installation-images-openSUSE installation-images-debuginfodeps-openSUSE
 
@@ -53,37 +53,7 @@ Prefer: libdb-4_8-devel
 Prefer: cdrkit-cdrtools-compat genisoimage
 VMinstall: util-linux libmount1 perl-base libdb-4_8 libsepol1 libblkid1 libuuid1 libsmartcols1
 VMinstall: kernel-obs-build
-#VMInstall: iproute2
-# we need either ip or ifconfig in the build root. net-tools is in Ring0
-# anyways, so use that one
 VMInstall: net-tools-deprecated
-
-
-ExportFilter: \.x86_64\.rpm$ x86_64
-ExportFilter: \.ia64\.rpm$ ia64
-ExportFilter: \.s390x\.rpm$ s390x
-ExportFilter: \.ppc64\.rpm$ ppc64
-ExportFilter: \.ppc64le\.rpm$ ppc64le
-ExportFilter: \.ppc\.rpm$ ppc
-ExportFilter: -ia32-.*\.rpm$
-ExportFilter: -32bit-.*\.sparc64\.rpm$
-ExportFilter: -64bit-.*\.sparcv9\.rpm$
-ExportFilter: -64bit-.*\.aarch64_ilp32\.rpm$
-ExportFilter: \.armv7l\.rpm$ armv7l
-ExportFilter: \.armv7hl\.rpm$ armv7l
-ExportFilter: ^glibc(?:-devel)?-32bit-.*\.sparc64\.rpm$ sparc64
-ExportFilter: ^glibc(?:-devel)?-64bit-.*\.sparcv9\.rpm$ sparcv9
-# it would be a great idea to have, but sometimes installation-images wants to build debuginfos in
-#ExportFilter: -debuginfo-.*\.rpm$
-#ExportFilter: -debugsource-.*\.rpm$
-#ExportFilter: ^master-boot-code.*\.i586.rpm$ . x86_64
-ExportFilter: ^acroread.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.ppc.rpm$ . ppc64
-ExportFilter: ^avmailgate.*\.s390.rpm$ . s390x
-ExportFilter: ^flash-player.*\.i586.rpm$ . x86_64
-ExportFilter: ^novell-messenger-client.*\.i586.rpm$ . x86_64
-ExportFilter: ^openCryptoki-32bit.*\.s390.rpm$ . s390x
 
 Required: rpm-build
 # Build all packages with -pie enabled
@@ -836,11 +806,8 @@ Target: armv6hl-suse-linux
 Target: armv7hl-suse-linux
 %endif
 
-
-#Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables
 Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables
 
-# 13.3 does not exist !
 %define suse_version 1500
 %define is_opensuse 1
 

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -823,7 +823,6 @@ Macros:
 %kernel_module_package_buildreqs kmod-compat kernel-syms
 
 %sles_version 0
-%ul_version 0
 %do_profiling 1
 %_vendor suse
 
@@ -855,3 +854,4 @@ Macros:
 %info_del(:-:) test -x /sbin/install-info -a ! -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --quiet --delete --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
 %{nil}
 :Macros
+

--- a/configs/sle15.0.conf
+++ b/configs/sle15.0.conf
@@ -1,50 +1,58 @@
 
-Release: lp150.<CI_CNT>.<B_CNT>
 %define gcc_version 7
 
-# Help with the switch to the gcc7 provided libs
-Prefer: -libstdc++6-gcc7 -libtsan0-gcc7 -libgomp1-gcc7 -libgcc_s1-gcc7 -libatomic1-gcc7 -libcilkrts5-gcc7 -libitm1-gcc7
-Prefer: -liblsan0-gcc7 -libmpx2-gcc7 -libubsan0-gcc7
+Patterntype: rpm-md ymp
 
-# kiwi-desc-isoboot pulls in a good set of packages also needed for instsource media (where we have no extra -requires for)
-Substitute: kiwi-packagemanager:instsource kiwi-desc-isoboot-requires kiwi-instsource kiwi-instsource-plugins-openSUSE-13-2
-Substitute: kiwi-setup:image kiwi createrepo tar -kiwi-desc-isoboot-requires -kiwi-desc-oemboot-requires -kiwi-desc-netboot-requires -kiwi-desc-vmxboot-requires -kiwi-desc-xenboot-requires
+Substitute: kiwi-packagemanager:instsource product-builder-plugin-Tumbleweed
+Substitute: system-packages:kiwi-product product-builder
+Substitute: kiwi-packagemanager: kiwi-packagemanager:zypper
 
-Prefer: installation-images-openSUSE installation-images-debuginfodeps-openSUSE
+%ifarch s390
+Substitute: valgrind
+Substitute: valgrind-devel
+Substitute: pkgconfig(valgrind)
+%endif
+%ifarch s390 s390x
+Substitute: libunwind-devel
+Substitute: pkgconfig(libunwind)
+%endif
 
-# switch to kiwi v8
-Prefer: python3-kiwi
-Prefer: kiwi-boot-require
+%ifarch s390 s390x
+Ignore: libsensors4-devel
+%endif
 
-FileProvides: /usr/sbin/groupadd shadow
-FileProvides: /usr/sbin/useradd shadow
-FileProvides: /usr/sbin/usermod shadow
-FileProvides: /sbin/netconfig sysconfig-netconfig
-FileProvides: /usr/bin/docbook2man docbook-utils
-FileProvides: /usr/bin/mkisofs cdrkit-cdrtools-compat
-#FileProvides: /usr/bin/mkisofs mkisofs
-FileProvides: /usr/sbin/lockdev lockdev
-FileProvides: /bin/logger util-linux-systemd
+Prefer: lua53 liblua5_3-5 lua53-devel libtolua++-5_3-devel
+Prefer: -liblua5_3 -liblua5_1 -liblua5_2
+
 FileProvides: /bin/csh tcsh
+FileProvides: /bin/logger util-linux-systemd
+FileProvides: /sbin/netconfig sysconfig-netconfig
+FileProvides: /sbin/setcap libcap-progs
 FileProvides: /usr/bin/csh tcsh
+FileProvides: /usr/bin/docbook2man docbook-utils
+FileProvides: /usr/bin/eu-nm elfutils
+FileProvides: /usr/bin/fipscheck fipscheck
+FileProvides: /usr/bin/killall psmisc
 FileProvides: /usr/bin/mimencode metamail
+FileProvides: /usr/bin/mkisofs cdrkit-cdrtools-compat
 FileProvides: /usr/bin/pkg-config pkg-config
+FileProvides: /usr/bin/python python-base
+FileProvides: /usr/bin/setfacl acl
 FileProvides: /usr/bin/sg_inq sg3_utils
 FileProvides: /usr/bin/tput ncurses-utils
-FileProvides: /usr/bin/eu-nm elfutils
-FileProvides: /usr/bin/Xvfb xorg-x11-server
 FileProvides: /usr/bin/xmllint libxml2-tools
-FileProvides: /sbin/setcap libcap-progs
-FileProvides: /usr/bin/setfacl acl
-FileProvides: /usr/bin/fipscheck fipscheck
-FileProvides: /usr/bin/python python-base
+FileProvides: /usr/bin/Xvfb xorg-x11-server
+FileProvides: /usr/sbin/groupadd shadow
+FileProvides: /usr/sbin/lockdev lockdev
+FileProvides: /usr/sbin/useradd shadow
+FileProvides: /usr/sbin/usermod shadow
 
 Preinstall: aaa_base attr bash coreutils diffutils
 Preinstall: filesystem fillup glibc grep
 Preinstall: libbz2-1 libgcc_s1 libncurses6 pam
 Preinstall: permissions libreadline7 rpm sed tar libz1 libselinux1
 Preinstall: liblzma5 libcap2 libacl1 libattr1
-Preinstall: libpopt0 libelf1 liblua5_3
+Preinstall: libpopt0 libelf1 liblua5_3-5
 Preinstall: libpcre1
 
 Runscripts: aaa_base
@@ -53,58 +61,21 @@ Prefer: libdb-4_8-devel
 Prefer: cdrkit-cdrtools-compat genisoimage
 VMinstall: util-linux libmount1 perl-base libdb-4_8 libsepol1 libblkid1 libuuid1 libsmartcols1
 VMinstall: kernel-obs-build
-#VMInstall: iproute2
-# we need either ip or ifconfig in the build root. net-tools is in Ring0
-# anyways, so use that one
-VMInstall: net-tools-deprecated
-
-
-ExportFilter: \.x86_64\.rpm$ x86_64
-ExportFilter: \.ia64\.rpm$ ia64
-ExportFilter: \.s390x\.rpm$ s390x
-ExportFilter: \.ppc64\.rpm$ ppc64
-ExportFilter: \.ppc64le\.rpm$ ppc64le
-ExportFilter: \.ppc\.rpm$ ppc
-ExportFilter: -ia32-.*\.rpm$
-ExportFilter: -32bit-.*\.sparc64\.rpm$
-ExportFilter: -64bit-.*\.sparcv9\.rpm$
-ExportFilter: -64bit-.*\.aarch64_ilp32\.rpm$
-ExportFilter: \.armv7l\.rpm$ armv7l
-ExportFilter: \.armv7hl\.rpm$ armv7l
-ExportFilter: ^glibc(?:-devel)?-32bit-.*\.sparc64\.rpm$ sparc64
-ExportFilter: ^glibc(?:-devel)?-64bit-.*\.sparcv9\.rpm$ sparcv9
-# it would be a great idea to have, but sometimes installation-images wants to build debuginfos in
-#ExportFilter: -debuginfo-.*\.rpm$
-#ExportFilter: -debugsource-.*\.rpm$
-#ExportFilter: ^master-boot-code.*\.i586.rpm$ . x86_64
-ExportFilter: ^acroread.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.ppc.rpm$ . ppc64
-ExportFilter: ^avmailgate.*\.s390.rpm$ . s390x
-ExportFilter: ^flash-player.*\.i586.rpm$ . x86_64
-ExportFilter: ^novell-messenger-client.*\.i586.rpm$ . x86_64
-ExportFilter: ^openCryptoki-32bit.*\.s390.rpm$ . s390x
+VMInstall: iproute2
 
 Required: rpm-build
-# Build all packages with -pie enabled
 Required: gcc-PIE
 
-# needed for su's default config - perhaps we should use a simplified form?
-Support: pam-modules 
+Support: pam-modules
 
-# the basic stuff
 Support: perl build-mkbaselibs
 Support: brp-check-suse post-build-checks rpmlint-Factory
-
-%ifarch ia64
-Support: libunwind libunwind-devel
-Preinstall: libunwind
-%endif
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream
 Prefer: bundle-lang-gnome:gnome-session-branding-openSUSE
 Prefer: cinnamon-gschemas:cinnamon-gschemas-branding-upstream
+Prefer: enlightenment-theme-upstream
 Prefer: exo-data:exo-branding-upstream
 Prefer: fcitx:fcitx-branding-openSUSE
 Prefer: gdm:gdm-branding-upstream
@@ -131,20 +102,22 @@ Prefer: libsocialweb:libsocialweb-branding-upstream
 Prefer: libxfce4ui:libxfce4ui-branding-upstream
 Prefer: lightdm-gtk-greeter:lightdm-gtk-greeter-branding-upstream
 Prefer: mate-desktop-gschemas:mate-desktop-gschemas-branding-upstream
-Prefer: NetworkManager:NetworkManager-branding-openSUSE
+Prefer: NetworkManager-branding-upstream
 Prefer: PackageKit:PackageKit-branding-upstream
 Prefer: plasma5-desktop:plasma5-desktop-branding-upstream
 Prefer: plasma5-workspace:plasma5-workspace-branding-upstream
 Prefer: sddm:sddm-branding-upstream
-Prefer: systemd-presets-branding-openSUSE
+Prefer: systemd-presets-branding-SLE
 Prefer: wallpaper-branding-openSUSE
 Prefer: xfce4-notifyd:xfce4-notifyd-branding-upstream
 Prefer: xfce4-settings:xfce4-settings-branding-upstream
 Prefer: xfdesktop:xfdesktop-branding-upstream
 Prefer: yast2-branding-openSUSE
 Prefer: yast2-qt:yast2-qt-branding-openSUSE
+Prefer: yast2-theme-openSUSE
 
 # Build cycle handling - prefer -mini packages were possible, break deps as needed
+
 Conflict: krb5-devel:krb5-mini
 Conflict: krb5:krb5-mini-devel
 Prefer: gettext-tools-mini gettext-runtime-mini
@@ -168,16 +141,12 @@ Ignore: libudev-mini1:this-is-only-for-build-envs
 Ignore: libunbound-devel-mini:this-is-only-for-build-envs
 Ignore: systemd-mini:this-is-only-for-build-envs
 Ignore: udev-mini:this-is-only-for-build-envs
-
-# curl
+Ignore: curl-mini:this-is-only-for-build-envs
 Ignore: libcurl-mini-devel:this-is-only-for-build-envs
 Ignore: libcurl4-mini:this-is-only-for-build-envs
-# curl: -full and -mini packages don't mingle well
-Prefer: -libcurl4-mini -libcurl-mini-devel
-Conflict: libcurl4-mini:curl
-Conflict: libcurl-mini-devel:libcurl4
 
 # When kiwi comes into play, we do not want the -mini packages; -mini does not target end user systems
+Conflict: kiwi:curl-mini
 Conflict: kiwi:libudev-mini1
 Conflict: kiwi:systemd-mini
 
@@ -190,10 +159,11 @@ Conflict: udev:libudev-mini1
 Conflict: systemd:libsystemd0-mini
 Conflict: systemd-mini-devel:systemd
 
-Prefer: -suse-build-key
+# curl: there is a -mini package to bootstrap and a full; some programs decide on what they want to build in based on what curl can do, so let's prefer full curl
+Prefer: -curl-mini -libcurl-mini-devel -libcurl4-mini
+
 # Set postfix as the 'default' smtp_daemon (virtual symbol provided by all MTAs)
 Prefer: postfix
-# Give the worker any default apache2-MPM for apache2- chosing 'prefork' (alternatives are -event and -worker, dep-wise they are equal)
 
 # prefer the PHP5 variants over PHP7
 Prefer: php5-ctype
@@ -210,11 +180,43 @@ Prefer: php5 php5-json
 Prefer: php5-tokenizer
 Prefer: php5-zip
 
+# go exists in mutliple versions by now - we prefer the 'unversioned package'
+Prefer: go
+
+# python([23])-pep8 is provided by python\1-pep8 and python\1-pycodestyle - favoring 'the real one'
+Prefer: python2-pep8 python3-pep8
+
+# When perl provides a module that is also in a different package, but the consumer specifies no version, we go with perl
+Prefer: perl
+
+# Assist migration to python-pycups (python3-cups is going to be removed)
+Prefer: python3-pycups python-pycups
+
+# Apache requires a MPM - we pick prefork
+Prefer: apache2:apache2-prefork
+
+# for symbol syslog (syslogd is best as it has the least dependencies)
+Prefer: syslogd
+
+# rmt is provided by tar-rmt and star-rmt - we prefer star-rmt, which was the one in the past providing rmt
+Prefer: star-rmt
+
+# A couple packares require a dbus daemon to show notifications - unless oterhwise specified, we prefer the 'standalong notification-daemon;
+Prefer: notification-daemon
+
+# Stuff that wants to have /etc/os-release available should require distribution-release, which we then offer dummy-release for (openSUSE-release changes daily for TW)
+Prefer: dummy-release
+
+# Tumbleweed ships nodejs4 for compatibility reasons - but it's not the preferred version
+Prefer: -nodejs4
+
+# have choice for libpulse.so.0 needed by wine-32bit: apulse-32bit libpulse0-32bit - prefering the 'original'
+Prefer: libpulse0-32bit
+
 # Below list still needs to be reviewed
 
 Prefer: xorg-x11-Xvnc:icewm
 Prefer: cracklib-dict-small
-Prefer: apache2:apache2-prefork
 Prefer: libstdc++6 libgcc_s1 libquadmath0
 Prefer: libstdc++6-32bit libstdc++6-64bit
 Prefer: libstdc++6-x86
@@ -222,18 +224,12 @@ Prefer: libmpx2 libmpxwrappers2 libmpx2-32bit libmpxwrappers2-32bit
 %ifarch s390x
 Prefer: -libstdc++41
 %endif
-# for symbol syslog (syslogd is best as it has the least dependencies)
-Prefer: syslog-service syslogd
-# rmt is provided by tar-rmt and star-rmt - we prefer star-rmt, which was the one in the past providing rmt
-Prefer: star-rmt
-Prefer: yast2-packagemanager-devel:yast2-packagemanager
+Prefer: syslog-service
 Prefer: poppler-tools
 Prefer: libjpeg8-devel libjpeg-turbo
 Prefer: microcode_ctl:kernel-default
-Prefer: notification-daemon
 Prefer: gnu-jaf yast2-control-center-qt
 Prefer: vim-normal myspell-american wine
-Prefer: yast2-theme-openSUSE enlightenment-theme-upstream
 Prefer: amarok:amarok-xine
 Prefer: kdenetwork3-vnc:tightvnc
 Prefer: libgweather0 jessie ndesk-dbus ndesk-dbus-glib tomcat-jsp-2_2-api tomcat-jsp-2_3-api tomcat-servlet-2_5-api
@@ -246,10 +242,13 @@ Prefer: texlive-xmltex texlive-tools texlive-jadetex
 Prefer: libesd-devel:esound
 Prefer: libesd0:esound-daemon
 Prefer: package-lists-openSUSE-KDE-cd: esound-daemon
-Prefer: -geronimo-jta-1_0_1B-api -geronimo-jms-1_1-api -geronimo-el-1_0-api -java-1_5_0-gcj-compat -geronimo-jta-1_1-api classpathx-mail
+Prefer: librest-0_7-0
+
 Prefer: rhino:xmlbeans-mini
-Prefer: rpcbind  eclipse-source
+Prefer: -geronimo-jta-1_0_1B-api -geronimo-jms-1_1-api -geronimo-el-1_0-api -java-1_5_0-gcj-compat -geronimo-jta-1_1-api classpathx-mail
 Prefer: mx4j:log4j-mini
+
+Prefer: rpcbind  eclipse-source
 Prefer: libcdio_cdda0 libcdio_paranoia0
 Prefer: boo tog-pegasus
 Prefer: sysvinit(network) wicked-service
@@ -257,12 +256,7 @@ Prefer: kdebase4-workspace:kdebase4-workspace-ksysguardd
 Prefer: kdebase4-openSUSE:kdebase4-workspace
 Prefer: ant:xerces-j2
 Prefer: dhcp-client:dhcp
-Prefer: dummy-release
 Prefer: libGLw1
-# Help GNOME:Factory over librest-0_7-0 vs librest0 choice
-Prefer: librest-0_7-0
-# Tumbleweed ships nodejs4 for compatibility reasons - but it's not the preferred version
-Prefer: -nodejs4
 # provides typelib(St)
 Prefer: -cinnamon
 Prefer: -bundle-lang-kde-de -bundle-lang-kde-en -bundle-lang-kde-es
@@ -301,7 +295,8 @@ Prefer: -crimson
 # in doubt, take higher versions
 Prefer: -rubygem-rack-1_1 -rubygem-rack-1_2 -rubygem-rack-1_3 -rubygem-tilt-1_1 -rubygem-rack-1_4
 Prefer: -rubygem-method_source-0_7 -rubygem-rails-2_3 -rubygem-activerecord-2_3
-Prefer: -rubygem-json_pure-1_5 -ruby2.2-rubygem-listen-3_0 -ruby2.2-rubygem-fast_gettext-1_1 -ruby2.2-rubygem-nokogiri-1_6 -ruby2.3-rubygem-nokogiri-1_6
+Prefer: -rubygem-json_pure-1_5
+Prefer: -ruby2.4-rubygem-fast_gettext-1_1 -ruby2.4-rubygem-listen-3_0 -ruby2.4-rubygem-nokogiri-1_6 -ruby2.4-rubygem-i18n-0_6 -ruby2.4-rubygem-ruby_dep-1_3
 Prefer: geronimo-servlet-2_4-api
 Prefer: -libhdf5-0-openmpi -libhdf5_hl0-openmpi -libhdf5_hl8-openmpi -libhdf5-8-openmpi -libhdf5_hl9-openmpi -libhdf5-9-openmpi -libhdf5-10-openmpi -libhdf5_hl10-openmpi -libhdf5-11-openmpi -libhdf5_hl11-openmpi -libhdf5-100-openmpi -libhdf5_hl100-openmpi
 # prefer the small systemd for building
@@ -309,6 +304,7 @@ Prefer: star
 Prefer: xmlgraphics-commons:apache-commons-io
 # the -32bit stuff provides things it shouldn't (hopefully temporary)
 Prefer: -typelib-1_0-GdkPixbuf-2_0-32bit -typelib-1_0-Pango-1_0-32bit -glib2-devel-32bit
+Prefer: -typelib-1_0-GdkPixbuf-2_0-64bit -typelib-1_0-Pango-1_0-64bit -glib2-devel-64bit
 Prefer: postgresql postgresql-server postgresql-devel
 Prefer: -unzip-rcc
 Prefer: -primus -primus-32bit
@@ -318,7 +314,7 @@ Prefer: -clutter-gst-devel
 Prefer: -opencv-qt5-devel
 # ffmpeg and its fork libav both provide libswscale; prefer the 'original' ffmpeg
 Prefer: -libswscale-libav-devel -libavformat-libav-devel -libavresample-libav-devel -libavcodec-libav-devel -libavdevice-libav-devel -libavfilter-libav-devel -libpostproc-libav-devel -libavutil-libav-devel
-Prefer: -ffmpeg2-devel
+Prefer: -ffmpeg2-devel -python-configparser2
 # as long as kactivities4 exists and is provided
 Prefer: kactivities5
 # oxygen5-icon-theme osboletes oxygen-icon-theme
@@ -337,6 +333,7 @@ Prefer: libgcc_s1 libgcc_s1-32bit libgcc_s1-64bit
 Prefer: libffi-devel
 Prefer: libatomic1 libcilkrts5 libitm1 liblsan0 libtsan0 libubsan0
 Prefer: libatomic1-32bit libcilkrts5-32bit libitm1-32bit libubsan0-32bit
+Prefer: libatomic1-64bit libcilkrts5-64bit libitm1-64bit libubsan0-64bit
 Prefer: libgcc_s1-x86 libgcj_bc1
 Prefer: libgomp1 libgomp1-32bit libgomp1-64bit
 Prefer: libmudflap4 libmudflap4-32bit libmudflap4-64bit
@@ -356,7 +353,7 @@ Prefer: -libpcap -libiniparser -loudmouth -libkonq4 -libnetcdf-4
 Prefer: NetworkManager:dhcp-client
 Prefer: kdebase3-SuSE:kdebase3
 Prefer: pcre-tools
-Prefer: libpopt0
+Prefer: libpopt0 makeinfo
 Prefer: -apache2-mod_perl -otrs -qa_apache_testsuite -ctcs2
 Prefer: libgnome-keyring-devel
 Prefer: gnome-keyring-32bit
@@ -364,7 +361,7 @@ Prefer: linux-glibc-devel
 Prefer: squid sysvinit
 Prefer: libpng16-compat-devel
 Prefer: -python3 -python3-gobject-devel -python3-gobject2-devel -x11-video-fglrxG02 -libpng12-0
-Prefer: python3-docutils python2-pep8
+Prefer: python3-docutils
 Prefer: perl-Mail-SPF:perl-Error libldb0 -audit-libs mysql-community-server mysql-community-server-client
 #needed because new xml-commons package
 Prefer: xml-commons-resolver12 xml-commons-jaxp-1.3-apis
@@ -389,6 +386,10 @@ Prefer: -typelib-1_0-MediaArt-2_0
 Prefer: -typelib-1_0-Gtk-2_0 -typelib-1_0-Gtk-4_0
 Prefer: -python-atspi
 Prefer: gettext-its-gtk3 gtk3-schema
+# for pkgconfig(ijs) and no one actually rely on ghostscript-mini-devel in Factory
+Prefer: ghostscript-devel
+# for pkgconfig(libotf) libotf-devel and libotf-devel-32bit both provides it
+Prefer: libotf-devel
 
 Ignore: installation-images-openSUSE:cracklib-dict-full
 Ignore: systemd-sysvinit:systemd
@@ -404,7 +405,6 @@ Ignore: libgcj46,libstdc++46-devel
 Ignore: libgcj47,libstdc++47-devel
 Ignore: librtas:util-linux
 Ignore: pwdutils:openslp
-Ignore: pam-modules:resmgr
 Ignore: rpm:suse-build-key,build-key
 Ignore: cloud-init:cloud-init-config
 # python-pyudev requires libudev1 in normal situations
@@ -412,7 +412,6 @@ Ignore: python-pyudev:libudev1
 Ignore: python-SPARQLWrapper:python-rdflib
 Ignore: python3-SPARQLWrapper:python3-rdflib
 Ignore: bind-utils:bind-libs
-Ignore: alsa:dialog,pciutils
 Ignore: portmap:syslogd
 Ignore: xorg-x11:x11-tools,resmgr,xkeyboard-config,xorg-x11-Mesa,libusb,freetype2,libjpeg,libpng
 Ignore: xorg-x11-server:xorg-x11-driver-input,xorg-x11-driver-video
@@ -436,16 +435,11 @@ Ignore: libgnomeprintui:libgnomecups
 Ignore: orbit2-devel:indent
 Ignore: qt3:libmng
 Ignore: qt-sql:qt_database_plugin
-Ignore: gtk2:libpng,libtiff
 Ignore: libgnomecanvas-devel:glib-devel
 Ignore: libgnomeui:gnome-icon-theme,shared-mime-info
 Ignore: scrollkeeper:docbook_4
 Ignore: gnome-desktop:libgnomesu,startup-notification
 Ignore: python-devel:python-tk
-Ignore: gnome-pilot:gnome-panel
-Ignore: gnome-panel:control-center2
-Ignore: gnome-menus:kdebase3
-Ignore: gnome-main-menu:rug
 Ignore: libgtk-3-0:adwaita-icon-theme
 Ignore: libgtk-3-0:gdk-pixbuf-loader-rsvg
 Ignore: samba-libs:krb5
@@ -491,38 +485,18 @@ Ignore: systemd:dbus-1
 Ignore: systemd:pam-config
 Ignore: systemd:udev
 Ignore: pesign:systemd
-Ignore: polkit:ConsoleKit
 Ignore: logrotate:cron
 Ignore: texlive-filesystem:cron
 Ignore: xinit:xterm
 Ignore: xdm:xterm
 Ignore: gnome-control-center:gnome-themes-accessibility
-Ignore: coreutils:info
-Ignore: cpio:info
-Ignore: diffutils:info
-Ignore: findutils:info
-Ignore: gawk:info
-Ignore: grep:info
-Ignore: groff:info
-Ignore: m4:info
-Ignore: sed:info
-Ignore: tar:info
-Ignore: util-linux:info
-Ignore: gettext-tools:info
-Ignore: gettext-runtime:info
-Ignore: libgcrypt-devel:info
-Ignore: binutils:info
-Ignore: gzip:info
-Ignore: make:info
-Ignore: bison:info
-Ignore: flex:info
-Ignore: help2man:info
+
+
 Ignore: man:groff-full
 Ignore: git-core:rsync
 Ignore: apache2:systemd
 Ignore: icewm-lite:icewm
 Ignore: cluster-glue:sudo
-
 Ignore: libgcc:glibc-32bit
 Ignore: libgcc41:glibc-32bit
 Ignore: libgcc42:glibc-32bit
@@ -575,19 +549,12 @@ Ignore: gecko-sharp2:mono(glib-sharp),mono(gtk-sharp)
 Ignore: vcdimager:libcdio.so.6,libcdio.so.6(CDIO_6),libiso9660.so.4,libiso9660.so.4(ISO9660_4)
 Ignore: libcdio:libcddb.so.2
 
-Ignore: gnome-libs:libgnomeui
-Ignore: nautilus:gnome-themes
-Ignore: gnome-panel:gnome-themes
-Ignore: gnome-panel:tomboy
-Ignore: NetworkManager:NetworkManager-client
-Ignore: libbeagle:beagle
 Ignore: coreutils:coreutils-lang
 Ignore: cpio:cpio-lang
 Ignore: glib2:glib2-lang
 Ignore: gtk2:gtk2-lang
 Ignore: gtk:gtk-lang
 Ignore: atk:atk-lang
-Ignore: hal:pm-utils
 Ignore: MozillaThunderbird:pinentry-dialog
 Ignore: seamonkey:pinentry-dialog
 Ignore: pinentry:pinentry-dialog
@@ -622,9 +589,7 @@ Ignore: xfce4-panel:xfce4-panel-branding
 Ignore: xfce4-session:xfce4-session-branding
 Ignore: kdebase4-runtime:kdebase4-runtime-branding
 Ignore: kwin:kdebase4-workspace-branding
-Ignore: pulseaudio:kernel
 Ignore: transmission-common:transmission-ui
-Ignore: mutter-moblin:moblin-branding
 Ignore: sysvinit-tools:mkinitrd cifs-utils:mkinitrd
 Ignore: mkinitrd:sbin_init
 Ignore: opensc:pinentry
@@ -646,6 +611,7 @@ Ignore: libglue-devel:cluster-glue
 Ignore: libqca2:gpg2
 Ignore: NetworkManager:wpa_supplicant
 Ignore: NetworkManager:dhcp-client
+Ignore: openSUSE-release:product_flavor(openSUSE)
 Ignore: libgio-2_0-0:dbus-1-x11
 Ignore: weather-wallpaper:inkscape
 Ignore: libgamin-1-0:gamin-server
@@ -654,11 +620,6 @@ Ignore: python3:python3-pip
 Ignore: avahi:sysvinit(network)
 Ignore: cluster-glue:sysvinit(network)
 Ignore: dracut:systemd-sysvinit
-
-%ifarch ppc64le
-#Constraint: hostlabel PPC64LE_HOST
-Constraint: hardware:cpu:flag power8
-%endif
 
 Macros:
 # RUBY - UNVERSIONED STUFF
@@ -686,64 +647,41 @@ Macros:
 %rubydevelxSTOP() %*
 #
 
-# RUBY STUFF
 #
 # IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
 #
 #  if you change any macros here you have to update the copy in
-#  ruby2.2 aswell.
+#  ruby2.4 aswell.
 #
 # IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
 #
-%rubygemsruby22() rubygem(ruby:2.2.0:%{expand:%%rubygemsx%*} %{expand:%%{rubygems%*}}
-%rubygemsxruby22() %{expand:%%{rubygemsx%*}}
+%rubygemsruby24() rubygem(ruby:2.4.0:%{expand:%%rubygemsx%*} %{expand:%%{rubygems%*}}
+%rubygemsxruby24() %{expand:%%{rubygemsx%*}}
 
-%rubyruby22() ruby2.2 %{expand:%%rubyx%*} %{expand:%%{ruby%*}}
-%rubyxruby22() %{expand:%%{rubyx%*}}
+%rubyruby24() ruby2.4 %{expand:%%rubyx%*} %{expand:%%{ruby%*}}
+%rubyxruby24() %{expand:%%{rubyx%*}}
 
-%rubydevelruby22() ruby2.2-devel %{expand:%%rubydevelx%*} %{expand:%%{rubydevel%*}}
-%rubydevelxruby22() %{expand:%%{rubydevelx%*}}
+%rubydevelruby24() ruby2.4-devel %{expand:%%rubydevelx%*} %{expand:%%{rubydevel%*}}
+%rubydevelxruby24() %{expand:%%{rubydevelx%*}}
 
-%_with_ruby22               1
+%_with_ruby24               1
 
-#
-# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
-#
-#  if you change any macros here you have to update the copy in
-#  ruby2.3 aswell.
-#
-# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
-#
-%rubygemsruby23() rubygem(ruby:2.3.0:%{expand:%%rubygemsx%*} %{expand:%%{rubygems%*}}
-%rubygemsxruby23() %{expand:%%{rubygemsx%*}}
+%rb_default_ruby        ruby24
+%rb_default_ruby_suffix ruby2.4
+%rb_default_ruby_abi    ruby:2.4.0
 
-%rubyruby23() ruby2.3 %{expand:%%rubyx%*} %{expand:%%{ruby%*}}
-%rubyxruby23() %{expand:%%{rubyx%*}}
-
-%rubydevelruby23() ruby2.3-devel %{expand:%%rubydevelx%*} %{expand:%%{rubydevel%*}}
-%rubydevelxruby23() %{expand:%%{rubydevelx%*}}
-
-%_with_ruby23               1
-
+%rb_build_ruby_abis     ruby:2.4.0
+%rb_build_versions      ruby24
 :Macros
 
-%define _with_ruby22         1
-%define _with_ruby23         1
+%define _with_ruby24         1
 
-%define rb_default_ruby        ruby22
-%define rb_default_ruby_suffix ruby2.2
-%define rb_default_ruby_abi    ruby:2.2.0
+%define rb_default_ruby        ruby24
+%define rb_default_ruby_suffix ruby2.4
+%define rb_default_ruby_abi    ruby:2.4.0
 
-%define rb_build_ruby_abis     ruby:2.2.0 ruby:2.3.0
-%define rb_build_versions      ruby22 ruby23
-Macros:
-%rb_default_ruby        ruby22
-%rb_default_ruby_suffix ruby2.2
-%rb_default_ruby_abi    ruby:2.2.0
-
-%rb_build_ruby_abis     ruby:2.2.0 ruby:2.3.0
-%rb_build_versions      ruby22 ruby23
-:Macros
+%define rb_build_ruby_abis     ruby:2.4.0
+%define rb_build_versions      ruby24
 
 Prefer: -ruby-stdlib
 Prefer: %{rb_default_ruby_suffix}-rubygem-gem2rpm
@@ -760,12 +698,18 @@ Prefer: %{rb_default_ruby_suffix}-rubygem-cfa
 # END RUBY STUFF
 
 # PYTHON STUFF
-# defined in tpython-rpm-macros
 
 Macros:
-%have_python2 1
-%have_python3 1
-%python_module() %{expand: %{?have_python2:python2-%{**}} %{?have_python3:python3-%{**}} %{?have_pypy3:pypy3-%{**}}}
+%pythons  %{?!skip_python2:python2} %{?!skip_python3:python3}
+
+# This method for generating python_modules gets too deep to expand at about 5 python flavors.
+# It is replaced by a Lua macro in macros.lua
+# However, OBS has a much higher expansion depth, so this works fine.
+%python_module_iter(a:) %{-a*}-%{args} %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a%*}}}
+%python_module_iter_STOP stop
+%python_module() %{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}
+
+%add_python() %{expand:%%define pythons %pythons %1}
 :Macros
 
 # END PYTHON STUFF
@@ -805,12 +749,9 @@ Substitute: kernel-binary-packages kernel-s390
 Substitute: kernel-binary-packages kernel-default
 %endif
 
-# until the builds of the packages are fixed...
-Substitute: yast2-theme-SLED
-Substitute: yast2-theme-SLE
-
 Optflags: i586 -fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches
-Optflags: i686 -march=i686 -mtune=generic -fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches
+# no longer needed according to Richard Biener
+#  Optflags: i686 -fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches -fstack-protector
 Optflags: x86_64 -fmessage-length=0 -grecord-gcc-switches
 Optflags: ppc -fmessage-length=0 -grecord-gcc-switches
 Optflags: ppc64 -fmessage-length=0 -grecord-gcc-switches
@@ -840,13 +781,20 @@ Target: armv7hl-suse-linux
 #Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables
 Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables
 
-# 13.3 does not exist !
 %define suse_version 1500
-%define is_opensuse 1
+%define sle_version 150000
+
+%define is_opensuse 0
+
+%define is_susecaasp 1
+%define is_susesap 1
 
 Macros:
 %suse_version 1500
-%is_opensuse 1
+%sle_version 150000
+%is_susecaasp 1 
+%is_susesap 1
+%is_opensuse 0
 
 %insserv_prereq insserv sed
 %fillup_prereq fillup coreutils grep diffutils
@@ -856,7 +804,6 @@ Macros:
 %kernel_module_package_buildreqs kmod-compat kernel-syms
 
 %sles_version 0
-%ul_version 0
 %do_profiling 1
 %_vendor suse
 
@@ -888,3 +835,4 @@ Macros:
 %info_del(:-:) test -x /sbin/install-info -a ! -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --quiet --delete --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
 %{nil}
 :Macros
+


### PR DESCRIPTION
Use-case: our build farm includes many wimpy ARM cards as workers, as well as an amd64 server for OBS master and amd64 builds. ARMs are dead slow, especially when I/O is involved - regardless of whether we do it on local MMC, local tmpfs, over NFS backed by spinning rust or NFS backed by RAM disk on the server - within 10% fluctuations, unpacking preinstall images or compressing the final image takes minutes every time, if done by ARM.

Ultimately I've set up the farm to dedicate a ramdisk on the amd64 server for build roots, made available over NFS to all ARM workers (each has a subdirectory), mounted in such a way that the workers and the server see same contents by the same full pathnames. All farm hosts trust each other, so it is no big deal for an ARM card to call the amd64 server over SSH and say "unpack this" or "pack that - and also use `pigz` on your 24 cores while compressing the tar.gz image files!"

This change played a prominent role in cutting our build times of ARM packages and images by more than an order of magnitude in some cases. Other bits that were missing for us in OBS, and helped gain some time here and there, are being posted in other PRs. Also, defining and stashing finely tuned preinstall images to seed the most common builds (including final simpleimage builds) was also of paramount importance.