### PR TITLE
    Support root switching in Dockerfile

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -138,9 +138,15 @@ recipe_build_docker() {
     done
 
     # patch in obs-docker-support helper
-    sed -i '/^[ 	]*[fF][rR][oO][mM]/a COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
+    sed -i '/^[ 	]*[rR][uU][nN][	 ]/i COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
     echo >> $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
-    if test -n "$(sed -ne '/^[ 	]*[uU][sS][eE][rR][ 	]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
+    # USER root must be ignored, we look for the last RUN line executed as root
+    if test -n "$(sed -e '/^[      ]*[uU][sS][eE][rR][     ]root/d' -ne '/^[ 	]*[uU][sS][eE][rR][ 	]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
+    	sed -i '1,/^[ 	]*[uU][sS][eE][rR][ 	]/b; {
+/^[ 	]*[uU][sS][eE][rR][ 	]/i RUN obs-docker-support --uninstall
+}' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
+    elsif test -n "$(sed -e '/^[      ]*[uU][sS][eE][rR][     ]/d' -ne '/^[ 	]*[uU][sS][eE][rR][ 	]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
+        # No "USER root" line case
     	sed -i '1,/^[ 	]*[uU][sS][eE][rR][ 	]/{
 /^[ 	]*[uU][sS][eE][rR][ 	]/i RUN obs-docker-support --uninstall
 }' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -140,16 +140,10 @@ recipe_build_docker() {
     # patch in obs-docker-support helper
     sed -i '/^[ 	]*[rR][uU][nN][	 ]/i COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
     echo >> $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
-    # USER root must be ignored, we look for the last RUN line executed as root
-    if test -n "$(sed -e '/^[      ]*[uU][sS][eE][rR][     ]root/d' -ne '/^[ 	]*[uU][sS][eE][rR][ 	]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
-    	sed -i '1,/^[ 	]*[uU][sS][eE][rR][ 	]/b; {
-/^[ 	]*[uU][sS][eE][rR][ 	]/i RUN obs-docker-support --uninstall
-}' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
-    elsif test -n "$(sed -e '/^[      ]*[uU][sS][eE][rR][     ]/d' -ne '/^[ 	]*[uU][sS][eE][rR][ 	]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
-        # No "USER root" line case
-    	sed -i '1,/^[ 	]*[uU][sS][eE][rR][ 	]/{
-/^[ 	]*[uU][sS][eE][rR][ 	]/i RUN obs-docker-support --uninstall
-}' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
+    if test -n "$(sed -ne '/^[         ]*[uU][sS][eE][rR][     ]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
+    	tac "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" | sed '1,/^RUN/{
+/^RUN /i RUN obs-docker-support --uninstall
+}' | tac > "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" && mv "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
     else
 	echo 'RUN obs-docker-support --uninstall' >> "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
     fi

--- a/obs-docker-support
+++ b/obs-docker-support
@@ -243,6 +243,11 @@ EOF
     esac
 }
 
+if test `id -u` != "0"; then
+    echo "obs-docker-support: not executed as root user!"
+    exit 1
+fi
+
 case ${0##*/} in
 obs-docker-support)
     obs_docker_support "$@"


### PR DESCRIPTION
    A Dockerfile may have "USER root" in the beginning to switch
    back to root user, because the base image has defined a non-root
    user via USER statement.
    
    We must install obs-docker-support therefore before the first
    RUN instead of after FROM line to be root at that point of time.

