### PR TITLE
Add support for .deb files which have control.tar.xz 

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -178,8 +178,9 @@ sub parse {
   return $ret;
 }
 
-sub ungzip {
+sub uncompress {
   my $data = shift;
+  my $tool = shift;
   local (*TMP, *TMP2);
   open(TMP, "+>", undef) or die("could not open tmpfile\n");
   syswrite TMP, $data;
@@ -188,13 +189,13 @@ sub ungzip {
   die("fork: $!\n") unless defined $pid;
   if (!$pid) {
     open(STDIN, "<&TMP");
-    exec 'gunzip';
-    die("gunzip: $!\n");
+    exec($tool);
+    die("$tool: $!\n");
   }
   close(TMP);
   $data = '';
   1 while sysread(TMP2, $data, 1024, length($data)) > 0;
-  close(TMP2) || die("gunzip error");
+  close(TMP2) || die("$tool error");
   return $data;
 }
 
@@ -229,6 +230,7 @@ sub debq {
     return ();
   }
   my $data = '';
+  my $decompressor = "gunzip";
   sysread(DEBF, $data, 4096);
   if (length($data) < 8+60) {
     warn("$fn: not a debian package - header too short\n");
@@ -270,10 +272,10 @@ sub debq {
   close DEBF unless ref($fn);
   $data = substr($data, 60, $len);
   my $controlmd5 = Digest::MD5::md5_hex($data);	# our header signature
-  if ($have_zlib) {
+  if ($have_zlib && $decompressor eq "gunzip") {
     $data = Compress::Zlib::memGunzip($data);
   } else {
-    $data = ungzip($data);
+    $data = uncompress($data, $decompressor);
   }
   if (!$data) {
     warn("$fn: corrupt control.tar.gz file\n");

--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -256,9 +256,14 @@ sub debq {
   $data = substr($data, 8 + 60 + $len);
   if (substr($data, 0, 16) ne 'control.tar.gz  ' &&
       substr($data, 0, 16) ne 'control.tar.gz/ ') {
-    warn("$fn: control.tar.gz is not second ar entry\n");
-    close DEBF unless ref $fn;
-    return ();
+    if (substr($data, 0, 16) eq 'control.tar.xz  ' ||
+        substr($data, 0, 16) eq 'control.tar.xz/ ') {
+      $decompressor = "unxz";
+    } else  {
+      warn("$fn: control.tar is not second ar entry\n");
+      close DEBF unless ref $fn;
+      return ();
+    }
   }
   $len = substr($data, 48, 10);
   if (length($data) < 60+$len) {
@@ -278,7 +283,7 @@ sub debq {
     $data = uncompress($data, $decompressor);
   }
   if (!$data) {
-    warn("$fn: corrupt control.tar.gz file\n");
+    warn("$fn: corrupt control.tar file\n");
     return ();
   }
   my $control;
@@ -288,7 +293,7 @@ sub debq {
     my $len = oct('00'.substr($data, 124,12));
     my $blen = ($len + 1023) & ~511;
     if (length($data) < $blen) {
-      warn("$fn: corrupt control.tar.gz file\n");
+      warn("$fn: corrupt control.tar file\n");
       return ();
     }
     if ($n eq './control' || $n eq "control") {
@@ -390,8 +395,11 @@ sub queryhdrmd5 {
   }
   $data = substr($data, 8 + 60 + $len);
   if (substr($data, 0, 16) ne 'control.tar.gz  ' &&
-      substr($data, 0, 16) ne 'control.tar.gz/ ') {
-    warn("$bin: control.tar.gz is not second ar entry\n");
+      substr($data, 0, 16) ne 'control.tar.gz/ ' &&
+      substr($data, 0, 16) ne 'control.tar.xz  ' &&
+      substr($data, 0, 16) ne 'control.tar.xz/ ')
+   {
+    warn("$bin: control.tar is not second ar entry\n");
     close F;
     return undef;
   }


### PR DESCRIPTION
Fixes issue #395. Testcase .deb:s at: http://people.linaro.org/~riku.voipio/fix-obsbuild/

Before my patches:

```
528a3601f6d4707259c046c64ec637eb
$VAR1 = {
          'provides' => [],
          'source' => 'hello',
          'hdrmd5' => '528a3601f6d4707259c046c64ec637eb',
          'name' => 'hello',
          'requires' => [
                          'libc6 (>= 2.14)'
                        ]
        };

hxz.deb: control.tar.gz is not second ar entry

hxz.deb: control.tar.gz is not second ar entry
$VAR1 = undef;
```
And with patches:
```
528a3601f6d4707259c046c64ec637eb
$VAR1 = {
          'source' => 'hello',
          'requires' => [
                          'libc6 (>= 2.14)'
                        ],
          'provides' => [],
          'name' => 'hello',
          'hdrmd5' => '528a3601f6d4707259c046c64ec637eb'
        };

56be34240ac273298ec9e37bd61b26f2
$VAR1 = {
          'source' => 'hello',
          'hdrmd5' => '56be34240ac273298ec9e37bd61b26f2',
          'name' => 'hello',
          'requires' => [
                          'libc6 (>= 2.14)'
                        ],
          'provides' => []
        };

```
Unfortunately I have no knowledge how perl testsuite works, so I don't know howto integrate the above under tests.