### PR TITLE
dummyhttpserver: also HTML-escape '

### DIFF
--- a/dummyhttpserver
+++ b/dummyhttpserver
@@ -121,6 +121,7 @@ sub escape {
   $d =~ s/</&lt;/sg;
   $d =~ s/>/&gt;/sg;
   $d =~ s/"/&quot;/sg;
+  $d =~ s/'/&#39;/sg;
   return $d; 
 }
 


### PR DESCRIPTION
For now this doesn't really matter since the generated HTML code doesn't use ' for attributes anywhere, but just to be on the safe side in case this changes some time in the future.