### PR TITLE
Run /sbin/ldconfig before booting VM

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -815,6 +815,8 @@ if test ! -e $BUILD_ROOT/installed-pkg -a ! -e $BUILD_ROOT/.build/init_buildsyst
 	run_pkg_scripts
 	pkg_initdb
 	touch $BUILD_ROOT/.init_b_cache/preinstall_finished
+    elif test -x $BUILD_ROOT/sbin/ldconfig ; then
+        chroot $BUILD_ROOT /sbin/ldconfig 2>&1
     fi
     # mark as preinstalled no longer needed
     rm -rf "$BUILD_ROOT/installed-pkg"


### PR DESCRIPTION
In some rare cases, `bash` depends on `libtermcap` package where appropriate
symlinks are missed. In such cases the build script has no chance to start in
VM at the second stage since `/bin/bash` is not functional yet:

```
    /bin/bash: error while loading shared libraries: libtermcap.so.2: cannot open shared object file: No such file or directory
```

Run `/sbin/ldconfig` for preinstalled packages to recover shared object
resolution.