### PR TITLE
add ability to store ccache when PKG_CCACHE variable is true

### DIFF
--- a/build
+++ b/build
@@ -106,6 +106,7 @@ DO_STATISTICS=
 RUN_SHELL=
 RUN_SHELL_CMD=
 CCACHE=
+PKG_CCACHE=
 DLNOSIGNATURE=
 BUILD_FLAVOR=
 OBS_PACKAGE=
@@ -253,6 +254,10 @@ Known Parameters:
 
   --ccache
               Use ccache to speed up rebuilds
+
+  --pkg-ccache /path/to/ccache.tar.gz
+              path to archive of ccache directory content.
+              Its contents will be extracted to /.ccache
 
   --icecream N
               Use N parallel build jobs with icecream
@@ -473,7 +478,7 @@ toshellscript() {
 }
 
 setupccache() {
-    if test -n "$CCACHE" ; then
+    if test -n "$CCACHE" -o -n "$PKG_CCACHE"; then
 	if mkdir -p $BUILD_ROOT/var/lib/build/ccache/bin; then
 	    for i in $(ls $BUILD_ROOT/usr/bin | grep -E '^(cc|gcc|[cg][+][+]|clang|clang[+][+])([-]?[.0-9])*$'); do
 		rm -f $BUILD_ROOT/var/lib/build/ccache/bin/$i
@@ -490,6 +495,13 @@ setupccache() {
 	chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.ccache"
 	echo "export CCACHE_DIR=/.ccache" > "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
 	echo 'export PATH=/var/lib/build/ccache/bin:$PATH' >> "$BUILD_ROOT"/etc/profile.d/build_ccache.sh
+        case $PKG_CCACHE in
+            *.tar.gz)
+                tar -zxf "$BUILD_ROOT/`basename $PKG_CCACHE`" -C /.ccache/
+                ;;
+            *)
+                ;;
+        esac
     else
 	rm -f "$BUILD_ROOT"/var/lib/build/ccache/bin/{gcc,g++,cc,c++,clang,clang++}
     fi
@@ -967,6 +979,11 @@ while test -n "$1"; do
       -ccache)
 	CCACHE=true
       ;;
+      -pkg-ccache)
+	needarg
+	PKG_CCACHE="$ARG"
+	shift
+      ;;
       -statistics)
 	DO_STATISTICS=1
       ;;
@@ -1258,7 +1275,7 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
     ADDITIONAL_PACKS=
     test -z "$BUILD_EXTRA_PACKS" || ADDITIONAL_PACKS="$ADDITIONAL_PACKS $BUILD_EXTRA_PACKS"
     test -z "$CREATE_BASELIBS" || ADDITIONAL_PACKS="$ADDITIONAL_PACKS build"
-    test -z "$CCACHE" || ADDITIONAL_PACKS="$ADDITIONAL_PACKS ccache"
+    test -z "$CCACHE" -a -z "$PKG_CCACHE" || ADDITIONAL_PACKS="$ADDITIONAL_PACKS ccache"
     test "$icecream" = 0 || ADDITIONAL_PACKS="$ADDITIONAL_PACKS icecream gcc-c++"
     test -z "$DO_LINT" || ADDITIONAL_PACKS="$ADDITIONAL_PACKS rpmlint-Factory"
     test "$VMDISK_FILESYSTEM" = xfs && ADDITIONAL_PACKS="$ADDITIONAL_PACKS libblkid1"

--- a/build-vm
+++ b/build-vm
@@ -894,6 +894,7 @@ vm_first_stage() {
     echo "VM_WATCHDOG='$VM_WATCHDOG'" >> $BUILD_ROOT/.build/build.data
     echo "BUILDENGINE='$BUILDENGINE'" >> $BUILD_ROOT/.build/build.data
     echo "CCACHE='$CCACHE'" >> $BUILD_ROOT/.build/build.data
+    echo "PKG_CCACHE='$PKG_CCACHE'" >> $BUILD_ROOT/.build/build.data
     echo "ABUILD_TARGET='$ABUILD_TARGET'" >> $BUILD_ROOT/.build/build.data
     echo "BUILD_FLAVOR='$BUILD_FLAVOR'" >> $BUILD_ROOT/.build/build.data
     echo "OBS_PACKAGE='$OBS_PACKAGE'" >> $BUILD_ROOT/.build/build.data
@@ -910,6 +911,7 @@ vm_first_stage() {
     if check_use_emulator ; then
         vm_init_script="/.build/$INITVM_NAME"
     fi
+    test -n "$PKG_CCACHE" && cp $PKG_CCACHE $BUILD_ROOT
     if test -n "$VM_ROOT" ; then
 	# copy out kernel & initrd (if they exist) during unmounting VM image
 	KERNEL_TEMP_DIR=
@@ -1039,9 +1041,17 @@ vm_save_statistics() {
     test -n "$sys_mounted" && umount /sys
 }
 
+vm_save_ccache() {
+    echo "... saving ccache"
+    local tarfile
+    tarfile="$BUILD_ROOT$TOPDIR/OTHER/.ccache.tar.gz"
+    tar -zcf "$tarfile" -C /.ccache/ .
+}
+
 # args: resultdirs
 vm_wrapup_build() {
     test "$DO_STATISTICS" = 1 && vm_save_statistics
+    test -n "$PKG_CCACHE" && vm_save_ccache
     if test -n "$VM_SWAP"; then
         echo "... saving built packages"
         swapoff "$VM_SWAP"


### PR DESCRIPTION
this feature will allow usage of ccache wihtin th build env.
the storage dir is /.ccache. the permission for the $BUILD_USER are
already available.

The activation of feature is dependent on param `--prpa-ccache` being
passed.

The created tar.gz is sent back only when there is a successful build
(non error, non unchanged).

This is the first part where worker only send the generate cache. The
second part where worker can download this cache is being implemetned.