### PR TITLE
build: collect *.ddeb, *.udeb files too

### DIFF
--- a/build
+++ b/build
@@ -1462,7 +1462,7 @@ if test -n "$BUILD_ROOT" -a "$BUILD_ROOT" != / ; then
 fi
 
 RPMS=`find $BUILD_ROOT/$TOPDIR/RPMS -type f -name "*.rpm" 2>/dev/null || true`
-DEBS=`find $BUILD_ROOT/$TOPDIR/DEBS -type f -name "*.deb" 2>/dev/null || true`
+DEBS=`find $BUILD_ROOT/$TOPDIR/DEBS -type f "(" -name "*.deb" -o -name "*.ddeb" -o -name "*.udeb" ")" 2>/dev/null || true`
 
 if test -n "$RPMS" -a -n "$BUILD_USER_ABUILD_USED" ; then
     recipe_check_file_owners


### PR DESCRIPTION
On Ubuntu 18.04, debug packages are called e.g.

php7-mapi-dbgsym_8.6.81.24-0+3.1_amd64.ddeb