### PR TITLE
Write nicer .rpmmacros

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -82,6 +82,7 @@ recipe_prepare_spec() {
 
     if test -n "$BUILD_JOBS" ; then
 	cat >> $BUILD_ROOT/root/$rawcfgmacros <<-EOF
+		### from obs-build
 		%jobs $BUILD_JOBS
 		%_smp_mflags -j$BUILD_JOBS
 		EOF


### PR DESCRIPTION
separate our additions from macros that originate from prjconf