### PR TITLE
build-recipe-dsc: Move all build results, not just *.deb and *.changes

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -114,8 +114,13 @@ dsc_build() {
 }
 
 dsc_move_build_result() {
-    for DEB in $BUILD_ROOT/$TOPDIR/*.{deb,changes} ; do
-	test -e "$DEB" && mv "$DEB" "$BUILD_ROOT/$TOPDIR/DEBS"
+    local changes
+
+    for changes in $BUILD_ROOT/$TOPDIR/*.changes ; do
+	while read f ; do
+	    mv "$BUILD_ROOT/$TOPDIR/$f" "$BUILD_ROOT/$TOPDIR/DEBS/"
+	done < <(sed -ne '/Files:/,$s/^ ................................ [0-9][0-9]* [^ ]* [^ ]* //p' "$changes")
+	mv "$changes" "$BUILD_ROOT/$TOPDIR/DEBS"
     done
 
     # link used sources over to DEB directory


### PR DESCRIPTION
The purpose of the changes file is to list everything that is to be
installed into the Debian (or derivative) archive, including *.deb,
*.udeb (micro-debs for the Debian installer), *.ddeb (detached debug
symbols, in Ubuntu and its derivatives) and *.buildinfo (details of the
build environment, mainly for reproducible builds). If we're providing
an equivalent of the Debian archive, then we should include all the
same files.

This change ensures that all build products get moved into the right
place, even if they are file types that obs-build doesn't yet know about,
or even file types that haven't been invented yet.

When obs-build is used in conjunction with OBS, changes to bs_publish
are also likely to be necessary for a full-stack solution.

Signed-off-by: Simon McVittie <smcv@collabora.com>

---

In the past we've used simpler changes that replaced `*.{deb,changes}` with `*.{deb,ddeb,changes}` or `*.{deb,udeb,changes}` or similar (I don't think those got sent upstream), but this version is more correct and future-proof.