### PR TITLE
[ArchLinux] Skip unsupported GPG check

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -59,5 +59,5 @@ recipe_cleanup_arch() {
 }
 
 _arch_recipe_makepkg() {
-    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf $*" $BUILD_USER
+    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --skippgpcheck --config ../makepkg.conf $*" $BUILD_USER
 }


### PR DESCRIPTION
GPG signing is not currently supported (https://github.com/openSUSE/obs-build/issues/321)
We want to disable the check so PKGBUILDs relying on `validpgpkeys` can still be built.