### PR TITLE
Support Dockerfile builds with multiple FROM sections

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -202,6 +202,7 @@ sub parse {
     @args = split(/[ \t]+/, $line);
     s/%([a-fA-F0-9]{2})/chr(hex($1))/ge for @args;
     if ($cmd eq 'FROM') {
+      shift @args if @args && $args[0] =~ /^--platform=/;
       if (@args && !$basecontainer && $args[0] ne 'scratch') {
         $basecontainer = $args[0];
         $basecontainer .= ':latest' unless $basecontainer =~ /:[^:\/]+$/;

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ install:
 	    telnet_login_wrapper \
 	    startdockerd \
 	    dummyhttpserver \
+	    patchdockerfile \
 	    obs-docker-support \
 	    create_container_package_list \
 	    call-podman \

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -138,17 +138,8 @@ recipe_build_docker() {
     done
 
     # patch in obs-docker-support helper
-    sed -i '1,/^[ 	]*[rR][uU][nN][	 ]/{
-/^[ 	]*[rR][uU][nN][	 ]/i COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install
-}' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
-    echo >> $BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE
-    if test -n "$(sed -ne '/^[         ]*[uU][sS][eE][rR][     ]/p' "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE")" ; then
-    	tac "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" | sed '1,/^[         ]*[uU][sS][eE][rR][     ]/{
-/^[         ]*[uU][sS][eE][rR][     ]/a RUN obs-docker-support --uninstall
-}' | tac > "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" && mv "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
-    else
-	echo 'RUN obs-docker-support --uninstall' >> "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
-    fi
+    patchdockerfile < "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE" > "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" && \
+       mv "$BUILD_ROOT/$TOPDIR/SOURCES/.$RECIPEFILE" "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
     test -n "$DISTURL" && echo "LABEL org.openbuildservice.disturl=$DISTURL" >> "$BUILD_ROOT/$TOPDIR/SOURCES/$RECIPEFILE"
 
     # now do the build

--- a/patchdockerfile
+++ b/patchdockerfile
@@ -1,0 +1,65 @@
+#!/usr/bin/perl -w
+
+################################################################
+#
+# Copyright (c) 2020 SUSE Linux Products GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program (see the file COPYING); if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+#
+################################################################
+
+use strict;
+use warnings;
+
+my $install_docker_support = "COPY .obs-docker-support /usr/local/sbin/obs-docker-support\nRUN obs-docker-support --install\n";
+my $uninstall_docker_support = "RUN obs-docker-support --uninstall\n";
+
+my @sections = ( [] );
+while (<STDIN>) {
+  push @sections, [] if /^FROM /i;
+  push @{$sections[-1]}, $_;
+}
+
+# write out header unmodified
+print join('', @{shift @sections});
+
+for my $s (@sections) {
+  # analyze section (first line is always FROM)
+  my @user_root;
+  my @user_nonroot;
+  my $idx = 0;
+  for my $line (@$s) {
+    if ($line =~ /^[uU][sS][eE][rR]\s+root[ \n]/) {
+      push @user_root, $idx;
+    } elsif ($line =~ /^[uU][sS][eE][rR]\s+/) {
+      push @user_nonroot, $idx;
+    }
+    $idx++;
+  }
+  # patch in commands
+  if (@user_root && (!@user_nonroot || $user_root[0] < $user_nonroot[0])) {
+    $s->[$user_root[0]] .= $install_docker_support;
+  } else {
+    $s->[0] .= $install_docker_support;
+  }
+  if (@user_nonroot && (!@user_root || $user_root[-1] < $user_nonroot[-1])) {
+    my @ok = @user_nonroot;
+    @ok = grep {$_ > $user_root[-1]} @user_nonroot if @user_root;
+    $s->[$ok[0]] = $uninstall_docker_support . $s->[$ok[0]];
+  } else {
+    $s->[-1] .= $uninstall_docker_support;
+  }
+  print join('', @$s);
+}


### PR DESCRIPTION
also fixes issue if no RUN line is inside of Dockerfile (section)

Additional perl helper is used now instead of simple sed replacement.

We must enable obs-docker-support after a possible existing "USER root"
line or after each FROM line.

disable must happen before a USER line (except it is the "USER root"
line) or at the end of each section