### PR TITLE
changelog2spec: fix "multiple .changes files" case

### DIFF
--- a/changelog2spec
+++ b/changelog2spec
@@ -83,7 +83,7 @@ if (@ARGV == 2 && $ARGV[0] eq '--file') {
   exit(1) unless @changes;	# nothing to do
   if (@changes > 1) {
     while ($file ne '') {
-      my @c = grep {/\Q$file\E/} @changes;
+      my @c = grep {/\Q${file}.changes\E/} @changes;
       if (@c) {
 	@changes = @c;
 	last;


### PR DESCRIPTION
in case of a package with multiple spec and changes files with
substring-matching names (example: build.{spec,changes},
build-mkbaselibs-sle.{spec,changes}), after commit 393c4906 the
longest filename was used, leading to build-mkbaselibs-sle.changes
being used for build.spec.
Use an exact match to fix up this problem.