### PR TITLE
also package pkg-config files by default into baselibs. (bsc#1172563)

### DIFF
--- a/baselibs_configs/baselibs_global-sle12.conf
+++ b/baselibs_configs/baselibs_global-sle12.conf
@@ -22,7 +22,7 @@ targettype 64bit extension 64
 
 targetname <name>-<targettype>
 
-+.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)$
++.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la|pc)$
 
 targettype 64bit -^(/usr)?/lib(ilp32)?/lib
 targettype 32bit -/lib64/

--- a/baselibs_configs/baselibs_global-sle15.conf
+++ b/baselibs_configs/baselibs_global-sle15.conf
@@ -22,7 +22,7 @@ targettype 64bit extension 64
 
 targetname <name>-<targettype>
 
-+.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)$
++.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la|pc)$
 
 targettype 64bit -^(/usr)?/lib(ilp32)?/lib
 targettype 32bit -/lib64/

--- a/baselibs_configs/baselibs_global.conf
+++ b/baselibs_configs/baselibs_global.conf
@@ -22,7 +22,7 @@ targettype 64bit extension 64
 
 targetname <name>-<targettype>
 
-+.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)$
++.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la|pc)$
 
 targettype 64bit -^(/usr)?/lib(ilp32)?/lib
 targettype 32bit -/lib64/


### PR DESCRIPTION
pkg-config files are interesting for development, so include them here.

e.g. used by wine development of 32bit