### PR TITLE
debootstrap: Add abuild shadow password entry

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -58,6 +58,7 @@ recipe_build_debootstrap() {
     # adapt passwd
     if test $BUILD_USER = abuild ; then
 	echo "abuild:x:${ABUILD_UID}:${ABUILD_GID}:Autobuild:/home/abuild:/bin/bash" >>$BUILD_ROOT/$myroot/etc/passwd
+	echo 'abuild:*:::::::' >>$BUILD_ROOT/$myroot/etc/shadow
 	echo 'abuild:*::' >>$BUILD_ROOT/$myroot/etc/gshadow
 	echo "abuild:x:${ABUILD_GID}:" >>$BUILD_ROOT/$myroot/etc/group
 	mkdir -p $BUILD_ROOT/$myroot/home/abuild


### PR DESCRIPTION
Without this, calling `su` can fail during PAM authentication. The `su`
from shadow will ignore this error when called by root, but the `su`
from util-linux does not and the build fails.

The outer buildroot configured the abuild user correctly, but the copied
configuration for the inner debootstrap root did not.