### PR TITLE
Fix rpm detection in build-recipe-appimage

### DIFF
--- a/build-recipe-appimage
+++ b/build-recipe-appimage
@@ -54,7 +54,7 @@ recipe_prepare_appimage() {
 
 recipe_build_appimage() {
     local ARCH DEB
-    if [ -x /bin/rpm ]; then
+    if [ -x "$BUILD_ROOT/bin/rpm" ]; then
         ARCH=$(chroot $BUILD_ROOT su -c "rpm --eval '%{_target_cpu}'")
     else
         ARCH=$(chroot $BUILD_ROOT su -c "dpkg-architecture -qDEB_BUILD_ARCH")


### PR DESCRIPTION
Check for the presence of rpm in the build root instead of the
host system.

Fixes: https://github.com/openSUSE/osc/issues/365 ("cannot build
sample AppImage with osc on ubuntu 16.04")