### PR TITLE
Do not pass the deprecated "--force" option to pacman -U

### DIFF
--- a/build-pkg-arch
+++ b/build-pkg-arch
@@ -50,7 +50,7 @@ pkg_install_arch() {
     # https://bbs.archlinux.org/viewtopic.php?id=129661
     (cd $BUILD_ROOT/etc && sed -i "s/^CheckSpace/#CheckSpace/g" pacman.conf)
     # -d -d disables deps checking
-    ( cd $BUILD_ROOT && chroot $BUILD_ROOT pacman -U --force -d -d --noconfirm .init_b_cache/$PKG.$PSUF 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( cd $BUILD_ROOT && chroot $BUILD_ROOT pacman -U --overwrite '*' -d -d --noconfirm .init_b_cache/$PKG.$PSUF 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(warning: could not get filesystem information for |loading packages|looking for inter-conflicts|looking for conflicting packages|Targets |Total Installed Size: |Net Upgrade Size: |Proceed with installation|checking package integrity|loading package files|checking for file conflicts|checking keyring|Packages \(\d+\)|:: Proceed with installation|:: Processing package changes|checking available disk space|installing |upgrading |warning:.*is up to date -- reinstalling|Optional dependencies for|    )/||/^$/||print'
 }
 


### PR DESCRIPTION
Instead, pass --overwrite '*' to pacman -U, which has the same effect
as the deprecated --force option. Note: this changes assumes that
the pacman -U command supports the --overwrite option (which is ok,
because Arch is a rolling distro).

If you think we should care about backward compatibility with old pacman
versions, I'll happily update the PR:)