### PR TITLE
debootstrap: ensure /etc/hosts exists

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -78,6 +78,10 @@ recipe_build_debootstrap() {
 
     chroot $BUILD_ROOT/$myroot apt-cache gencaches
 
+    if ! test -e $BUILD_ROOT/$myroot/etc/hosts ; then
+        cp $BUILD_ROOT/etc/hosts $BUILD_ROOT/$myroot/etc/hosts
+    fi
+
     # move topdir over
     mv "$BUILD_ROOT/$TOPDIR" "$BUILD_ROOT/$myroot/${TOPDIR%/*}"
 


### PR DESCRIPTION
debootstrap won't necesserily create /etc/hosts, so copy it from the
main buildroot if it's not there.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>
Signed-off-by: Héctor Orón Martínez <zumbi@debian.org>
Signed-off-by: Andrew Lee (李健秋) <ajqlee@debian.org>