### PR TITLE
set random.trust_cpu=1 in vm boot cmdline

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -36,7 +36,7 @@ vm_img_mkfs_xfs='mkfs.xfs -f'
 # ignore not backward compatible ext fs options like metadata_csum
 # Only protecting nonroot from root inside guest -> but anyone can be root inside guest
 # so disabling spectre/meltdown mitigations doesn't hurt security and gains performance
-vm_linux_kernel_parameter="ext4.allow_unsupported=1 kpti=off pti=off spectre_v2=off"
+vm_linux_kernel_parameter="ext4.allow_unsupported=1 kpti=off pti=off spectre_v2=off random.trust_cpu=1"
 
 # guest visible devices
 VM_ROOTDEV=/dev/hda1


### PR DESCRIPTION
Build hosts should never block getrandom() waiting for entropy
if CPU supports RDRAND/RDSEED.