### PR TITLE
Set target timezone to UTC (offset 0)

### DIFF
--- a/changelog2spec
+++ b/changelog2spec
@@ -37,7 +37,7 @@ my @wday = qw{Sun Mon Tue Wed Thu Fri Sat};
 my @mon = qw{Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec};
 
 my $ok;
-my $zone;
+my $zone = 0;
 my $test;
 my $fulltimestamps;
 my $printtype;


### PR DESCRIPTION
Instead of normalizing all dates/times in the .changes file to
whatever timezone the first entry has, let's normalize to UTC, especially
as this information is not found in the rpm changelog in the end.

Fixes issue #439.