### PR TITLE
Align test condition with error message in build-vm-ec2

### DIFF
--- a/build-vm-ec2
+++ b/build-vm-ec2
@@ -72,7 +72,7 @@ vm_verify_options_ec2() {
     fi
 
     # verify settings
-    if test -z "$AWS_ACCESS_KEY" -o -z "$AWS_ACCESS_KEY" ; then
+    if test -z "$AWS_ACCESS_KEY" -o -z "$AWS_SECRET_KEY" ; then
         cleanup_and_exit 3 "ERROR: No amazon EC2 environment set. Set AWS_ACCESS_KEY and AWS_SECRET_KEY."
     fi
     . /etc/profile.d/ec2.sh


### PR DESCRIPTION
The error message states that the AWS_ACCESS_KEY and AWS_SECRET_KEY
env variables should be set but the condition only checks for
AWS_ACCESS_KEY (two times). Instead, check for both variables.

Implicit assumption: the error message is correct and the condition
is wrong (I have no clue about AWS - this was just spotted while
reading the code).