### PR TITLE
flatpak: Allow to specify #!BuildVersion

### DIFF
--- a/build-recipe-flatpak
+++ b/build-recipe-flatpak
@@ -82,11 +82,14 @@ recipe_build_flatpak() {
 
     local FLATPAK_FILE="$TOPDIR/SOURCES/$RECIPEFILE"
     local FLATPAK_APP=$(perl -I$BUILD_DIR -MBuild::Flatpak -e 'Build::Flatpak::show' -- "$BUILD_ROOT$FLATPAK_FILE" name)
+    local FLATPAK_APP_VERSION=$(perl -I$BUILD_DIR -MBuild::Flatpak -e 'Build::Flatpak::show' -- "$BUILD_ROOT$FLATPAK_FILE" version)
+    FLATPAK_APP_VERSION="${FLATPAK_APP_VERSION:-0}"
     local FLATPAK_REPO=/tmp/flatpakrepo
     local FLATPAK_REMOTE=https://dl.flathub.org/repo/flathub.flatpakrepo
     export FLATPAK_REPO
     export FLATPAK_REMOTE
     export FLATPAK_APP
+    export FLATPAK_APP_VERSION
     export FLATPAK_FILE
     export TOPDIR
 

--- a/call-flatpak-builder
+++ b/call-flatpak-builder
@@ -49,8 +49,8 @@ test -e "$BUILD_ROOT/proc/self" || mount -n -tproc none $BUILD_ROOT/proc
 set -x
 
 # Build into repo
-chroot "$BUILD_ROOT" bash -c "cd /usr/src/packages/FLATPAK_ROOT && flatpak-builder --force-clean --repo=$FLATPAK_REPO build-dir $FLATPAK_FILE"
+chroot "$BUILD_ROOT" bash -c "cd /usr/src/packages/FLATPAK_ROOT && flatpak-builder --default-branch=$FLATPAK_APP_VERSION --force-clean --repo=$FLATPAK_REPO build-dir $FLATPAK_FILE"
 
 # Create bundle from repo
-chroot "$BUILD_ROOT" bash -c "flatpak build-bundle --runtime-repo=$FLATPAK_REMOTE $FLATPAK_REPO $TOPDIR/OTHER/$FLATPAK_APP.flatpak $FLATPAK_APP"
+chroot "$BUILD_ROOT" bash -c "flatpak build-bundle --runtime-repo=$FLATPAK_REMOTE $FLATPAK_REPO $TOPDIR/OTHER/$FLATPAK_APP-$FLATPAK_APP_VERSION.flatpak $FLATPAK_APP $FLATPAK_APP_VERSION"
 

--- a/t/data/flatpak.json
+++ b/t/data/flatpak.json
@@ -1,3 +1,4 @@
+#!BuildVersion: 3.36.2
 {
     "app-id": "org.gnome.Chess",
     "runtime": "org.gnome.Platform",

--- a/t/data/flatpak.yaml
+++ b/t/data/flatpak.yaml
@@ -1,3 +1,4 @@
+#!BuildVersion: 3.36.2
 ---
 app-id: org.gnome.Chess
 runtime: org.gnome.Platform

--- a/t/flatpak.t
+++ b/t/flatpak.t
@@ -22,7 +22,7 @@ sub capture_stdout {
 subtest parse => sub {
     my $expected = {
         name => 'org.gnome.Chess',
-        version => 0,
+        version => '3.36.2',
         sources => [
             "phalanx-XXV-source.tgz",
             "stockfish-10-src.zip",
@@ -49,11 +49,16 @@ subtest show => sub {
     local @ARGV = ("$path/flatpak.yaml", 'name');
     my $data = capture_stdout(sub { Build::Flatpak::show() });
     is $data, "org.gnome.Chess\n", 'Build::Flatpak::show name';
+
+    @ARGV = ("$path/flatpak.yaml", 'sources');
+    $data = capture_stdout(sub { Build::Flatpak::show() });
+    is $data, "phalanx-XXV-source.tgz\nstockfish-10-src.zip\ngnuchess-6.2.5.tar.gz\ngnome-chess-3.36.1.tar.xz\n", 'Build::Flatpak::show sources';
 };
 
 done_testing;
 
 __DATA__
+#!BuildVersion: 3.36.2
 {
     "app-id": "org.gnome.Chess",
     "runtime": "org.gnome.Platform",


### PR DESCRIPTION
The downloadable files need to have versions, but flatpak
manifests don't have version fields.