### PR TITLE
init_buildsystem : skip "Processing triggers for man-db..." when building DSC

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -857,6 +857,17 @@ if test -n "$CREATE_BUILD_BINARIES" ; then
 fi
 
 #
+# Save some package build environment preparation time on Debian-like systems
+# Note: for OS image builds we probably want the man-db constructed properly
+#
+if test -x "$BUILD_ROOT/usr/bin/debconf-set-selections" && test "$BUILDTYPE" = dsc ; then
+    echo "Preseed man-db/auto-update to false for a DSC package build..."
+    chroot "$BUILD_ROOT" /usr/bin/debconf-set-selections <<EOF
+man-db man-db/auto-update boolean false
+EOF
+fi
+
+#
 # reorder packages (already done in vm continuation)
 #
 if ! test -e $BUILD_ROOT/.build/init_buildsystem.data ; then


### PR DESCRIPTION
Depending on worker and its storage performance, this can shave tens of seconds off a package build that likely has no use for system manpages anyway.