### PR TITLE
add libidn2 and libunistring to preinstall for archlinux

### DIFF
--- a/configs/arch.conf
+++ b/configs/arch.conf
@@ -4,7 +4,7 @@ Preinstall: glibc bash perl sed grep coreutils pacman pacman-mirrorlist
 Preinstall: gawk gzip filesystem curl libidn acl gpgme libarchive
 Preinstall: openssl libssh2 zlib libassuan libgpg-error attr
 Preinstall: expat xz bzip2 readline lzo krb5 e2fsprogs keyutils
-Preinstall: ncurses lz4 libpsl icu gcc-libs libnghttp2
+Preinstall: ncurses lz4 libpsl icu gcc-libs libnghttp2 libidn2 libunistring
 
 VMinstall: util-linux libutil-linux binutils pcre libcap
 


### PR DESCRIPTION
`libpsl` (dependency of `curl`) requires `libidn2` & `libunistring`.

https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/libpsl&id=ab7b5d9e584beb55e93a1256db0ee306edd8a6b2