### PR TITLE
Add support for lxc version 3

### DIFF
--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -93,6 +93,12 @@ vm_startup_lxc_standalone() {
            cleanup_and_exit 1
            ;;
     esac
+    if ! [ -r "$BUILD_ROOT/.build/_exitcode" ]; then
+        echo "'$BUILD_ROOT/.build/_exitcode' not found"
+        return 3
+    fi
+    exitcode=$(cat $BUILD_ROOT/.build/_exitcode)
+    return "$exitcode"
 }
 
 vm_startup_lxc_libvirt() {


### PR DESCRIPTION
Some configuration parameters have changes in `lxc` version 3.
These changes
   * produce readable error message in case unsupported `lxc` version is installed,
   * add support for `lxc` version 3 by updating these parameters to new syntax,
   * correctly retrieve build exit code from finished container.

Please note that although `dir:` prefix is usually not required for `lxc.rootfs.path` parameter's value, it's necessary here because otherwise `lxc` configuration parser gets confused because pathname contains `:`.