### PR TITLE
Disable dir_index ext2/3/4 option

### DIFF
--- a/build
+++ b/build
@@ -332,6 +332,9 @@ Known Parameters:
   --vm-disk-filesystem TYPE
               Defaults for automatic setup of VM root/swap files.
               May get overruled by build config vmfstype build flag.
+  --vm-disk-dirindex
+              On ext2/3/4 enable the dir_index feature.
+              Makes readdir order indeterministic.
 
   --vm-memory SIZEINMB
               Set amount of RAM for VMs

--- a/build-vm
+++ b/build-vm
@@ -22,13 +22,8 @@
 ################################################################
 
 # defaults for vm_img_mkfs
-vm_img_mkfs_ext4_options='-O ^has_journal,^huge_file,^resize_inode,sparse_super'
-vm_img_mkfs_ext4_extra='-E lazy_itable_init,discard'
-vm_img_mkfs_ext4="mkfs.ext4 -m 0 -q -F $vm_img_mkfs_ext4_options"
 vm_img_tunefs_ext4='tune2fs -c 0'
-vm_img_mkfs_ext3='mkfs.ext3 -m 0 -q -F'
 vm_img_tunefs_ext3='tune2fs -c 0 -o journal_data_writeback'
-vm_img_mkfs_ext2='mkfs.ext2 -m 0 -q -F'
 vm_img_tunefs_ext2='tune2fs -c 0'
 vm_img_mkfs_reiserfs='mkreiserfs -q -f'
 vm_img_mkfs_btrfs='mkfs.btrfs'
@@ -58,6 +53,7 @@ VM_DEVICEOPT=()
 VM_TELNET=
 VM_CONSOLE_INPUT=
 VM_USER=
+VMDISK_EXT_DIRINDEX=
 VMDISK_ROOTSIZE=4096
 VMDISK_SWAPSIZE=1024
 VMDISK_FILESYSTEM=
@@ -200,6 +196,9 @@ vm_parse_options() {
 	needarg
 	VM_INITRD="$ARG"
 	shift
+      ;;
+      -vm-disk-dirindex)
+	VMDISK_EXT_DIRINDEX=1
       ;;
       -vm-disk-size|-vmdisk-rootsize)
 	needarg
@@ -370,6 +369,14 @@ vm_img_mkfs() {
     local fs="$1"
     local img="$2"
     local mkfs tunefs
+    vm_img_mkfs_ext_options='-O ^resize_inode'
+    [ "$VMDISK_EXT_DIRINDEX" = 1 ] || vm_img_mkfs_ext_options="$vm_img_mkfs_ext_options,^dir_index"
+    vm_img_mkfs_ext4_options='^has_journal,^huge_file,sparse_super'
+    vm_img_mkfs_ext4_extra='-E lazy_itable_init,discard'
+    vm_img_mkfs_ext4="mkfs.ext4 -m 0 -q -F $vm_img_mkfs_ext_options,$vm_img_mkfs_ext4_options"
+    vm_img_mkfs_ext3="mkfs.ext3 -m 0 -q -F $vm_img_mkfs_ext_options"
+    vm_img_mkfs_ext2="mkfs.ext2 -m 0 -q -F $vm_img_mkfs_ext_options"
+
     eval "mkfs=\"\$vm_img_mkfs_${fs}\""
     eval "mkfs_exta_options=\"\$vm_img_mkfs_${fs}_extra\""
     eval "tunefs=\"\$vm_img_tunefs_${fs}\""


### PR DESCRIPTION
This reduces indeterminism from filesystem readdir order,
e.g. this snippet suddenly delivers the same output every time:
```bash
mkdir -p in; for i in $(seq 10) ; do touch in/$i ; done
find in/ -type f > unreproducible
```

Since we usually do not have large directories, it should not slow
down the build processes.

Quick testing with
```bash
osc co openSUSE:Factory/python-service_identity && cd $_
time osc build --no-service --clean --vm-type=kvm \
    --offline --build-opt=--vm-disk-filesystem=ext4
```
showed that the difference is 0 +-0.2%

Alternative approach is to use a constant hash_seed via
https://github.com/tytso/e2fsprogs/commit/e1f7100643a46456be107b33098f6034b0835e6d
but that is not yet in Leap 15.0

Helps to limit the effect of problems like
http://bugzilla.opensuse.org/show_bug.cgi?id=1110339