### PR TITLE
Work around init_buildsystem occasionally failing to unmount old buildroot over NFS

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -18,16 +18,6 @@
 #
 ################################################################
 
-# TODO:
-# - parse Dockerfile and extract dependecies
-# - start docker daemon
-# - import base image to the docker daemon
-# - setup the dependencies directory
-# - setup a zypper repository that will serve the dependecies directory
-# - inject this repository as and ARG in the Dockerfile
-# - build the Dockerfile
-# - export the image tarball [OPTIONAL]
-
 package Build::Docker;
 
 use Build::SimpleXML;
@@ -246,7 +236,7 @@ sub showcontainerinfo {
 }
 
 sub showtags {
-  my ($fn, $image) = @ARGV;
+  my ($fn) = @ARGV;
   local $Build::Kiwi::urlmapper = sub { return $_[0] };
   my $d = {};
   $d = parse({}, $fn) if $fn;

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -2,8 +2,6 @@
 #
 # Docker specific functions.
 #
-# Author: TODO
-#
 ################################################################
 #
 # Copyright (c) 2017 SUSE Linux Products GmbH

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -6,9 +6,9 @@ Release: lp150.<CI_CNT>.<B_CNT>
 Prefer: -libstdc++6-gcc7 -libtsan0-gcc7 -libgomp1-gcc7 -libgcc_s1-gcc7 -libatomic1-gcc7 -libcilkrts5-gcc7 -libitm1-gcc7
 Prefer: -liblsan0-gcc7 -libmpx2-gcc7 -libubsan0-gcc7
 
-# kiwi-desc-isoboot pulls in a good set of packages also needed for instsource media (where we have no extra -requires for)
-Substitute: kiwi-packagemanager:instsource kiwi-desc-isoboot-requires kiwi-instsource kiwi-instsource-plugins-openSUSE-13-2
-Substitute: kiwi-setup:image kiwi createrepo tar -kiwi-desc-isoboot-requires -kiwi-desc-oemboot-requires -kiwi-desc-netboot-requires -kiwi-desc-vmxboot-requires -kiwi-desc-xenboot-requires
+Substitute: kiwi-packagemanager:instsource product-builder-plugin-Tumbleweed
+Substitute: system-packages:kiwi-product product-builder
+Substitute: kiwi-packagemanager: kiwi-packagemanager:zypper
 
 Prefer: installation-images-openSUSE installation-images-debuginfodeps-openSUSE
 
@@ -53,37 +53,7 @@ Prefer: libdb-4_8-devel
 Prefer: cdrkit-cdrtools-compat genisoimage
 VMinstall: util-linux libmount1 perl-base libdb-4_8 libsepol1 libblkid1 libuuid1 libsmartcols1
 VMinstall: kernel-obs-build
-#VMInstall: iproute2
-# we need either ip or ifconfig in the build root. net-tools is in Ring0
-# anyways, so use that one
 VMInstall: net-tools-deprecated
-
-
-ExportFilter: \.x86_64\.rpm$ x86_64
-ExportFilter: \.ia64\.rpm$ ia64
-ExportFilter: \.s390x\.rpm$ s390x
-ExportFilter: \.ppc64\.rpm$ ppc64
-ExportFilter: \.ppc64le\.rpm$ ppc64le
-ExportFilter: \.ppc\.rpm$ ppc
-ExportFilter: -ia32-.*\.rpm$
-ExportFilter: -32bit-.*\.sparc64\.rpm$
-ExportFilter: -64bit-.*\.sparcv9\.rpm$
-ExportFilter: -64bit-.*\.aarch64_ilp32\.rpm$
-ExportFilter: \.armv7l\.rpm$ armv7l
-ExportFilter: \.armv7hl\.rpm$ armv7l
-ExportFilter: ^glibc(?:-devel)?-32bit-.*\.sparc64\.rpm$ sparc64
-ExportFilter: ^glibc(?:-devel)?-64bit-.*\.sparcv9\.rpm$ sparcv9
-# it would be a great idea to have, but sometimes installation-images wants to build debuginfos in
-#ExportFilter: -debuginfo-.*\.rpm$
-#ExportFilter: -debugsource-.*\.rpm$
-#ExportFilter: ^master-boot-code.*\.i586.rpm$ . x86_64
-ExportFilter: ^acroread.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.i586.rpm$ . x86_64
-ExportFilter: ^avmailgate.*\.ppc.rpm$ . ppc64
-ExportFilter: ^avmailgate.*\.s390.rpm$ . s390x
-ExportFilter: ^flash-player.*\.i586.rpm$ . x86_64
-ExportFilter: ^novell-messenger-client.*\.i586.rpm$ . x86_64
-ExportFilter: ^openCryptoki-32bit.*\.s390.rpm$ . s390x
 
 Required: rpm-build
 # Build all packages with -pie enabled
@@ -836,11 +806,8 @@ Target: armv6hl-suse-linux
 Target: armv7hl-suse-linux
 %endif
 
-
-#Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector -funwind-tables -fasynchronous-unwind-tables
 Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables
 
-# 13.3 does not exist !
 %define suse_version 1500
 %define is_opensuse 1
 

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -823,7 +823,6 @@ Macros:
 %kernel_module_package_buildreqs kmod-compat kernel-syms
 
 %sles_version 0
-%ul_version 0
 %do_profiling 1
 %_vendor suse
 
@@ -855,3 +854,4 @@ Macros:
 %info_del(:-:) test -x /sbin/install-info -a ! -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --quiet --delete --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
 %{nil}
 :Macros
+


### PR DESCRIPTION
In our practice, sometimes the `umount` commands in the `init_buildsystem` script failed to deliver, especially against NFS build roots where some hiccup caused its files or directories to get stale at the wrong moment.

So they were augmented by forced+lazy unmounts, which ensured that subsequent file-deleting spree did not impact bind-mounted system directories, and later by asynchronous deletion of old build root so we do not block a new build on currently unremovable objects. Finally, recreate some things we've just deleted that were created by the `build` script a second before this...