### PR TITLE
Autodetect whether to use --pipe option of systemd-nspawn

### DIFF
--- a/build-vm-nspawn
+++ b/build-vm-nspawn
@@ -29,7 +29,11 @@ vm_verify_options_nspawn() {
 vm_startup_nspawn() {
     local name="${BUILD_ROOT##*/}"
     name="obsbuild.${name//_/-}"
-    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network --pipe "$vm_init_script"
+    local pipe_opt=
+    if test -z "$RUN_SHELL" && systemd-nspawn --help | fgrep -q -e --pipe; then
+        pipe_opt=--pipe
+    fi
+    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network $pipe_opt "$vm_init_script"
     BUILDSTATUS="$?"
     cleanup_and_exit "$BUILDSTATUS"
 }


### PR DESCRIPTION
The `--pipe` option of `systemd-nspawn` is useful for automated build, but it leads to very inconvenient results when running interactive shell using `osc shell` command: pressing `Ctrl+C` causes the whole session to terminate.

Also, `--pipe` option is not available on older versions of `systemd-nspawn`, like the one that is used in Raspbian 10.

This change makes `build-vm-nspawn` autodetect whether `--pipe` option is available, and use it only for automated build, but not interactive shell.