### PR TITLE
configs: fix testbuild fail with latest rpm in SP2 and Leap 15.2

### DIFF
--- a/configs/sl15.2.conf
+++ b/configs/sl15.2.conf
@@ -51,6 +51,9 @@ Prefer: libffi7
 
 Preinstall: liblua5_3-5
 
+# Needed with latest rpm (Use libgcrypt as crypto library for SP2 and Leap 15.2 [jsc#SLE-9552])
+Preinstall: libgcrypt20 libgpg-error0
+
 FileProvides: /bin/csh tcsh
 FileProvides: /bin/logger util-linux-systemd
 FileProvides: /sbin/netconfig sysconfig-netconfig

--- a/configs/sle15.2.conf
+++ b/configs/sle15.2.conf
@@ -55,6 +55,9 @@ Preinstall: liblzma5 libcap2 libacl1 libattr1
 Preinstall: libpopt0 libelf1 liblua5_3-5
 Preinstall: libpcre1
 
+# Needed with latest rpm (Use libgcrypt as crypto library for SP2 [jsc#SLE-9552])
+Preinstall: libgcrypt20 libgpg-error0
+
 Runscripts: aaa_base
 
 Prefer: libdb-4_8-devel


### PR DESCRIPTION
Since latest rpm in SP2 has BuildRequires libgcrypt-devel to use libgcrypt as crypto library, build config need to adjusted to add preinstall for crypto library.

build fail link: https://build.opensuse.org/package/live_build_log/openSUSE:Leap:15.2:Staging:A/build/standard/x86_64
rpm update: https://build.opensuse.org/request/show/760171