### PR TITLE
Disable kpti on guest kernel for performance and correctness

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -265,7 +265,13 @@ vm_startup_kvm() {
     if test -n "$VMDISK_MOUNT_OPTIONS" ; then
         qemu_append="$qemu_append rootflags=${VMDISK_MOUNT_OPTIONS#-o }"
     fi
-    qemu_append="$qemu_append panic=1 quiet no-kvmclock nmi_watchdog=0 rw rd.driver.pre=binfmt_misc $vm_linux_kernel_parameter elevator=noop console=$kvm_console init=$vm_init_script"
+    qemu_append="$qemu_append panic=1 quiet no-kvmclock "
+    # Only protecting nonroot from root inside guest -> but anyone can be root inside guest
+    # so disabling spectre/meltdown mitigations doesn't hurt security and gains performance
+    qemu_append="$qemu_append kpti=off pti=off spectre_v2=off"
+    qemu_append="$qemu_append nmi_watchdog=0 rw rd.driver.pre=binfmt_misc"
+    qemu_append="$qemu_append $vm_linux_kernel_parameter elevator=noop"
+    qemu_append="$qemu_append console=$kvm_console init=$vm_init_script"
     if test -z "$VM_NETOPT" -a -z "$VM_NETDEVOPT"; then
         kvm_options="$kvm_options -net none"
     fi


### PR DESCRIPTION
kpti costs performance for VM guests but doesn't bring security
benefits (the guest kernel shall be considered untrusted anyway
because the user can define a custom kernel for his project).
As a side effect it avoids a regression on some ARM SoCs (bsc#1097449)