### PR TITLE
Fixed use of provides tags

### DIFF
--- a/Build/Kiwi.pm
+++ b/Build/Kiwi.pm
@@ -97,7 +97,7 @@ sub kiwiparse {
       if (defined $type->{'image'}) {
         # for kiwi 4.1 and 5.x
         push @types, $type->{'image'};
-        push @packages, "kiwi-image:$type->{'image'}" if $schemaversion >= $schemaversion56;
+        push @packages, "kiwi-image($type->{'image'})" if $schemaversion >= $schemaversion56;
       } else {
         # for kiwi 3.8 and before
         push @types, $type->{'_content'};
@@ -130,7 +130,7 @@ sub kiwiparse {
         push @containerrepos, $prp if $prp;
       }
 
-      push @packages, "kiwi-filesystem:$type->{'filesystem'}" if $type->{'filesystem'};
+      push @packages, "kiwi-filesystem($type->{'filesystem'})" if $type->{'filesystem'};
       if (defined $type->{'boot'}) {
         if ($type->{'boot'} =~ /^obs:\/\/\/?([^\/]+)\/([^\/]+)\/?$/) {
           next unless $bootcallback;
@@ -143,7 +143,7 @@ sub kiwiparse {
           push @extrasources, @{$bret->{'extrasource'} || []};
         } else {
           die("bad boot reference: $type->{'boot'}\n") unless $type->{'boot'} =~ /^([^\/]+)\/([^\/]+)$/;
-          push @packages, "kiwi-boot:$1";
+          push @packages, "kiwi-boot($1)";
         }
       }
     }
@@ -310,7 +310,7 @@ sub kiwiparse {
   @requiredarch = unify(@requiredarch, @fallbackarchs);
 
   if (!$instsource) {
-    push @packages, "kiwi-packagemanager:$packman";
+    push @packages, "kiwi-packagemanager($packman)";
     push @packages, "--dorecommends--", "--dosupplements--" if $patterntype && $patterntype eq 'plusRecommended';
   } else {
     push @packages, "kiwi-packagemanager:instsource";


### PR DESCRIPTION
A provides tag of the format "foo:bar" causes a problem in rpm if the macro:

* %_wrong_version_format_terminate_build

is not set to 0. For suse builds the above macro is set to 0 and thus do not cause problems. But for other distributions the build fails if the kiwi packages creates provides tags in this format.

Therefore this patch is one out of series which changes the use of the provides tags to the format "foo(bar)". There will be reference patches to the spec files of the

* python-kiwi
* kiwi-boot-descriptions

packages to complete the required changes.

If you agree on the change I will put in the reference pull requests once I have created them so that all changes can be merged in one shot

Thanks