### PR TITLE
build-recipe: Adjust check for email only authors to be specific for SLE

### DIFF
--- a/build-recipe
+++ b/build-recipe
@@ -163,10 +163,10 @@ recipe_create_changelog() {
     esac
     # add --emailonly option for sles builds
     if test "$CFFORMAT" = rpm ; then
-	case `queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" eval '%{?is_opensuse}/%{?!fullname_in_changelog:%{?suse_version}}'` in
-	  *[1-9]*/*) ;;
-	  */*[1-9]*) CFFORMAT="$CFFORMAT --emailonly" ;;
-	esac
+        CFFORMAT_EMAILONLY=`queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" eval '%{!?fullname_in_changelog:%{?suse_version:%{!?is_opensuse:1}%{?is_opensuse}}%{!?suse_version:0}}%{?fullname_in_changelog:0}'`
+        if [ -n $CFFORMAT_EMAILONLY ]; then
+	    CFFORMAT="$CFFORMAT --emailonly"
+        fi
     fi
     echo "running changelog2spec --target $CFFORMAT --file $1"
     if ! $BUILD_DIR/changelog2spec --target $CFFORMAT --file "$1" > $BUILD_ROOT/.build-changelog ; then 


### PR DESCRIPTION
The way the condition was structured, setting `%fullname_in_changelog` to `1` would trigger the wrong behavior on non-SUSE systems.

This conditional evaluates to disable full identities only if it is a SUSE system that isn't openSUSE only if `%fullname_in_changelog` is not set.

In all other cases, it preserves full identities if they exist.