### PR TITLE
Use docker --mount instead of --volume

### DIFF
--- a/build-vm-docker
+++ b/build-vm-docker
@@ -32,7 +32,7 @@ vm_startup_docker() {
     docker rm "$name" >/dev/null 2>&1 || true
     docker run \
         --rm --name "$name" --cap-add=sys_admin --cap-add=MKNOD --net=none \
-        -v "$BUILD_ROOT:/mnt" busybox /bin/chroot /mnt "$vm_init_script"
+        --mount "type=volume,source=$BUILD_ROOT,destination=/mnt" busybox /bin/chroot /mnt "$vm_init_script"
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"


### PR DESCRIPTION
Completely _untested_ (based on the information in
https://docs.docker.com/engine/admin/volumes/volumes/#differences-between--v-and---mount-behavior)

This is needed to support colons in the volume name.

Fixes: https://github.com/openSUSE/osc/issues/358 ("--vm-type=docker
not compatible with build_root with common prj names containing ':'")