### PR TITLE
Kiwi build doesn't work because of expanddeps crash

### DIFF
--- a/expanddeps
+++ b/expanddeps
@@ -420,7 +420,7 @@ Build::readdeps($cf, undef, \%repo);
 
 #######################################################################
 
-my @sysdeps = Build::get_sysbuild($cf, $buildtype, $extrasysdeps);
+my ($rc, @sysdeps) = Build::get_sysbuild($cf, $buildtype, $extrasysdeps);
 
 if ($buildtype eq 'kiwi-image' || $buildtype eq 'kiwi-product') {
   # just use the sysdeps for now, ignore real deps


### PR DESCRIPTION
This one fixes Kiwi build with error:
[    0s] expanding package dependencies...
[   18s] Use of uninitialized value within %packs in hash element at /usr/lib/build/expanddeps line 354.
[   18s] Use of uninitialized value in concatenation (.) or string at /usr/lib/build/expanddeps line 354.
[   18s] Use of uninitialized value within %packs in exists at /usr/lib/build/expanddeps line 355.
[   18s] unsupported url for '1':
