### PR TITLE
Return correct exit code from systemd-nspawn build

### DIFF
--- a/build-vm-nspawn
+++ b/build-vm-nspawn
@@ -30,7 +30,8 @@ vm_startup_nspawn() {
     local name="${BUILD_ROOT##*/}"
     name="obsbuild.${name//_/-}"
     systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network --pipe "$vm_init_script"
-    return "$?"
+    BUILDSTATUS="$?"
+    cleanup_and_exit "$BUILDSTATUS"
 }
 
 vm_kill_nspawn() {


### PR DESCRIPTION
This change fixes an oversight that was made when implementing `systemd-nspawn` driver.
It's not enough to return error code from `vm_startup_nspawn` function, `cleanup_and_exit` should be called with exit code as argument.