### PR TITLE
fix errors while building in obs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: perl
+perl:
+  - "5.30"
+script: "make test"

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,1 @@
+requires 'YAML::PP', 0;

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -51,6 +51,7 @@ BuildRequires:  tar
 BuildRequires:  perl(Date::Parse)
 BuildRequires:  perl(Test::Harness)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl(YAML)
 %if 0%{?fedora}
 Requires:       perl-MD5
 Requires:       perl-TimeDate


### PR DESCRIPTION
OBS needs to know that it must install perl(YAML) otherwise the
test suite fails.