### PR TITLE
configs/15.5.conf: remove brp-extract-appdata from support package

### DIFF
--- a/configs/sl15.5.conf
+++ b/configs/sl15.5.conf
@@ -59,8 +59,6 @@ Support: perl build-mkbaselibs
 Support: brp-check-suse post-build-checks rpmlint-Factory
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
-# Extracting appdata.xml from desktop files
-Support: brp-extract-appdata
 
 Prefer: -suse-build-key
 Prefer: krb5-mini krb5-mini-devel


### PR DESCRIPTION
Support: brp-extract-appdata was disabled on Factory, remove brp-extract-appdata from config to preventing nothing provides brp-extract-appdata when build rebuilding.