### PR TITLE
Use shorter kernel flag for mitigations

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -36,7 +36,7 @@ vm_img_mkfs_xfs='mkfs.xfs -f'
 # ignore not backward compatible ext fs options like metadata_csum
 # Only protecting nonroot from root inside guest -> but anyone can be root inside guest
 # so disabling spectre/meltdown mitigations doesn't hurt security and gains performance
-vm_linux_kernel_parameter="ext4.allow_unsupported=1 kpti=off pti=off spectre_v2=off"
+vm_linux_kernel_parameter="ext4.allow_unsupported=1 mitigations=off"
 
 # guest visible devices
 VM_ROOTDEV=/dev/hda1


### PR DESCRIPTION
"spectre_v2=off" is x86-specific and would require "nospectre_v2" instead to be
architecture-independent. But there is also a shorter option called
mitigations= that includes nopti, kpti, etc.