### PR TITLE
allow to enter an existing buildroot w/o recipe

### DIFF
--- a/build
+++ b/build
@@ -1131,6 +1131,12 @@ fi
 
 set_build_arch
 
+if test "$DO_INIT" = false -a -n "$RUN_SHELL"; then
+    mount_stuff
+    chroot $BUILD_ROOT su - $BUILD_USER
+    cleanup_and_exit $?
+fi
+
 expand_recipe_directories
 
 if test -n "$LIST_STATE" ; then


### PR DESCRIPTION
The chroot needs to be done before the recipe code.
Otherwise one can not enter a buildroot from outside
a working directory.

In addition a recipe is not needed to chroot into
an existing buildroot.

Is needed in addition to https://github.com/openSUSE/osc/pull/710