### PR TITLE
build-recipe-livebuild: publish source tarball

### DIFF
--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -260,6 +260,10 @@ recipe_build_livebuild() {
 	    BUILD_SUCCEEDED=true
 	done
     done
+
+    # copy recipe source tarball so that it can be published
+    cp "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" \
+        "$BUILD_ROOT/$TOPDIR/OTHER/${RECIPEFILE%.livebuild}${buildnum}".livebuild.tar
 }
 
 recipe_resultdirs_livebuild() {


### PR DESCRIPTION
Packages are published with their source tarballs so that they can be
reproduced by users, among other reasons.
Publish the livebuild tarball for those same reasons together with the
ISO files.