### PR TITLE
Deb.pm: support Build-Depends-Arch

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -112,7 +112,8 @@ sub parse {
       @exclarch = sort keys %exclarch;
     } elsif ($tag eq 'SOURCE') {
       $name = $data;
-    } elsif ($tag eq 'BUILD-DEPENDS' || $tag eq 'BUILD-CONFLICTS' || $tag eq 'BUILD-IGNORE' || $tag eq 'BUILD-DEPENDS-INDEP') {
+    } elsif ($tag eq 'BUILD-DEPENDS' || $tag eq 'BUILD-CONFLICTS' || $tag eq 'BUILD-IGNORE' ||
+        $tag eq 'BUILD-DEPENDS-INDEP' || $tag eq 'BUILD-DEPENDS-ARCH' || $tag eq 'BUILD-CONFLICTS-ARCH' ) {
       my @d = split(/\s*,\s*/, $data);
       for my $d (@d) {
         my @alts = split('\s*\|\s*', $d);
@@ -163,7 +164,7 @@ sub parse {
 	$d =~ s/ \(([^\)]*)\)/ $1/g;
 	$d =~ s/>>/>/g;
 	$d =~ s/<</</g;
-	if ($tag eq 'BUILD-DEPENDS' || $tag eq 'BUILD-DEPENDS-INDEP') {
+	if ($tag eq 'BUILD-DEPENDS' || $tag eq 'BUILD-DEPENDS-INDEP' || $tag eq 'BUILD-DEPENDS-ARCH') {
 	  push @deps, $d;
 	} else {
 	  push @deps, "-$d";


### PR DESCRIPTION
Build-Depends-Arch and Build-Conflicts-Arch where added in dpkg 1.16.4.
They are now documented in man deb-src-control(5) and debian policy.
Add support to obs-build as packages in unstable are starting to use
them.