### PR TITLE
remove old shell behavior in recipe scripts

### DIFF
--- a/build-recipe-collax
+++ b/build-recipe-collax
@@ -29,14 +29,9 @@ recipe_prepare_collax() {
 collax_build() {
 	local buildroot="$1"
 
-	if test -n "$RUN_SHELL"; then
-		chroot "$buildroot" su -
-		ret=$?
-	else
-		chroot "$buildroot" su - $BUILD_USER -c \
-			"cd $TOPDIR/SOURCES && ./build"
-		ret=$?
-	fi
+	chroot "$buildroot" su - $BUILD_USER -c \
+		"cd $TOPDIR/SOURCES && ./build"
+	ret=$?
 	if test "$ret" = 0; then
 		BUILD_SUCCEEDED=true
 	fi

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -102,14 +102,10 @@ dsc_build() {
 	chmod +x $buildroot/$TOPDIR/SOURCES/build.script
     fi
 
-    if test -n "$RUN_SHELL"; then
-	chroot $buildroot su -
-    else
-	chroot $buildroot su -c "export DEB_BUILD_OPTIONS=${DSC_BUILD_OPTIONS} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
-	if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
-	   DEB_CHANGESFILE=${DEB_DSCFILE%.dsc}$OBS_DCH_RELEASE"_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes"
-	   chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
-	fi
+    chroot $buildroot su -c "export DEB_BUILD_OPTIONS=${DSC_BUILD_OPTIONS} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
+    if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
+	DEB_CHANGESFILE=${DEB_DSCFILE%.dsc}$OBS_DCH_RELEASE"_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes"
+	chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
     fi
 }
 

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -165,7 +165,7 @@ recipe_build_spec() {
     fi
 
     GEN_BUILDREQS_PACKS=()
-    if test -n "$HAVE_DYNAMIC_BUILDREQUIRES" -a -z "$RUN_SHELL" ; then
+    if test -n "$HAVE_DYNAMIC_BUILDREQUIRES" ; then
 	# query dynamic build requires
 	rm -f "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm
 	rpmdynbropts=("${rpmbopts[@]}")
@@ -209,14 +209,10 @@ recipe_build_spec() {
 	    > $BUILD_ROOT/.build.command
     chmod 755 $BUILD_ROOT/.build.command
     check_exit
-    if test -n "$RUN_SHELL"; then
-	chroot $BUILD_ROOT su -
-    else
-	chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null
-	st=$?
-	test "$st" = 0 && BUILD_SUCCEEDED=true
-	test "$st" = 11 -a -n "$HAVE_DYNAMIC_BUILDREQUIRES" && BUILD_SUCCEEDED=genbuildreqs
-    fi
+    chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null
+    st=$?
+    test "$st" = 0 && BUILD_SUCCEEDED=true
+    test "$st" = 11 -a -n "$HAVE_DYNAMIC_BUILDREQUIRES" && BUILD_SUCCEEDED=genbuildreqs
 }
 
 recipe_resultdirs_spec() {


### PR DESCRIPTION
Remove the RUN_SHELL handling in build-recipe-collax,  build-recipe-dsc and  build-recipe-spec. With the new logic introduced by @adrianschroeter these codepaths are not reached anymore.