### PR TITLE
ccache: it was updated to expect a suffix for -evict-older-than option

### DIFF
--- a/build
+++ b/build
@@ -1611,8 +1611,11 @@ if test -n "$CCACHE" ; then
     if test -n "$REMOVE_CCACHE" ; then
         echo "... cleaning ccache"
         test_cmd="ccache -h | grep -c evict-older-than"
-        clean_cmd="ccache --evict-older-than $(($(date +%s) - $CCACHE_SETUP_START_TIME))"
-        chroot $BUILD_ROOT su -c "$test_cmd && $clean_cmd" - $BUILD_USER
+        # ccache -Version >= 4.0
+        clean_cmd_with_suffix="ccache --evict-older-than $(($(date +%s) - $CCACHE_SETUP_START_TIME))s"
+        # older version with the patch (without patch, $test_cmd would fail)
+        clean_cmd_without_suffix="ccache --evict-older-than $(($(date +%s) - $CCACHE_SETUP_START_TIME))"
+        chroot $BUILD_ROOT su -c "($test_cmd && $clean_cmd_with_suffix) || ($test_cmd && $clean_cmd_without_suffix)" - $BUILD_USER
     fi
     echo "... saving ccache"
     tar ${REMOVE_CCACHE:+--remove-files} -cf "$BUILD_ROOT/$TOPDIR/OTHER/_ccache.tar" -C "$BUILD_ROOT/.ccache/" .


### PR DESCRIPTION
this suffix is mandatory and should either be s(econds)/d(ays).

this patch tries both (with and without suffix), avoiding to do any
complex checks for version (ccache -Version). The version comparison
would need either need floating point comparision or extracting major
and minor version and comparing those.

The with_suffix variant is tried first as it is what will be supported
going ahead.


Would be nice to have a second pair of eyes for the bash !