### PR TITLE
queryconfig explodes with "Can't locate Build.pm"

### DIFF
--- a/queryconfig
+++ b/queryconfig
@@ -21,7 +21,7 @@
 ################################################################
 
 BEGIN {
-  unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/build');
+  unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/obs-build');
 }
 
 use strict;
@@ -38,7 +38,7 @@ sub evalmacros {
 
 my ($dist, $archs, $configdir, $type, $argument);
 
-$configdir = ($::ENV{'BUILD_DIR'} || '/usr/lib/build') . '/configs';
+$configdir = ($::ENV{'BUILD_DIR'} || '/usr/lib/obs-build') . '/configs';
 
 while (@ARGV)  {
   if ($ARGV[0] eq '--dist') {


### PR DESCRIPTION
Seen on Ubuntu-20.04 with default
ii  obs-build      20180831-3ubuntu1 all          scripts for building RPM/debian packages for multiple distributions
```
Can't locate Build.pm in @INC (you may need to install the Build module) (@INC contains: /usr/lib/build /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/lib/obs-build/queryconfig line 29.
```

/usr/lib/obs-build/queryconfig tries to find its own perl modules in /usr/lib/build instead of /usr/lib/obs-build.
Workaround:
`sudo ln -s obs-build /usr/lib/build`