### PR TITLE
Improve 'build' and 'osc build' experience

### DIFF
--- a/build
+++ b/build
@@ -257,7 +257,7 @@ Known Parameters:
   --release release
               Override Release in spec file
 
-  --stage -bSTAGE
+  --stage=-bSTAGE
               Set stage for rpmbuild. Defaults to -ba.
 
   --target platform

--- a/build
+++ b/build
@@ -183,6 +183,13 @@ Known Parameters:
 
   --no-checks Do not run checks (postbuild and %check)
 
+  --norootforbuild
+              Force building with user 'abuild'. Otherwise, 'build'
+	      searches the recipe file for a "needsrootforbuild"
+              hint to decide what user to use.
+
+  --changelog Append rpm changelog from SUSE .changes file to spec file.
+
   --logfile logfile
               Capture build output to logfile. Defaults to
               .build.log in the build root for non-VM builds.
@@ -197,6 +204,15 @@ Known Parameters:
 
   --rpms path1:path2:...
               Specify path where to find the RPMs for the build system
+
+  --rpmlist file
+              Specify file with packages to install. Format is
+              <package> <package_source>.
+              <package> can be an ordinary package or one of preinstall:,
+              vminstall:, installonly:, noinstall:, preinstallimage:,
+              preinstallimagesource:, runscripts:, dist:, rpmid:.
+              <package_source> can be either a local path or a URL
+              (valid: zypp://, http://, https://, ftp://, ftps://).
 
   --arch arch1:arch2:...
               Specify what architectures to select from the RPMs
@@ -291,6 +307,9 @@ Known Parameters:
 
   --statistics
               monitor used resources during build inside VM
+
+  --buildflavor flavor
+              Specify flavor to replace @BUILD_FLAVOR@ in spefile with.
 
   --kvm
               Use KVM to secure build process. Your hardware needs to support

--- a/build
+++ b/build
@@ -257,8 +257,13 @@ Known Parameters:
   --release release
               Override Release in spec file
 
-  --stage=-bSTAGE
-              Set stage for rpmbuild. Defaults to -ba.
+  --stage=[-bSTAGE|..STAGE|STAGE|STAGE..]
+              -bSTAGE: Set stage for rpmbuild. Defaults to -ba.
+	      Legacy behavior.
+	      ..STAGE: Build up to and including the specified stage.
+	      STAGE: Build only the single stage.
+	      STAGE..: Build all stages from and including the specified
+              stage.
 
   --target platform
               Set target platform for rpmbuild

--- a/build-recipe
+++ b/build-recipe
@@ -54,7 +54,15 @@ recipe_parse_options() {
     case ${PARAM/#--/-} in
       -stage)
 	needarg
-	BUILD_RPM_BUILD_STAGE="$ARG"
+	case $ARG in
+	-b*) BUILD_RPM_BUILD_STAGE="$ARG" ;;
+	..[abcilps]) BUILD_RPM_BUILD_STAGE="-b${ARG#\.\.}"
+	    BUILD_RPM_BUILD_MODE=pre ;;
+	[abcilps]..) BUILD_RPM_BUILD_STAGE="-b${ARG%\.\.}"
+	    BUILD_RPM_BUILD_MODE=post ;;
+	[abcilps])  BUILD_RPM_BUILD_STAGE="-b${ARG}"
+	    BUILD_RPM_BUILD_MODE=single ;;
+	*) return 1 ;;
 	shift
 	;;
       -kiwi-parameter)

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -21,13 +21,75 @@
 #
 ################################################################
 
+# Check build stage and set stages list according to BUILD_RPM_BUILD_MODE:
+# there are three modes:
+# 'pre' or not set: build all stages up to BUILD_RPM_BUILD_STAGE
+#                  if not set, defaults to -ba
+# 'single': do an rpmbuild --short-circuit' build on stage BUILD_RPM_BUILD_STAGE
+# 'post': continue building from stage BUILD_RPM_BUILD_STAGE
+
+rpm_build_keep=
+rpm_build_stages=
+
+check_set_build_stages() {
+    local pre_d post_s
+    test -n "$BUILD_RPM_BUILD_MODE" || BUILD_RPM_BUILD_MODE=pre
+    test -z "$BUILD_RPM_BUILD_STAGE" -a "$BUILD_RPM_BUILD_MODE" != "pre" && \
+       cleanup_and_exit 1 "Error: --buildmode only allowed with --stage or BUILD_RPM_BUILD_STAGE set"
+    test -z "$BUILD_RPM_BUILD_STAGE" && BUILD_RPM_BUILD_STAGE=-ba
+    case $BUILD_RPM_BUILD_MODE in
+       pre) ;;
+       single|post)
+           test "$BUILDTYPE" = debbuild && cleanup_and_exit 1 "Error: --mode not implemented for debbuild"
+           test -z "$BUILD_RPM_BUILD_STAGE" && \
+               cleanup_and_exit 1 "Error: --buildmode only allowed with no --stage setting";
+           test "$CLEAN_BUILD" != "--clean" || \
+                             cleanup_and_exit 1 "Error: --clean not compatible with --mode"
+           case $BUILD_RPM_BUILD_STAGE in
+               -bp) test $BUILD_RPM_BUILD_MODE = post && BUILD_RPM_BUILD_STAGE=-ba
+                    BUILD_RPM_BUILD_MODE=pre ;;
+               -bc) pre_d="BUILD"; post_s="-bc -bi -bb -bs" ;;
+               -bi) pre_d="BUILD"; post_s="-bi -bb -bs" ;;
+               -bb|-ba) pre_d="BUILD BUILDROOT"; post_s="-bb -bs" ;;
+               -bl) pre_d="BUILD BUILDROOT" ;;&
+               -bs|-bl) BUILD_RPM_BUILD_MODE=single; post_s=$BUILD_RPM_BUILD_STAGE ;;
+               *) cleanup_and_exit 1 "Error: unknown stage $BUILD_RPM_BUILD_STAGE" ;;
+           esac
+           ;;
+       *) cleanup_and_exit 1 "Error: unknown build mode: $BUILD_RPM_BUILD_MODE" ;;
+    esac
+    for i in $pre_d; do
+       test -z $BUILD_ROOT$TOPDIR/$i/* &&
+           cleanup_and_exit 1 \
+               "Error: $i must not be empty for mode $BUILD_RPM_BUILD_MODE with stage $BUILD_RPM_BUILD_STAGE"
+    done
+    case $BUILD_RPM_BUILD_MODE in
+       pre|single) rpm_build_stages=$BUILD_RPM_BUILD_STAGE ;;
+       post) rpm_build_stages="$post_s" ;;
+    esac
+    [ -n "$pre_d" ] && rpm_build_keep="$pre_d"
+}
+
 recipe_setup_spec() {
+    local rpmdirs="BUILD RPMS/`uname -m` RPMS/i386 RPMS/noarch SOURCES SPECS SRPMS BUILDROOT OTHER"
     TOPDIR=`chroot $BUILD_ROOT su -c "rpm --eval '%_topdir'" - $BUILD_USER`
     if test -z "$TOPDIR"; then
 	cleanup_and_exit 1 "Error: TOPDIR empty"
     fi
-    test "$DO_INIT_TOPDIR" = false || rm -rf "$BUILD_ROOT$TOPDIR"
-    for i in BUILD RPMS/`uname -m` RPMS/i386 RPMS/noarch SOURCES SPECS SRPMS BUILDROOT OTHER ; do
+    check_set_build_stages
+    if test "$DO_INIT_TOPDIR" != false; then
+        if test -z "$rpm_build_keep"; then
+            rm -rf "$BUILD_ROOT$TOPDIR"
+        else
+            for i in $rpmdirs; do
+                for j in $rpm_build_keep; do
+                    test $i = $j && continue 2
+                done
+                rm -rf "$BUILD_ROOT$TOPDIR/$i"
+            done
+        fi
+    fi
+    for i in $rpmdirs; do
 	mkdir -p $BUILD_ROOT$TOPDIR/$i
     done
     chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT$TOPDIR"
@@ -115,7 +177,6 @@ recipe_prepare_spec() {
 }
 
 recipe_build_spec() {
-    test -z "$BUILD_RPM_BUILD_STAGE" && BUILD_RPM_BUILD_STAGE=-ba
 
     rpmbuild=rpmbuild
     test -x $BUILD_ROOT/usr/bin/rpmbuild || rpmbuild=rpm
@@ -126,91 +187,97 @@ recipe_build_spec() {
 	HAVE_DYNAMIC_BUILDREQUIRES=true
     fi
 
+    for build_rpm_build_stage in $rpm_build_stages; do
     # XXX: move _srcdefattr to macro file?
-    rpmbopts=("$BUILD_RPM_BUILD_STAGE" "--define" "_srcdefattr (-,root,root)")
-    if test "$DO_CHECKS" != true ; then
-	if chroot "$BUILD_ROOT" "$rpmbuild" --nocheck --help >/dev/null 2>&1; then
-	    rpmbopts[${#rpmbopts[@]}]="--nocheck"
-	else
-	    echo "warning: --nocheck is not supported by this $rpmbuild version"
+	rpmbopts=("$build_rpm_build_stage" "--define" "_srcdefattr (-,root,root)")
+	if test "$DO_CHECKS" != true ; then
+	    if chroot "$BUILD_ROOT" "$rpmbuild" --nocheck --help >/dev/null 2>&1; then
+		rpmbopts[${#rpmbopts[@]}]="--nocheck"
+	    else
+		echo "warning: --nocheck is not supported by this $rpmbuild version"
+	    fi
 	fi
-    fi
-    if test "$rpmbuild" == "debbuild" ; then
-	rpmbopts[${#rpmbopts[@]}]="-vv"
-    fi
-    if test "$rpmbuild" == "rpmbuild" ; then
+	case $BUILD_RPM_BUILD_MODE in
+	    single|post) rpmbopts[${#rpmbopts[@]}]="--short-circuit" ;;
+	esac
+	if test "$rpmbuild" == "debbuild" ; then
+	    rpmbopts[${#rpmbopts[@]}]="-vv"
+	fi
+	if test "$rpmbuild" == "rpmbuild" ; then
 	    # use only --nosignature for rpm v4
-	rpmbopts[${#rpmbopts[@]}]="--nosignature"
-    fi
-    if test -n "$ABUILD_TARGET" ; then
-	rpmbopts[${#rpmbopts[@]}]="--target=$ABUILD_TARGET"
-    fi
-    if test -n "$BUILD_DEBUG" ; then
-	rpmbopts[${#rpmbopts[@]}]='--define'
-	rpmbopts[${#rpmbopts[@]}]="_build_create_debug 1"
-    fi
-    if test -n "$DISTURL" ; then
-	rpmbopts[${#rpmbopts[@]}]='--define'
-	rpmbopts[${#rpmbopts[@]}]="disturl $DISTURL"
-    fi
-    if test -n "$RSYNCDONE" ; then
-	rpmbopts[${#rpmbopts[@]}]='--define'
-	rpmbopts[${#rpmbopts[@]}]="RSYNCDONE 1"
-    fi
+	    rpmbopts[${#rpmbopts[@]}]="--nosignature"
+	fi
+	if test -n "$ABUILD_TARGET" ; then
+	    rpmbopts[${#rpmbopts[@]}]="--target=$ABUILD_TARGET"
+	fi
+	if test -n "$BUILD_DEBUG" ; then
+	    rpmbopts[${#rpmbopts[@]}]='--define'
+	    rpmbopts[${#rpmbopts[@]}]="_build_create_debug 1"
+	fi
+	if test -n "$DISTURL" ; then
+	    rpmbopts[${#rpmbopts[@]}]='--define'
+	    rpmbopts[${#rpmbopts[@]}]="disturl $DISTURL"
+	fi
+	if test -n "$RSYNCDONE" ; then
+	    rpmbopts[${#rpmbopts[@]}]='--define'
+	    rpmbopts[${#rpmbopts[@]}]="RSYNCDONE 1"
+	fi
 
-    buildrootoverride=$(queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" buildflags rpm-buildroot-override)
-    if test -n "$buildrootoverride" ; then
-	rpmbopts[${#rpmbopts[@]}]='--buildroot'
-	rpmbopts[${#rpmbopts[@]}]="$buildrootoverride"
-    fi
+	buildrootoverride=$(queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" buildflags rpm-buildroot-override)
+	if test -n "$buildrootoverride" ; then
+	    rpmbopts[${#rpmbopts[@]}]='--buildroot'
+	    rpmbopts[${#rpmbopts[@]}]="$buildrootoverride"
+	fi
 
-    GEN_BUILDREQS_PACKS=()
-    if test -n "$HAVE_DYNAMIC_BUILDREQUIRES" ; then
-	# query dynamic build requires
-	rm -f "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm
-	rpmdynbropts=("${rpmbopts[@]}")
-	rpmdynbropts[0]=-br
+	GEN_BUILDREQS_PACKS=()
+	if test -n "$HAVE_DYNAMIC_BUILDREQUIRES" ; then
+	    # query dynamic build requires
+	    rm -f "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm
+	    rpmdynbropts=("${rpmbopts[@]}")
+	    rpmdynbropts[0]=-br
+	    toshellscript $rpmbuild \
+		    --nodeps \
+		    "${definesnstuff[@]}" \
+		    "${rpmdynbropts[@]}" \
+		    "$TOPDIR/SOURCES/$RECIPEFILE" \
+		    > $BUILD_ROOT/.build.command
+	    chmod 755 $BUILD_ROOT/.build.command
+	    chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null
+	    st=$?
+	    if test "$st" != 0 -a "$st" != 11 ; then
+		return
+	    fi
+	    : > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
+	    if test "$st" = 11 ; then
+		reqsfile=
+		for i in "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm ; do
+		    test -f "$i" && reqsfile=${i##*/}
+		done
+		test -n "$reqsfile" || cleanup_and_exit 1 "no buildreqs.nosrc.rpm file?"
+		chroot $BUILD_ROOT rpm -qp --requires "$TOPDIR/SRPMS/$reqsfile" | grep -v '^rpmlib(' | sort -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
+		chroot $BUILD_ROOT rpmspec -q --srpm --requires "$TOPDIR/SOURCES/$RECIPEFILE" >> $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp || cleanup_and_exit 1 "rpm -q --spec failed"
+		sort < $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp | uniq -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
+		rm -f $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
+		while read db ; do
+		    GEN_BUILDREQS_PACKS[${#GEN_BUILDREQS_PACKS[@]}]="$db"
+		done < $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
+	    fi
+	    rm -f "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm
+	fi
+
+	# su involves a shell which would require even more
+	# complicated quoting to bypass than this
 	toshellscript $rpmbuild \
-		--nodeps \
 		"${definesnstuff[@]}" \
-		"${rpmdynbropts[@]}" \
+		"${rpmbopts[@]}" \
 		"$TOPDIR/SOURCES/$RECIPEFILE" \
 		> $BUILD_ROOT/.build.command
 	chmod 755 $BUILD_ROOT/.build.command
+	check_exit
 	chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null
 	st=$?
-	if test "$st" != 0 -a "$st" != 11 ; then
-	    return
-	fi
-	: > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
-	if test "$st" = 11 ; then
-	    reqsfile=
-	    for i in "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm ; do
-		test -f "$i" && reqsfile=${i##*/}
-	    done
-	    test -n "$reqsfile" || cleanup_and_exit 1 "no buildreqs.nosrc.rpm file?"
-	    chroot $BUILD_ROOT rpm -qp --requires "$TOPDIR/SRPMS/$reqsfile" | grep -v '^rpmlib(' | sort -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
-	    chroot $BUILD_ROOT rpmspec -q --srpm --requires "$TOPDIR/SOURCES/$RECIPEFILE" >> $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp || cleanup_and_exit 1 "rpm -q --spec failed"
-	    sort < $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp | uniq -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
-	    rm -f $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
-	    while read db ; do
-		GEN_BUILDREQS_PACKS[${#GEN_BUILDREQS_PACKS[@]}]="$db"
-	    done < $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
-	fi
-	rm -f "$BUILD_ROOT$TOPDIR/SRPMS/"*.buildreqs.nosrc.rpm
-    fi
-
-    # su involves a shell which would require even more
-    # complicated quoting to bypass than this
-    toshellscript $rpmbuild \
-	    "${definesnstuff[@]}" \
-	    "${rpmbopts[@]}" \
-	    "$TOPDIR/SOURCES/$RECIPEFILE" \
-	    > $BUILD_ROOT/.build.command
-    chmod 755 $BUILD_ROOT/.build.command
-    check_exit
-    chroot $BUILD_ROOT su -c /.build.command - $BUILD_USER < /dev/null
-    st=$?
+	test "$st" != 0 && break
+    done
     test "$st" = 0 && BUILD_SUCCEEDED=true
     test "$st" = 11 -a -n "$HAVE_DYNAMIC_BUILDREQUIRES" && BUILD_SUCCEEDED=genbuildreqs
 }

--- a/build.1
+++ b/build.1
@@ -134,7 +134,7 @@ Specify file with packages to install. Format is
 <package_source> can be either a local path or a URL
 (valid: 'zypp://', 'http://', 'https://', 'ftp://', 'ftps://').
 .TP
-.B --stage
+.BI "--stage=" -bSTAGE
 Pass a stage option to rpmbuild. The default is \fB-ba\fP.
 .TP
 .B --target

--- a/build.1
+++ b/build.1
@@ -134,8 +134,23 @@ Specify file with packages to install. Format is
 <package_source> can be either a local path or a URL
 (valid: 'zypp://', 'http://', 'https://', 'ftp://', 'ftps://').
 .TP
-.BI "--stage=" -bSTAGE
-Pass a stage option to rpmbuild. The default is \fB-ba\fP.
+.BI "\-\-stage=" -bSTAGE
+.TQ
+.BI "\-\-stage=" ..STAGE
+.TQ
+.BI "\-\-stage=" STAGE
+.TQ
+.BI "\-\-stage=" STAGE..
+.IR "-bSTAGE" :
+pass a stage option to rpmbuild (legacy). The default is \fB-ba\fP.
+.br
+Build everything up to
+.RI ( ..STAGE ),
+starting from
+.RI ( STAGE.. )
+or only
+.RI ( STAGE )
+STAGE.
 .TP
 .B --target
 Call rpmbuild with a target option. This can be used for cross building.

--- a/build.1
+++ b/build.1
@@ -112,6 +112,12 @@ do not specify this option so you should almost never need it.
 
 .SH RPM BUILD SPECIFIC OPTIONS
 .TP
+.BI "\-\-buildflavor " flavor
+Specify flavor to replace @BUILD_FLAVOR@ in spefile with.
+.TP
+.B --changelog
+Append rpm changelog from SUSE .changes file to spec file.
+.TP
 .B --useusedforbuild
 Tell build not to do dependency expansion, but to extract the
 list of packages to install from "# usedforbuild" lines or, if none
@@ -119,11 +125,23 @@ are found, from all "BuildRequires" lines.  This option is useful
 if you want to re-build a package from a srcrpm with exactly the
 same packages used for the srcrpm build.
 .TP
+.BI "\-\-rpmlist " file
+Specify file with packages to install. Format is
+<package> <package_source>.
+<package> can be an ordinary package or one of 'preinstall:'
+, 'vminstall:', 'installonly:', 'noinstall:', 'preinstallimage:',
+,'preinstallimagesource:', 'runscripts:', 'dist:', 'rpmid:',
+<package_source> can be either a local path or a URL
+(valid: 'zypp://', 'http://', 'https://', 'ftp://', 'ftps://').
+.TP
 .B --stage
 Pass a stage option to rpmbuild. The default is \fB-ba\fP.
 .TP
 .B --target
 Call rpmbuild with a target option. This can be used for cross building.
+.TP
+.B --statistics
+monitor used resources during build inside VM
 .TP
 .B --verify
 Verify the files in an existing build system.


### PR DESCRIPTION
This set contains two things:

1. Improvement of the 'build' and 'osc build' experience: together with changes to github.com/openSUSE/osc and if supported for the underlying build system, allow for 'partial' builds - like rpmbuild --short-circuit -b<build_stage>, but better: for multi-stage builds, it allows to execute:
    - a single build stage, 
    - a build up to a specified stage or 
    - a build starting from a specified stage (provided all previous stages have already been performed).
No more waiting for endless %builds just to test a change to an %files stage, no more need to fiddle with rpmbuild directly in the chroot (and forgetting to copy back the changes to the spec file later).
(Note: this is presently available for rpmbuild only, the design is sufficiently generic that it should be implementable to every other build system - provided this supports multiple build stages and running them individually.
2. Additions to the documentation to document the changes in (1.) as well as some other missing bits and pieces.