### PR TITLE
Modernize download script.

### DIFF
--- a/download
+++ b/download
@@ -61,7 +61,7 @@ for my $url (@ARGV) {
   } else {
     $url = URI->new($url);
   }
-  $ua->env_proxy  if $url->scheme ne 'https';
+  $ua->env_proxy;
   my $dest = "$dir/".basename($url->path);
   unlink($dest);	# just in case
   my $retry = 3;

--- a/download
+++ b/download
@@ -20,7 +20,6 @@
 #
 ################################################################
 
-use Net::SSL ();
 BEGIN {
   $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0,
   unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/build');

--- a/download
+++ b/download
@@ -21,7 +21,6 @@
 ################################################################
 
 BEGIN {
-  $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0,
   unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/build');
 }
 
@@ -38,7 +37,10 @@ my $dir = shift @ARGV;
 
 my $ua = LWP::UserAgent->new(
   agent => "openSUSE build script",
-  timeout => 42);
+  timeout => 42,
+  ssl_opts => {
+    verify_hostname => 1
+  });
 
 for my $url (@ARGV) {
   if ($url =~ /^zypp:\/\/([^\/]*)\/?/) {


### PR DESCRIPTION
This PR switches the download script to use the non-deprecated default implementation (IO::Socket::Ssl) backend for LWP::Protocol::https, enables hostname verification and HTTPS proxying support.

Besides mitigating MITM attacks (without hostname verification, any certificate trusted by the system anchor will be accepted as valid, even though issued for a completely different hostname), this also fixes huge performance problems for HTTPS-scheme downloads.

On my test system, downloading a rather small file over HTTPS took anywhere from 13 to 60 seconds(!) with the deprecated Crypt::SSLeay backend, while the IO::Socket::Ssl backend clocks in at a more reasonable 0.5 seconds on average. This made HTTPS downloads completely unusable.