### PR TITLE
[ArchLinux] Only use --skippgpcheck in prepare()

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -41,7 +41,7 @@ recipe_setup_arch() {
 
 recipe_prepare_arch() {
     echo "Preparing sources..."
-    if ! _arch_recipe_makepkg -so "2>&1" ">/dev/null" ; then
+    if ! _arch_recipe_makepkg -so --skippgpcheck "2>&1" ">/dev/null" ; then
 	cleanup_and_exit 1 "failed to prepare sources"
     fi
 }
@@ -59,5 +59,5 @@ recipe_cleanup_arch() {
 }
 
 _arch_recipe_makepkg() {
-    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --skippgpcheck --config ../makepkg.conf $*" $BUILD_USER
+    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf $*" $BUILD_USER
 }


### PR DESCRIPTION
This is only needed in the "prepare" stage.