### PR TITLE
archlinux: add zstd to Preinstall for libarchive

### DIFF
--- a/configs/arch.conf
+++ b/configs/arch.conf
@@ -1,7 +1,7 @@
 Repotype: arch
 
 Preinstall: glibc bash perl sed grep coreutils pacman pacman-mirrorlist
-Preinstall: gawk gzip filesystem curl libidn acl gpgme libarchive
+Preinstall: gawk gzip filesystem curl libidn acl gpgme libarchive zstd
 Preinstall: openssl libssh2 zlib libassuan libgpg-error attr
 Preinstall: expat xz bzip2 readline lzo krb5 e2fsprogs keyutils
 Preinstall: ncurses lz4 libpsl icu gcc-libs libnghttp2 libidn2 libunistring


### PR DESCRIPTION
https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/libarchive&id=82ec2e0ca20e3e3cf29f1bfb2b95dde88da68394

Currently all builds for archlinux are failing with this error:

```
pacman: error while loading shared libraries: libzstd.so.1: cannot open shared object file: No such file or directory
[   20s] exit ...
```