### PR TITLE
Improve usage of ccache to speed up builds

### DIFF
--- a/build
+++ b/build
@@ -103,6 +103,7 @@ SIGNDUMMY=
 DO_STATISTICS=
 RUN_SHELL=
 CCACHE=
+#DO_CCACHE_STATISTICS=
 DLNOSIGNATURE=
 BUILD_FLAVOR=
 OBS_PACKAGE=
@@ -255,6 +256,10 @@ Known Parameters:
               Usually the runtime dependencies are minimal, so the same
               binary should work on any Linux distro from the same era.
               If PATH_TO_BINARY is "yes", copy host /usr/bin/ccache.
+
+  --ccache-statistics
+              optionally report ccache statistics and log of operations
+              done during this build job, in the end of usual build log.
 
   --icecream N
               Use N parallel build jobs with icecream
@@ -560,8 +565,11 @@ CCACHE_DIR="/.ccache"
 CCACHE_LOGFILE="/.build.log.ccache"
 PATH="/.ccache-bin:\$PATH"
 export PATH CCACHE_LOGFILE CCACHE_DIR
-echo "CCache state before build:"
-ccache -s
+if test -z "\$NO_CCACHE_STATS" || test x"\$NO_CCACHE_STATS" = xyes ; then
+    echo "CCache state before build:"
+    ccache -s
+fi
+true
 EOF
     else
         rm -f "$BUILD_ROOT"/.ccache-bin/{gcc,g++,cc,c++,clang,clang++}{,-*}
@@ -1017,6 +1025,9 @@ while test -n "$1"; do
 	CCACHE_HOST_BIN="$ARG"
 	shift
       ;;
+      -ccache-statistics)
+	DO_CCACHE_STATISTICS=1
+      ;;
       -statistics)
 	DO_STATISTICS=1
       ;;
@@ -1124,6 +1135,7 @@ test "$BUILD_ROOT" != /var/tmp/build-root && validate_param "--root" "$BUILD_ROO
 test "$CONFIG_DIR" != "$BUILD_DIR/configs" && validate_param "--configdir" "$CONFIG_DIR" CONFIG_DIR
 
 # Beside CLI, these can come from envvars (sourced by worker configs)
+# Note the env can also enforce DO_CCACHE_STATISTICS=1 to post the logs
 if test -n "$CCACHE_HOST_DIR" || test -n "$CCACHE_HOST_BIN" ; then
     CCACHE=true
 fi
@@ -1596,5 +1608,25 @@ fi
 echo
 echo "$HOST finished \"build $RECIPEFILE\" at `date --utc`."
 echo
+
+if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
+    if [ -s "$BUILD_ROOT/.build.log.ccache" ] ; then
+        echo "Dumping current run's CCACHE log:"
+        echo "======="
+        cat "$BUILD_ROOT/.build.log.ccache"
+        echo "======="
+    fi
+
+    if [ -x $BUILD_ROOT/.ccache-bin/ccache ] && [ -s "$BUILD_ROOT"/etc/profile.d/build_ccache.sh ] ; then
+        echo
+        echo "CCACHE stats after this run:"
+        echo
+        chroot "$BUILD_ROOT" /usr/bin/bash -c "NO_CCACHE_STATS=yes ; . /etc/profile.d/build_ccache.sh && /.ccache-bin/ccache -s"
+    fi
+
+    echo
+    echo "$HOST finished \"build $RECIPEFILE\" augmented by CCACHE at `date --utc`."
+    echo
+fi
 
 cleanup_and_exit "$exitcode"

--- a/build
+++ b/build
@@ -551,6 +551,7 @@ setupccache() {
         fi
     fi
 
+    rm -f "$BUILD_ROOT/.build.log.ccache" || true
     if test "$WRAPPED_CCACHE" = 1 ; then
         mkdir -p "$BUILD_ROOT/.ccache"
         if test -n "$CCACHE_HOST_DIR" ; then

--- a/build
+++ b/build
@@ -244,6 +244,18 @@ Known Parameters:
   --ccache
               Use ccache to speed up rebuilds
 
+  --ccache-host-dir DIRNAME
+              Mount DIRNAME from host to share and persist the cache
+              data to speed up rebuilds (may be backed by NFS+autofs)
+
+  --ccache-host-bin PATH_TO_BINARY
+              If the build root environment packaging does not provide
+              a /usr/bin/ccache, copy the binary from the worker host OS
+              into the build root, to speed up rebuilds. Test this first!
+              Usually the runtime dependencies are minimal, so the same
+              binary should work on any Linux distro from the same era.
+              If PATH_TO_BINARY is "yes", copy host /usr/bin/ccache.
+
   --icecream N
               Use N parallel build jobs with icecream
 
@@ -457,26 +469,102 @@ toshellscript() {
     echo
 }
 
-setupccache() {
-    if test -n "$CCACHE" ; then
-	if mkdir -p $BUILD_ROOT/var/lib/build/ccache/bin; then
-	    for i in $(ls $BUILD_ROOT/usr/bin | grep -E '^(cc|gcc|[cg][+][+]|clang|clang[+][+])([-]?[234][.]?[0-9])*$'); do
-		rm -f $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		test -e $BUILD_ROOT/usr/bin/$i || continue
-		echo '#! /bin/sh' > $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		echo "test -e /usr/bin/$i || exit 1" >> $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		echo 'export PATH=/usr/lib/icecc/bin:/opt/icecream/bin:/usr/bin:$PATH' >> $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		echo "ccache $i \"\$@\"" >> $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		chmod 755 $BUILD_ROOT/var/lib/build/ccache/bin/$i
-		echo "Installed ccache wrapper as $BUILD_ROOT/var/lib/build/ccache/bin/$i"
-	    done
-	fi
-	mkdir -p "$BUILD_ROOT/.ccache"
-	chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.ccache"
-	echo "export CCACHE_DIR=/.ccache" > "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
-	echo 'export PATH=/var/lib/build/ccache/bin:$PATH' >> "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
+provide_ccache() {
+    # If called, ensure a "/.ccache-bin/ccache" is present in the BUILD_ROOT.
+    # It may be a link to "/usr/bin/ccache" installed via packaging, or as a
+    # fallback only, the worker host's copy can be used, from default location
+    # (if CCACHE_HOST_BIN==yes), or from absolute-path location pointed to by
+    # the CCACHE_HOST_BIN value. This routine is called from setupccache(),
+    # and only if CCACHE support is enabled for this build.
+
+    # Fasttrack if already set up
+    [ -x "$BUILD_ROOT/.ccache-bin/ccache" ] && return 0
+
+    # Setup is indeed needed... do some sanity check first
+    [ -n "$BUILD_ROOT" ] && [ -d "$BUILD_ROOT" ] || return
+    mkdir -p $BUILD_ROOT/.ccache-bin
+    rm -f "$BUILD_ROOT/.ccache-bin/ccache" 2>dev/null || true
+
+    # First try using a binary that may already exist in the build root via
+    # packaging as /usr/bin/ccache. Note that this path can be an absolute
+    # symlink, so can be misleading in the host environment - so we must
+    # chroot before evaluating it.
+    if chroot "$BUILD_ROOT" /usr/bin/test -x /usr/bin/ccache || \
+       chroot "$BUILD_ROOT" /bin/test -x /usr/bin/ccache ; then
+        ln -s "../usr/bin/ccache" "$BUILD_ROOT/.ccache-bin/ccache"
     else
-	rm -f "$BUILD_ROOT"/var/lib/build/ccache/bin/{gcc,g++,cc,c++,clang,clang++}
+        case "$CCACHE_HOST_BIN" in
+            yes|true|on) CCACHE_HOST_BIN="/usr/bin/ccache" ;;
+            /*) ;;
+            *|"") return 1 ;;
+        esac
+
+        if [ -n "$CCACHE_HOST_BIN" ] && [ -x "$CCACHE_HOST_BIN" ] ; then
+            cp -pLf "$CCACHE_HOST_BIN" "$BUILD_ROOT/.ccache-bin/"
+        fi
+    fi
+
+    test -s "$BUILD_ROOT/.ccache-bin/ccache" && test -x "$BUILD_ROOT/.ccache-bin/ccache"
+    # Return exit-code of this test
+}
+
+setupccache() {
+    # This routine sets up CCACHE wrappers for build roots, if enabled.
+    # This involves a /.ccache-bin/ directory with ccache itself and wrapper
+    # scripts for the compilers found on the build root, and a /.ccache/
+    # directory with the cache that can be private (useless unless you
+    # rebuild in same workers without wiping), or mounted from the host OS
+    # (including a bind-mount of an autofs+NFS mounted directory), so that
+    # the same cache directory can be shared between OBS workers.
+    local WRAPPED_CCACHE=0
+    case "$BUILDTYPE" in
+        *image*) return 0 ;;
+    esac
+
+    if test -n "$CCACHE" || test -n "$CCACHE_HOST_DIR" ; then
+        if mkdir -p $BUILD_ROOT/.ccache-bin; then
+            for i in $(ls $BUILD_ROOT/usr/bin | grep -E '^(cc|gcc|[cg][+][+]|clang|clang[+][+])([-]?[234][.]?[0-9])*$'); do
+                rm -f $BUILD_ROOT/.ccache-bin/$i
+                # Note: a mediated absolute symlink may be used in the
+                # build-root, so the verbatim $BUILD_ROOT/usr/bin/$i
+                # points nowhere valid in the host environment...
+                chroot $BUILD_ROOT /usr/bin/test -e /usr/bin/$i || chroot $BUILD_ROOT /bin/test -e /usr/bin/$i || continue
+                provide_ccache || break
+                WRAPPED_CCACHE=1
+                echo '#! /bin/sh' > $BUILD_ROOT/.ccache-bin/$i
+                echo "test -e /usr/bin/$i || exit 1" >> $BUILD_ROOT/.ccache-bin/$i
+                echo 'export PATH=/usr/lib/icecc/bin:/opt/icecream/bin:/usr/bin:$PATH' >> $BUILD_ROOT/.ccache-bin/$i
+                echo "/.ccache-bin/ccache $i \"\$@\"" >> $BUILD_ROOT/.ccache-bin/$i
+                chmod 755 $BUILD_ROOT/.ccache-bin/$i
+                echo "Installed ccache wrapper as $BUILD_ROOT/.ccache-bin/$i"
+            done
+        fi
+    fi
+
+    if test "$WRAPPED_CCACHE" = 1 ; then
+        mkdir -p "$BUILD_ROOT/.ccache"
+        if test -n "$CCACHE_HOST_DIR" ; then
+            if ! test -d "$CCACHE_HOST_DIR" ; then
+                echo "Creating new CCACHE_HOST_DIR='$CCACHE_HOST_DIR' owned by '$ABUILD_UID:$ABUILD_GID' on the host system"
+                mkdir -p "$CCACHE_HOST_DIR" && \
+                chown -R "$ABUILD_UID:$ABUILD_GID" "$CCACHE_HOST_DIR"
+            fi
+            echo "Using host's CCACHE_HOST_DIR='$CCACHE_HOST_DIR' as /.ccache inside BUILD_ROOT"
+            mount -o rbind "$CCACHE_HOST_DIR" "$BUILD_ROOT/.ccache"
+        else
+            chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.ccache"
+        fi
+        cat << EOF > "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
+echo 'Sourcing /etc/profile.d/build_ccache.sh...' >&2
+CCACHE_DIR="/.ccache"
+CCACHE_LOGFILE="/.build.log.ccache"
+PATH="/.ccache-bin:\$PATH"
+export PATH CCACHE_LOGFILE CCACHE_DIR
+echo "CCache state before build:"
+ccache -s
+EOF
+    else
+        rm -f "$BUILD_ROOT"/.ccache-bin/{gcc,g++,cc,c++,clang,clang++}{,-*}
     fi
 }
 
@@ -917,6 +1005,18 @@ while test -n "$1"; do
       -ccache)
 	CCACHE=true
       ;;
+      -ccache-host-dir)
+	needarg
+	CCACHE=true
+	CCACHE_HOST_DIR="$ARG"
+	shift
+      ;;
+      -ccache-host-bin)
+	needarg
+	CCACHE=true
+	CCACHE_HOST_BIN="$ARG"
+	shift
+      ;;
       -statistics)
 	DO_STATISTICS=1
       ;;
@@ -1022,6 +1122,11 @@ test -n "$VERIFY_BUILD_SYSTEM" && validate_param "--verify" "$VERIFY_BUILD_SYSTE
 test -n "$BUILD_RPM_BUILD_STAGE" && validate_param "--stage" "$BUILD_RPM_BUILD_STAGE" BUILD_RPM_BUILD_STAGE
 test "$BUILD_ROOT" != /var/tmp/build-root && validate_param "--root" "$BUILD_ROOT" BUILD_ROOT
 test "$CONFIG_DIR" != "$BUILD_DIR/configs" && validate_param "--configdir" "$CONFIG_DIR" CONFIG_DIR
+
+# Beside CLI, these can come from envvars (sourced by worker configs)
+if test -n "$CCACHE_HOST_DIR" || test -n "$CCACHE_HOST_BIN" ; then
+    CCACHE=true
+fi
 
 # validate the buildroot
 validate_buildroot "$BUILD_ROOT"

--- a/build
+++ b/build
@@ -539,7 +539,7 @@ setupccache() {
                 echo '#! /bin/sh' > $BUILD_ROOT/.ccache-bin/$i
                 echo "test -e /usr/bin/$i || exit 1" >> $BUILD_ROOT/.ccache-bin/$i
                 echo 'export PATH=/usr/lib/icecc/bin:/opt/icecream/bin:/usr/bin:$PATH' >> $BUILD_ROOT/.ccache-bin/$i
-                echo "/.ccache-bin/ccache $i \"\$@\"" >> $BUILD_ROOT/.ccache-bin/$i
+                echo "exec /.ccache-bin/ccache $i \"\$@\"" >> $BUILD_ROOT/.ccache-bin/$i
                 chmod 755 $BUILD_ROOT/.ccache-bin/$i
                 echo "Installed ccache wrapper as $BUILD_ROOT/.ccache-bin/$i"
             done

--- a/build
+++ b/build
@@ -565,12 +565,15 @@ CCACHE_DIR="/.ccache"
 CCACHE_LOGFILE="/.build.log.ccache"
 PATH="/.ccache-bin:\$PATH"
 export PATH CCACHE_LOGFILE CCACHE_DIR
-if test -z "\$NO_CCACHE_STATS" || test x"\$NO_CCACHE_STATS" = xyes ; then
-    echo "CCache state before build:"
+if test x"\$PROFILE_CCACHE_STATS" = xyes ; then
+    echo "CCache stats before build:"
     ccache -s
-fi
+fi >&2
 true
 EOF
+        if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
+            chroot "$BUILD_ROOT" /bin/sh -c "PROFILE_CCACHE_STATS=yes ; . /etc/profile.d/build_ccache.sh"
+        fi
     else
         rm -f "$BUILD_ROOT"/.ccache-bin/{gcc,g++,cc,c++,clang,clang++}{,-*}
     fi
@@ -1621,7 +1624,7 @@ if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
         echo
         echo "CCACHE stats after this run:"
         echo
-        chroot "$BUILD_ROOT" /usr/bin/bash -c "NO_CCACHE_STATS=yes ; . /etc/profile.d/build_ccache.sh && /.ccache-bin/ccache -s"
+        chroot "$BUILD_ROOT" /bin/sh -c "PROFILE_CCACHE_STATS=no ; . /etc/profile.d/build_ccache.sh && /.ccache-bin/ccache -s"
     fi
 
     echo

--- a/build
+++ b/build
@@ -493,14 +493,15 @@ provide_ccache() {
     # Setup is indeed needed... do some sanity check first
     [ -n "$BUILD_ROOT" ] && [ -d "$BUILD_ROOT" ] || return
     mkdir -p $BUILD_ROOT/.ccache-bin
-    rm -f "$BUILD_ROOT/.ccache-bin/ccache" 2>dev/null || true
+    rm -f "$BUILD_ROOT/.ccache-bin/ccache" 2>/dev/null || true
 
     # First try using a binary that may already exist in the build root via
     # packaging as /usr/bin/ccache. Note that this path can be an absolute
     # symlink, so can be misleading in the host environment - so we must
     # chroot before evaluating it.
-    if chroot "$BUILD_ROOT" /usr/bin/test -x /usr/bin/ccache || \
-       chroot "$BUILD_ROOT" /bin/test -x /usr/bin/ccache ; then
+    if chroot "$BUILD_ROOT" /usr/bin/test -x /usr/bin/ccache 2>/dev/null || \
+       chroot "$BUILD_ROOT" /bin/test -x /usr/bin/ccache 2>/dev/null ; then
+        echo "Using preferred ccache binary provided in the build root"
         ln -s "../usr/bin/ccache" "$BUILD_ROOT/.ccache-bin/ccache"
     else
         case "$CCACHE_HOST_BIN" in
@@ -510,7 +511,8 @@ provide_ccache() {
         esac
 
         if [ -n "$CCACHE_HOST_BIN" ] && [ -x "$CCACHE_HOST_BIN" ] ; then
-            cp -pLf "$CCACHE_HOST_BIN" "$BUILD_ROOT/.ccache-bin/"
+            echo "Using fallback ccache binary provided by the build worker: $CCACHE_HOST_BIN"
+            cp -pLf "$CCACHE_HOST_BIN" "$BUILD_ROOT/.ccache-bin/ccache"
         fi
     fi
 
@@ -1639,7 +1641,7 @@ if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
         echo "======="
     fi
 
-    if [ -x $BUILD_ROOT/.ccache-bin/ccache ] && [ -s "$BUILD_ROOT"/etc/profile.d/build_ccache.sh ] ; then
+    if [ -x "$BUILD_ROOT"/.ccache-bin/ccache ] && [ -s "$BUILD_ROOT"/etc/profile.d/build_ccache.sh ] ; then
         echo
         echo "CCACHE stats after this run:"
         echo

--- a/build
+++ b/build
@@ -104,6 +104,7 @@ DO_STATISTICS=
 RUN_SHELL=
 CCACHE=
 #DO_CCACHE_STATISTICS=
+#DO_CCACHE_LOGGING=
 DLNOSIGNATURE=
 BUILD_FLAVOR=
 OBS_PACKAGE=
@@ -256,6 +257,10 @@ Known Parameters:
               Usually the runtime dependencies are minimal, so the same
               binary should work on any Linux distro from the same era.
               If PATH_TO_BINARY is "yes", copy host /usr/bin/ccache.
+
+  --ccache-logging
+              optionally enable saving a ccache log of operations done
+              during this build job, beware of overheads and slowdown.
 
   --ccache-statistics
               optionally report ccache statistics and log of operations
@@ -559,18 +564,28 @@ setupccache() {
         else
             chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.ccache"
         fi
+
         cat << EOF > "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
 echo 'Sourcing /etc/profile.d/build_ccache.sh...' >&2
 CCACHE_DIR="/.ccache"
-CCACHE_LOGFILE="/.build.log.ccache"
 PATH="/.ccache-bin:\$PATH"
-export PATH CCACHE_LOGFILE CCACHE_DIR
+export PATH CCACHE_DIR
 if test x"\$PROFILE_CCACHE_STATS" = xyes ; then
     echo "CCache stats before build:"
     ccache -s
 fi >&2
 true
 EOF
+
+        # Note: logging does incur considerable overhead and slowdown
+        # so do not enable it unless investigating your ccache setup.
+        if [ "$DO_CCACHE_LOGGING" = 1 ] ; then
+            touch "$BUILD_ROOT/.build.log.ccache"
+            chown "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.build.log.ccache"
+            chmod 664 "$BUILD_ROOT/.build.log.ccache"
+            echo 'CCACHE_LOGFILE="/.build.log.ccache" ; export CCACHE_LOGFILE' >> "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
+        fi
+
         if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
             chroot "$BUILD_ROOT" /bin/sh -c "PROFILE_CCACHE_STATS=yes ; . /etc/profile.d/build_ccache.sh"
         fi
@@ -1027,6 +1042,9 @@ while test -n "$1"; do
 	CCACHE=true
 	CCACHE_HOST_BIN="$ARG"
 	shift
+      ;;
+      -ccache-logging)
+	DO_CCACHE_LOGGING=1
       ;;
       -ccache-statistics)
 	DO_CCACHE_STATISTICS=1

--- a/build
+++ b/build
@@ -573,7 +573,7 @@ PATH="/.ccache-bin:\$PATH"
 export PATH CCACHE_DIR
 if test x"\$PROFILE_CCACHE_STATS" = xyes ; then
     echo "CCache stats before build:"
-    ccache -s
+    CCACHE_LOGFILE='' ccache -s
 fi >&2
 true
 EOF
@@ -1643,7 +1643,7 @@ if [ "$DO_CCACHE_STATISTICS" = 1 ] ; then
         echo
         echo "CCACHE stats after this run:"
         echo
-        chroot "$BUILD_ROOT" /bin/sh -c "PROFILE_CCACHE_STATS=no ; . /etc/profile.d/build_ccache.sh && /.ccache-bin/ccache -s"
+        chroot "$BUILD_ROOT" /bin/sh -c "PROFILE_CCACHE_STATS=no ; . /etc/profile.d/build_ccache.sh && CCACHE_LOGFILE='' /.ccache-bin/ccache -s"
     fi
 
     echo

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -41,6 +41,10 @@ recipe_prepare_dsc() {
     rm -rf "$BUILD_ROOT$TOPDIR/BUILD"
     mkdir -p "$BUILD_ROOT$TOPDIR/SOURCES.DEB"
     chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT$TOPDIR"
+    if [ -s "$BUILD_ROOT"/etc/profile.d/build_ccache.sh ]; then
+	grep CCACHE_BASEDIR "$BUILD_ROOT"/etc/profile.d/build_ccache.sh > /dev/null || \
+	echo "CCACHE_BASEDIR='$TOPDIR/BUILD' ; export CCACHE_BASEDIR" >> "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
+    fi
     DEB_TRANSFORM=
     DEB_SOURCEDIR="$TOPDIR/SOURCES"
     DEB_DSCFILE="$RECIPEFILE"

--- a/build-recipe-preinstallimage
+++ b/build-recipe-preinstallimage
@@ -49,6 +49,7 @@ recipe_build_preinstallimage() {
 	.srcfiles*) continue ;;
 	.pkgs) continue ;;
 	.rpm-cache) continue ;;
+	.ccache*) continue ;;
 	installed-pkg) continue ;;
 	proc|sys) continue ;;
       esac

--- a/build-recipe-simpleimage
+++ b/build-recipe-simpleimage
@@ -72,6 +72,7 @@ recipe_build_simpleimage() {
 	.pkgs) continue ;;
 	.rpm-cache) continue ;;
 	.tmp) continue ;;
+	.ccache*) continue ;;
 	installed-pkg) continue ;;
 	proc|sys) continue ;;
       esac

--- a/build-vm
+++ b/build-vm
@@ -845,6 +845,8 @@ vm_first_stage() {
     echo "VM_WATCHDOG='$VM_WATCHDOG'" >> $BUILD_ROOT/.build/build.data
     echo "BUILDENGINE='$BUILDENGINE'" >> $BUILD_ROOT/.build/build.data
     echo "CCACHE='$CCACHE'" >> $BUILD_ROOT/.build/build.data
+    echo "CCACHE_HOST_DIR='$CCACHE_HOST_DIR'" >> $BUILD_ROOT/.build/build.data
+    echo "CCACHE_HOST_BIN='$CCACHE_HOST_BIN'" >> $BUILD_ROOT/.build/build.data
     echo "ABUILD_TARGET='$ABUILD_TARGET'" >> $BUILD_ROOT/.build/build.data
     echo "BUILD_FLAVOR='$BUILD_FLAVOR'" >> $BUILD_ROOT/.build/build.data
     echo "OBS_PACKAGE='$OBS_PACKAGE'" >> $BUILD_ROOT/.build/build.data

--- a/configs/debian.conf
+++ b/configs/debian.conf
@@ -9,7 +9,7 @@ Runscripts: base-files initscripts
 
 VMinstall: util-linux binutils libblkid1 libuuid1 libdevmapper1.02 mount
 
-Required: autoconf automake binutils bzip2 gcc gettext libc6
+Required: autoconf automake binutils bzip2 gcc gettext libc6 ccache
 Required: libtool libncurses5 perl zlib1g dpkg
 
 Support: build-essential fakeroot
@@ -21,7 +21,7 @@ Support: net-tools util-linux
 Support: patch procps psmisc rcs strace
 Support: texinfo unzip vim ncurses-base sysvinit
 
-Keep: binutils cpp cracklib file findutils gawk gcc gcc-ada gcc-c++
+Keep: binutils cpp cracklib file findutils gawk gcc gcc-ada gcc-c++ ccache
 Keep: gzip libada libstdc++ libunwind
 Keep: libunwind-devel libzio make mktemp pam-devel pam-modules
 Keep: patch perl rcs timezone

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -156,6 +156,7 @@ cleanup_and_exit() {
 	umount -n "$BUILD_ROOT/proc" 2> /dev/null || true
 	umount -n "$BUILD_ROOT/dev/pts" 2> /dev/null || true
 	umount -n "$BUILD_ROOT/mnt" 2> /dev/null || true
+	umount -n "$BUILD_ROOT/.ccache" 2> /dev/null || true
     fi
     exit $1
 }
@@ -167,6 +168,7 @@ clean_build_root() {
 	umount -n "$BUILD_ROOT/dev/pts" 2> /dev/null || true
 	umount -n "$BUILD_ROOT/dev/shm" 2> /dev/null || true
 	umount -n "$BUILD_ROOT/mnt" 2> /dev/null || true
+	umount -n "$BUILD_ROOT/.ccache" 2> /dev/null || true
 	rm -rf -- "$BUILD_ROOT"/* 2> /dev/null || true
 	chattr -a -A -i -R -- "$BUILD_ROOT" 2> /dev/null || true
 	rm -rf -- "$BUILD_ROOT"/*
@@ -486,6 +488,7 @@ if test -e "$BUILD_IS_RUNNING" ; then
     umount -n $BUILD_ROOT/proc 2> /dev/null
     umount -n $BUILD_ROOT/dev/pts 2> /dev/null
     umount -n $BUILD_ROOT/mnt 2> /dev/null
+    umount -n $BUILD_ROOT/.ccache 2> /dev/null || true
     echo "Your build system is broken!! Shall I execute"
     echo
     echo "    rm -rf -- $BUILD_ROOT/*"


### PR DESCRIPTION
Port of our (older) OBS setup, which benefits greatly from use of the same persistent `ccache` directory on all workers, ARM and amd64 alike (and Jenkins workers running builds in similar OS images too, added for good measure).

These changes allow to optionally enforce usage of `ccache` binary provided by the worker host (such approach should suffice for most Linux distros) even if the build-root does not pull ccache as a package, and to optionally bind-mount the cache directory from the worker's host so that a shared cache is easy to do.