### PR TITLE
build-recipe-debootstrap: add fallback for Debian SID distro

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -31,7 +31,11 @@ recipe_prepare_debootstrap() {
 
 recipe_build_debootstrap() {
     local arch=$(chroot $BUILD_ROOT su -c "dpkg-architecture -qDEB_BUILD_ARCH")
-    local dist=$(chroot $BUILD_ROOT su -c "lsb_release --codename --short")
+    if chroot $BUILD_ROOT grep -q '/sid' /etc/debian_version ; then
+        local dist=unstable
+    else
+        local dist=$(chroot $BUILD_ROOT su -c "lsb_release --codename --short")
+    fi
     local myroot=debootstraproot
     test -d $BUILD_ROOT/.build.binaries || cleanup_and_exit 1
     if test "$DO_INIT" = true -o ! -d "$BUILD_ROOT/.build.binaries/dists" ; then


### PR DESCRIPTION
When attempting to build Debian unstable, distribution is
calculated using lsb, which relies on apt cache.

As our build systems lack apt cache and network we cannot detect
we are building for Debian SID (aka unstable).

For more background information see:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845651

Tested-by: Héctor Orón Martínez <hector.oron@collabora.co.uk>
Signed-off-by: Andrew Lee (李健秋) <ajqlee@debian.org>