### PR TITLE
Fix sysdeps parsing in case of kiwi image

### DIFF
--- a/expanddeps
+++ b/expanddeps
@@ -423,6 +423,11 @@ Build::readdeps($cf, undef, \%repo);
 my @sysdeps = Build::get_sysbuild($cf, $buildtype, $extrasysdeps);
 
 if ($buildtype eq 'kiwi-image' || $buildtype eq 'kiwi-product') {
+  if (!shift @sysdeps) {
+    print STDERR "expansion error\n";
+    print STDERR "  $_\n" for @sysdeps;
+    exit(1);
+  }
   # just use the sysdeps for now, ignore real deps
   print_rpmlist(@sysdeps);
   exit(0);


### PR DESCRIPTION
- Build::get_sysbuild returns and array where at the first position
is the result of the whole operation. This was not handled properly
for kiwi outputs