### PR TITLE
Support autosetup and autopatch

### DIFF
--- a/spec_add_patch
+++ b/spec_add_patch
@@ -62,6 +62,7 @@ open(S, '<', $specname) or die;
 my $ifdef_level = 0;
 my $in_prep = 0;
 my $in_global = 1;
+my $autopatch = 0;
 my $last_patch_in_prep_index = 0;
 my $last_patch_in_global_index = 0;
 my $last_source_in_global_index = 0;
@@ -89,6 +90,10 @@ while(<S>)
         die if ($in_global);
     }
 
+    if ($in_prep
+        && /^%auto(patch|setup)\b/) {
+        $autopatch = 1;
+    }
     if ($in_prep
         && /^%setup\b/) {
         $last_patch_in_prep_index = $index;
@@ -128,7 +133,7 @@ if ($last_patch_in_global_index == 0) {
 
 die if ($ifdef_level > 0);
 die if ($in_global || $in_prep);
-die if ($last_patch_in_prep_index == 0);
+die if ($last_patch_in_prep_index == 0 && !$autopatch);
 die if ($last_patch_in_global_index == 0);
 
 #print "adding Patch: $diffname to line $last_patch_in_global_index\n";
@@ -161,7 +166,7 @@ for my $diffname (keys %diffs) {
     print "Adding patch$striplevel $diffname to $specname\n";
 
 
-    splice @c, $last_patch_in_prep_index+1, 0, ("\%patch$patchnum$striplevel\n");
+    splice @c, $last_patch_in_prep_index+1, 0, ("\%patch$patchnum$striplevel\n") unless $autopatch;
     splice @c, $last_patch_in_global_index+1, 0,
     (sprintf "Patch%s:%s%s\n", $patchnum, ' ' x (10-length($patchnum)), $diffname);
     ++$last_patch_in_global_index;


### PR DESCRIPTION
Without this patch,
%autosetup caused it to die in line 131
and %autopatch succeeded but would fail to build
because it applied the patch twice.

Might fix https://bugzilla.opensuse.org/show_bug.cgi?id=1172891

I tested this patch on `%setup`, `%autosetup` and `%autopatch` cases.

The -p level is ignored