### PR TITLE
Add systemd-nspawn backend

### DIFF
--- a/build
+++ b/build
@@ -305,7 +305,7 @@ Known Parameters:
 
   --vm-type TYPE
               Use virtual machine instead of chroot
-              TYPE is one of xen|kvm|uml|qemu|lxc|zvm|openstack|ec2|docker|pvm
+              TYPE is one of xen|kvm|uml|qemu|lxc|zvm|openstack|ec2|docker|pvm|nspawn
 
   --vm-worker GUEST
               GUEST is a z/VM build worker controlled by the controlling
@@ -1155,9 +1155,9 @@ if test -z "$VM_ROOT" -a -z "$LOGFILE" ; then
     if test -z "$RUNNING_IN_VM"; then
         LOGFILE="$BUILD_ROOT/.build.log"
     else
-        # lxc and docker are special cases: vm shares logfile with host
+        # lxc, docker and nspawn are special cases: vm shares logfile with host
         case "$VM_TYPE" in
-        lxc|docker)
+        lxc|docker|nspawn)
             ;;
         *)
             LOGFILE="$BUILD_ROOT/.build.log"

--- a/build-vm
+++ b/build-vm
@@ -78,7 +78,7 @@ EMULATOR_SCRIPT=
 # openstack specific
 VM_OPENSTACK_FLAVOR=
 
-for i in ec2 emulator kvm lxc openstack qemu uml xen zvm docker pvm; do
+for i in ec2 emulator kvm lxc openstack qemu uml xen zvm docker pvm nspawn; do
     . "$BUILD_DIR/build-vm-$i"
 done
 
@@ -150,7 +150,7 @@ vm_parse_options() {
 	needarg
 	VM_TYPE="$ARG"
 	case "$VM_TYPE" in
-	    lxc|docker) ;;
+	    lxc|docker|nspawn) ;;
 	    ec2|xen|kvm|uml|qemu|emulator|openstack|zvm|pvm)
 		test -z "$VM_ROOT" && VM_ROOT=1
 	    ;;
@@ -303,7 +303,7 @@ vm_shutdown() {
     fi
     exec >&0 2>&0	# so that the logging tee finishes
     sleep 1		# wait till tee terminates
-    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && exit $1
+    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker -o "$VM_TYPE" = nspawn && exit $1
     kill -9 -1        # goodbye cruel world
     if ! test -x /sbin/halt ; then
 	test -e /proc/sysrq-trigger || mount -n -tproc none /proc
@@ -532,7 +532,7 @@ vm_detect_2nd_stage() {
     fi
     RUNNING_IN_VM=true
     test -e /proc/version || mount -orw -n -tproc none /proc
-    if test "$VM_TYPE" != lxc -a "$VM_TYPE" != docker ; then
+    if test "$VM_TYPE" != lxc -a "$VM_TYPE" != docker -a "$VM_TYPE" != nspawn ; then
 	mount -n ${VMDISK_MOUNT_OPTIONS},remount,rw /
     fi
     umount /run >/dev/null 2>&1
@@ -849,7 +849,7 @@ vm_first_stage() {
 	ppc|ppcle|s390) PERSONALITY=8 ;;	# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
 	aarch64) test "$BUILD_ARCH" != "${BUILD_ARCH#armv[567]}" && PERSONALITY=8 ;; # workaround, to be removed
     esac
-    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker && PERSONALITY=0
+    test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker -o "$VM_TYPE" = nspawn && PERSONALITY=0
     echo "PERSONALITY='$PERSONALITY'" >> $BUILD_ROOT/.build/build.data
     echo "VM_HOSTNAME='$HOST'" >> $BUILD_ROOT/.build/build.data
     echo -n "definesnstuff=(" >> $BUILD_ROOT/.build/build.data

--- a/build-vm-nspawn
+++ b/build-vm-nspawn
@@ -1,0 +1,73 @@
+#
+# systemd-nspawn specific functions
+#
+################################################################
+#
+# Copyright (c) 2019 Oleg Girko
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+
+vm_verify_options_nspawn() {
+    VM_ROOT=
+    VM_SWAP=
+}
+
+vm_startup_nspawn() {
+    local name="${BUILD_ROOT##*/}"
+    name="obsbuild.${name//_/-}"
+    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network --pipe "$vm_init_script"
+    return "$?"
+}
+
+vm_kill_nspawn() {
+    local name="${BUILD_ROOT##*/}"
+    name="obsbuild.${name//_/-}"
+    machinectl terminate "$name"
+}
+
+vm_fixup_nspawn() {
+    :
+}
+
+vm_attach_root_nspawn() {
+    :
+}
+
+vm_attach_swap_nspawn() {
+    :
+}
+
+vm_detach_root_nspawn() {
+    :
+}
+
+vm_detach_swap_nspawn() {
+    :
+}
+
+vm_sysrq_nspawn() {
+    :
+}
+
+vm_wipe_nspawn() {
+    :
+}
+
+vm_cleanup_nspawn() {
+    :
+}
+


### PR DESCRIPTION
This change adds support for building inside a lightweight containers created by `systemd-nspawn`.

As Fedora 31 switched to cgroup v2, `lxc` can't support limiting device access to host system anymore.

There are no files in cgroup v2 hierarchy that provide interface to rules for device access: eBPF program should be used instead.

Also, Docker does not work as well with cgroup v2.

This leaves us without working backends supporting lightweight containers, so a new backend that can work with cgroup v2 becomes necessary.