### PR TITLE
create folders before trying to copy ccache.tar

### DIFF
--- a/build
+++ b/build
@@ -1329,7 +1329,9 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	copy_oldpackages
         # chroot based builds
         # rsync as source and dest could be same
-        test -n "$PKG_CCACHE" -a -e "$PKG_CCACHE" && rsync -v "$PKG_CCACHE" "$BUILD_ROOT/.build.oldpackages/_ccache.tar"
+        test -n "$PKG_CCACHE" -a -e "$PKG_CCACHE" && \
+            mkdir -p "$BUILD_ROOT/.build.oldpackages/" && \
+            rsync -v "$PKG_CCACHE" "$BUILD_ROOT/.build.oldpackages/_ccache.tar"
     fi
 
     mount_stuff


### PR DESCRIPTION
this folder wont be present when calling

osc build --pkg-ccache /path/to/_ccache.tar