### PR TITLE
Prefer libffi7

### DIFF
--- a/configs/sl15.1.conf
+++ b/configs/sl15.1.conf
@@ -405,6 +405,7 @@ Prefer: -NX -xaw3dd -db43
 Prefer: -xerces-j2-xml-resolver -xerces-j2-xml-apis
 Prefer: libgcc_s1 libgcc_s1-32bit libgcc_s1-64bit
 Prefer: libffi-devel
+Prefer: libffi7
 Prefer: libatomic1 libcilkrts5 libitm1 liblsan0 libtsan0 libubsan0
 Prefer: libatomic1-32bit libcilkrts5-32bit libitm1-32bit libubsan0-32bit
 Prefer: libgcc_s1-x86 libgcj_bc1


### PR DESCRIPTION
Before:

[  791s] expanding package dependencies...
[  795s] expansion error
[  795s]   have choice for libffi.so.7()(64bit) needed by libgobject-2_0-0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libgobject-2_0-0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7()(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7()(64bit) needed by python3-base: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by python3-base: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by python3-base: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7()(64bit) needed by libwayland-client0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libwayland-client0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7()(64bit) needed by libwayland-server0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libwayland-server0: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7()(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7
[  795s]   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7

After:

(builds normally)