### PR TITLE
Copy dirs/extracted archives as AppImage source

### DIFF
--- a/build-recipe-appimage
+++ b/build-recipe-appimage
@@ -34,7 +34,7 @@ recipe_setup_appimage() {
     if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
-	cp -p "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
+	cp -rp "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     fi
 
     rawcfgmacros=.rpmmacros


### PR DESCRIPTION
This allows to specify a tar archive as source in appimage.yaml, eg.:

```
…
build:
  packages:
    - linuxdeployqt
    …
  files:
    - https://github.com/Martchus/cpp-utilities/archive/v4.13.0.tar.gz
    - https://github.com/Martchus/qtutilities/archive/v5.9.0.tar.gz
    …
```

I tested this locally and it works. The change also didn't break copying regular files and using Git sources.

However, I'm wondering why nobody else has run into this issue yet. Maybe I'm doing something wrong here? I just run `osc build AppImage x86_64 appimage.yml`. The sources are downloaded and *extracted* automatically (the extraction makes this change necessary).