### PR TITLE
cleanup old obsgendiff execution way

### DIFF
--- a/build-recipe
+++ b/build-recipe
@@ -207,12 +207,7 @@ recipe_gendiff() {
         )
 
     if test -n "$obsgendiff"; then
-         if test -x "$BUILD_ROOT/usr/lib/build/obsgendiff"; then
-             # FIXME: to be removed ASAP
-             if ! chroot "$BUILD_ROOT" /usr/lib/build/obsgendiff ; then
-                 cleanup_and_exit 1 "/usr/lib/build/obsgendiff script failed!"
-             fi
-         elif test -d "$BUILD_ROOT/usr/lib/build/obsgendiff.d"; then
+         if test -d "$BUILD_ROOT/usr/lib/build/obsgendiff.d"; then
              for script in "$BUILD_ROOT"/usr/lib/build/obsgendiff.d/*; do
                  if test -x "$script" && ! chroot "$BUILD_ROOT" "/usr/lib/build/obsgendiff.d/${script##*/}" ; then
                      cleanup_and_exit 1 "/usr/lib/build/obsgendiff.d/${script##*/} script failed!"


### PR DESCRIPTION
It used to be single script only.
The new way is to place scripts into

  /usr/lib/build/obsgendiff.d/

directory