### PR TITLE
build-recipe-dsc: avoid source package rebuilds

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -95,7 +95,7 @@ dsc_build() {
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc -b"
     if test -e $buildroot/$TOPDIR/SOURCES/build.script ; then
 	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"


### PR DESCRIPTION
If we use build suffixes, rebuilding the source package will
result in the build suffix being included into the source package,
which we'd rather avoid.

Attach patch to avoid source package rebuild, which causes
issues as the source package appends undesired suffix.

Author: Andrew Shadura <andrew.shadura@collabora.co.uk>
Signed-off-by: Andrew Lee (李健秋) <ajqlee@debian.org>