### PR TITLE
livebuild: quote variable to fix error with bash 5.0

### DIFF
--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -248,7 +248,7 @@ recipe_build_livebuild() {
     # move created products (and their metadata files) to destination and
     # create sha256 hashsums
     local buildnum="${RELEASE:+-Build${RELEASE}}"
-    for prefix in $(echo -e ${build_results} | sort | uniq) ; do
+    for prefix in $(echo -e "${build_results}" | sort | uniq) ; do
 	for f in ${prefix}.* ; do
 	    mv ${f} \
 		$BUILD_ROOT/$TOPDIR/OTHER/${prefix##*/}${buildnum}${f#${prefix}}


### PR DESCRIPTION
With bash 5.0 echo -e ${build_results} returns nothing even though it is
set:

```
[  368s] + local build_results=
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/auto
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/binary
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/build.log
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/cache
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/chroot
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/chroot.files
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/chroot.packages.install
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/chroot.packages.live
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/config
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/local
[  368s] + continue
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64.contents
[  368s] + case "${i##*/}" in
[  368s] + sleep 1
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64.files
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64.hybrid.iso
[  368s] + case "${i##*/}" in
[  368s] + build_results='\n///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64'
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64.hybrid.iso.zsync
[  368s] + case "${i##*/}" in
[  368s] + for i in $BUILD_ROOT/$TOPDIR/$LIVEBUILD_ROOT/*
[  368s] + test -f ///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64.packages
[  368s] + case "${i##*/}" in
[  368s] + '[' -z '\n///usr/src/packages/LIVEBUILD_ROOT/vyatta-master-amd64-vrouter/vyatta-master-amd64-vrouter_20190119T1731-amd64' ']'
[  368s] + local buildnum=-Build28.4
[  368s] ++ echo -e
[  368s] ++ uniq
[  368s] ++ sort
[  368s] + cp ///usr/src/packages/SOURCES/vyatta-master-amd64-vrouter.livebuild ///usr/src/packages/OTHER/vyatta-master-amd64-vrouter-Build28.4.livebuild.tar
[  368s] + test false = true
[  368s] + cleanup_and_exit 1
```

(note how build_results is both set and shown in the if [ -z ] but results empty with echo -e)

Quote the variable name to fix the issue. Backward compatible with older
versions of bash.