### PR TITLE
fix tests on newer perl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all:
 .PHONY:	test
 
 test:
-	prove -v
+	PERL5LIB=. prove -v
 
 install:
 	install -m755 -d \


### PR DESCRIPTION
e.g. perl-5.26 on Tumbleweed does not have '.' in the default `@INC` anymore