### PR TITLE
add "-vv" parameter in case of debbuild

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -130,6 +130,9 @@ recipe_build_spec() {
 	    echo "warning: --nocheck is not supported by this $rpmbuild version"
 	fi
     fi
+    if test "$rpmbuild" == "debbuild" ; then
+	rpmbopts[${#rpmbopts[@]}]="-vv"
+    fi
     if test "$rpmbuild" == "rpmbuild" ; then
 	    # use only --nosignature for rpm v4
 	rpmbopts[${#rpmbopts[@]}]="--nosignature"


### PR DESCRIPTION
Without this patch if using the new version (18.12.0) is used all output is
suppressed. This is very confusing as you normally can see the output of
the build process.

This patch enables verbosity level 2, so also the output of the building
process is printed.

This patch shouldn`t harm older versions of debbuild as it had already an
options "-vv". SEE

https://github.com/ascherer/debbuild/blob/18.8.1/debbuild#L304