### PR TITLE
Fix pattern for debuginfo packages in baselibs_global.conf

### DIFF
--- a/baselibs_configs/baselibs_global-sle15.conf
+++ b/baselibs_configs/baselibs_global-sle15.conf
@@ -42,5 +42,5 @@ post "/sbin/ldconfig"
 
 package /(.*)-debuginfo$/
 targetname <match1>-<targettype>-debuginfo
-+/usr/lib(64|ilp32)?/debug/.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)\.debug$
-+/usr/lib(64|ilp32)?/debug/.build-id/.*
++/usr/lib/debug/(.*/)?lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug$
++/usr/lib/debug/\.build-id/.*

--- a/baselibs_configs/baselibs_global.conf
+++ b/baselibs_configs/baselibs_global.conf
@@ -42,5 +42,5 @@ post "/sbin/ldconfig"
 
 package /(.*)-debuginfo$/
 targetname <match1>-<targettype>-debuginfo
-+/usr/lib(64|ilp32)?/debug/.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)\.debug$
-+/usr/lib(64|ilp32)?/debug/.build-id/.*
++/usr/lib/debug/(.*/)?lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug$
++/usr/lib/debug/\.build-id/.*


### PR DESCRIPTION
Since SLE15 the debuginfo files are suffixed with version-release-arch so
the current pattern no longer matches debuginfo files in the glibc
package.  Also, debuginfo files only reside in /usr/lib/debug.