### PR TITLE
Allow packets to overwrite the macro _build_insert_debug_package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ install:
 	    $(DESTDIR)$(pkglibdir)/Build \
 	    $(DESTDIR)$(pkglibdir)/emulator \
 	    $(DESTDIR)$(bindir) \
-	    $(DESTDIR)$(man1dir)
+	    $(DESTDIR)$(man1dir) \
+	    $(DESTDIR)$(sysconfdir)/rpm
 	install -m755 \
 	    build \
 	    vc \
@@ -79,6 +80,7 @@ install:
 	    $(DESTDIR)$(pkglibdir)
 	install -m755 emulator/emulator.sh $(DESTDIR)$(pkglibdir)/emulator/
 	install -m644 Build/*.pm $(DESTDIR)$(pkglibdir)/Build
+	install -m644 macros.build $(DESTDIR)$(sysconfdir)/rpm
 	install -m644 qemu-reg $(DESTDIR)$(pkglibdir)
 	install -m644 build-vm build-vm-* $(DESTDIR)$(pkglibdir)
 	install -m644 build-recipe build-recipe-* $(DESTDIR)$(pkglibdir)

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -72,10 +72,6 @@ recipe_prepare_spec() {
 	echo '
 %prep %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%prep
 %package %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%package
-%_build_insert_debug_package \
-%global __debug_package 1 \
-%undefine _enable_debug_packages \
-%debug_package
 
 ' >> $BUILD_ROOT/root/$rawcfgmacros
     fi

--- a/macros.build
+++ b/macros.build
@@ -1,0 +1,9 @@
+# obs build related macros
+#
+
+# Called from <HOME>/.rpmmacros to add a debug package depending on obs project settings.
+# We place this here to allow projects to override this
+%_build_insert_debug_package \
+%global __debug_package 1 \
+%undefine _enable_debug_packages \
+%debug_package


### PR DESCRIPTION
Creating mingwxx projects require a different implementation for creating debug packages than native packages. To allow this, the_build_insert_debug_package macro is moved to the macros.build
file, making it overwritable by packages.

I tested this with a local osc installation.