### PR TITLE
Don't rely on AppImage's auto-detection for architecture

### DIFF
--- a/build-recipe-appimage
+++ b/build-recipe-appimage
@@ -91,7 +91,7 @@ recipe_build_appimage() {
         release_option="--release $RELEASE"
     fi
 
-    chroot $BUILD_ROOT su -c "cd $TOPDIR/SOURCES && /usr/lib/appimagetool/pkg2appimage $release_option" - root \
+    chroot $BUILD_ROOT su -c "cd $TOPDIR/SOURCES && ARCH=$ARCH /usr/lib/appimagetool/pkg2appimage $release_option" - root \
 	|| cleanup_and_exit 1
 
     # extract build result basenames


### PR DESCRIPTION
Otherwise build errors occur when AppImage's auto-detection for the architecture fails, eg.:
```
[  367s] Use appimagetool
[  367s] /usr/src/packages/OTHER /usr/src/packages/SOURCES
[  367s] appimagetool, continuous build (commit 88400e4975cd3fb1270e5a6352a7180195dfae83), build (null) built on 
[  367s] Unable to guess the architecture of the AppDir source directory "/usr/src/packages/Tag Editor-0-Build5.1-x86_64"
[  367s] A valid architecture with the ARCH environmental variable should be provided
[  367s] e.g. ARCH=x86_64 appimagetool ...
[  367s] 
[  367s] cloud136 failed "build appimage.yml" at Sat Feb 10 19:42:41 UTC 2018.
```

I tested locally that passing the architecture manually like this PR proposes works, at least for `x86_64`.

Note that the error message is emitted here: https://github.com/AppImage/AppImageKit/blob/appimagetool/master/src/appimagetool.c#L607

As a workaround I could just place an `*.so` file in the directory the auto-detection checks, but I think it is cleaner not to rely on the auto-detection and just pass the architecture since it is determined anyways.