### PR TITLE
flatpak: Add more dependencies

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -129,8 +129,9 @@ my %subst_defaults = (
   'build-packages:helm' => [
     'helm',
   ],
-  'build-packages:flatpack' => [
-    'flatpack', 'flatpack-builder', 'fuse', 'unzip', 'gzip', 'xz',
+  'build-packages:flatpak' => [
+    'flatpak', 'flatpak-builder', 'fuse', 'unzip', 'gzip', 'xz', 'libffi7',
+    'elfutils', 'librsvg', 'gdk-pixbuf-loader-rsvg',
   ],
   'system-packages:livebuild' => [
     'apt-utils', 'cpio', 'dpkg-dev', 'live-build', 'lsb-release', 'tar',
@@ -610,7 +611,7 @@ sub get_build {
     return (undef, $err) if $err;
   }
   my $buildtype = $config->{'type'} || '';
-  if (grep {$_ eq $buildtype} qw{livebuild docker kiwi fissile helm flatpack}) {
+  if (grep {$_ eq $buildtype} qw{livebuild docker kiwi fissile helm flatpak}) {
     push @deps, @{$config->{'substitute'}->{"build-packages:$buildtype"}
 		  || $subst_defaults{"build-packages:$buildtype"} || []};
   }


### PR DESCRIPTION
We need the following additional dependencies:

libffi7:
```
 expansion error
   have choice for libffi.so.7()(64bit) needed by python3-base: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by python3-base: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by python3-base: ghc-bootstrap libffi7
   have choice for libffi.so.7()(64bit) needed by libgobject-2_0-0: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libgobject-2_0-0: ghc-bootstrap libffi7
   have choice for libffi.so.7()(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by libgirepository-1_0-1: ghc-bootstrap libffi7
   have choice for libffi.so.7()(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_BASE_7.0)(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
   have choice for libffi.so.7(LIBFFI_CLOSURE_7.0)(64bit) needed by libp11-kit0: ghc-bootstrap libffi7
```

librsvg, gdk-pixbuf-loader-rsvg:
```
    error: /usr/src/packages/FLATPAK_ROOT/build-dir/export/share/icons/hicolor/scalable/apps/org.gnome.Chess.svg is not a valid icon: Format not recognized
```

elfutils:
```
    Failed to execute child process ?eu-strip?
```

For elfutils it looks like this should be added as a dependency to
flatpak-builder itself:
https://github.com/flatpak/flatpak.github.io/issues/70

Maybe the same for libffi7 and the rsvg libs.

Also fix typos: `s/flatpack/flatpak/`