### PR TITLE
Rename vc.1 manpage to buildvc.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ install:
 	install -m644 configs/* $(DESTDIR)$(pkglibdir)/configs
 	install -m644 baselibs_configs/* $(DESTDIR)$(pkglibdir)/baselibs_configs
 	install -m644 build.1 $(DESTDIR)$(man1dir)
-	install -m644 vc.1 $(DESTDIR)$(man1dir)
+	install -m644 buildvc.1 $(DESTDIR)$(man1dir)
 	install -m644 unrpm.1 $(DESTDIR)$(man1dir)
 	ln -sf $(pkglibdir)/build $(DESTDIR)$(bindir)/build
 	ln -sf $(pkglibdir)/vc    $(DESTDIR)$(bindir)/buildvc

--- a/buildvc.1
+++ b/buildvc.1
@@ -1,8 +1,8 @@
 .TH vc 1 "(c) 1997-2014 SuSE Linux AG Nuernberg, Germany"
 .SH NAME
-vs \- create a SUSE stype changes entry
+buildvc \- create a SUSE stype changes entry
 .SH SYNOPSIS
-.B vc
+.B buildvc
 .RB [ -m
 .IR message ]
 .RB [ -e ]
@@ -10,14 +10,14 @@ vs \- create a SUSE stype changes entry
 .RI [ commentfile ]]
 
 .SH DESCRIPTION
-The \fBvc\fP tool adds a new changes entry to a SUSE \fB.changes\fP file.
+The \fBbuildvc\fP tool adds a new changes entry to a SUSE \fB.changes\fP file.
 The \fB-m\fP option can be used to directly specify the entry, if it is
 not given an editor is started to interactively enter the new changes
 entry. If a \fIcommentfile\fP is given, its content is used as template
 for the new entry instead of an empty entry, whereas the \fB-e\fP option
 suppresses the creation of an empty entry.
 
-If no \fIchangesfile\fP is specified, \fBvc\fP will search the current
+If no \fIchangesfile\fP is specified, \fBbuildvc\fP will search the current
 directory for a file ending with \fB.changes\fP. If a directory is
 specified instead of a changes will, it will be searched instead.
 


### PR DESCRIPTION
The command is /usr/bin/buildvc, so the manpage should match that
name.