### PR TITLE
Save the _statistics file in the $BUILD_ROOT dir

### DIFF
--- a/build-recipe
+++ b/build-recipe
@@ -191,7 +191,7 @@ recipe_needs_build_binaries() {
 }
 
 recipe_build_time_statistics() {
-    if test "$DO_STATISTICS" = 1 -a -n "$RECIPE_BUILD_START_TIME" -a -n "$TOPDIR" ; then
+    if test "$DO_STATISTICS" = 1 -a -n "$RECIPE_BUILD_START_TIME" -a -n "$TOPDIR" -a -n "$RUNNING_IN_VM" ; then
 	mkdir -p "$TOPDIR/OTHER"
 	echo "TIME_main_build: $(( `date +%s` - $RECIPE_BUILD_START_TIME))"  >> "$TOPDIR/OTHER/_statistics"
 	RECIPE_BUILD_START_TIME=


### PR DESCRIPTION
Currently, the _statistics file is saved in $TOPDIR/OTHER instead
of $BUILD_ROOT/$TOPDIR/OTHER.

Fixes: https://github.com/openSUSE/osc/issues/449 ("osc build
creates _statistics outside chroot")