### PR TITLE
flatpak: Replace source urls with file paths

### DIFF
--- a/build-recipe-flatpak
+++ b/build-recipe-flatpak
@@ -81,8 +81,12 @@ recipe_build_flatpak() {
     cp $BUILD_ROOT$TOPDIR/SOURCES/* .
 
     local FLATPAK_FILE="$TOPDIR/SOURCES/$RECIPEFILE"
+    local FLATPAK_FILE_LOCAL="$TOPDIR/SOURCES/flatpak-local.yaml"
     local FLATPAK_APP=$(perl -I$BUILD_DIR -MBuild::Flatpak -e 'Build::Flatpak::show' -- "$BUILD_ROOT$FLATPAK_FILE" name)
     local FLATPAK_APP_VERSION=$(perl -I$BUILD_DIR -MBuild::Flatpak -e 'Build::Flatpak::show' -- "$BUILD_ROOT$FLATPAK_FILE" version)
+    # Rewrite http urls to file urls
+    perl -I$BUILD_DIR -MBuild::Flatpak -e 'Build::Flatpak::rewrite' -- "$BUILD_ROOT$FLATPAK_FILE" > "$BUILD_ROOT$FLATPAK_FILE_LOCAL"
+    FLATPAK_FILE="$FLATPAK_FILE_LOCAL"
     FLATPAK_APP_VERSION="${FLATPAK_APP_VERSION:-0}"
     local FLATPAK_REPO=/tmp/flatpakrepo
     local FLATPAK_REMOTE=https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/t/data/flatpak-rewritten.yaml
+++ b/t/data/flatpak-rewritten.yaml
@@ -1,0 +1,62 @@
+---
+app-id: org.gnome.Chess
+cleanup:
+- /share/gnuchess
+- /share/info
+- /share/man
+- /include
+command: gnome-chess
+finish-args:
+- --share=ipc
+- --socket=fallback-x11
+- --socket=wayland
+- --metadata=X-DConf=migrate-path=/org/gnome/Chess/
+modules:
+- build-commands:
+  - make
+  - install -D phalanx /app/bin/phalanx
+  - install -D pbook.phalanx /app/share/phalanx/pbook.phalanx
+  - install -D sbook.phalanx /app/share/phalanx/sbook.phalanx
+  - install -D eco.phalanx /app/share/phalanx/eco.phalanx
+  buildsystem: simple
+  name: phalanx
+  sources:
+  - sha256: b3874d5dcd22c64626b2c955b18b27bcba3aa727855361a91eab57a6324b22dd
+    type: archive
+    url: file:///usr/src/packages/SOURCES/phalanx-XXV-source.tgz
+  - path: phalanx-books-path.patch
+    type: patch
+- build-commands:
+  - make build
+  - install -D stockfish /app/bin/stockfish
+  build-options:
+    arch:
+      aarch64:
+        env:
+          ARCH: armv7
+      arm:
+        env:
+          ARCH: armv7
+      x86_64:
+        env:
+          ARCH: x86-64
+  buildsystem: simple
+  name: stockfish
+  sources:
+  - sha256: 29bd01e7407098aa9e851b82f6ea4bf2b46d26e9075a48a269cb1e40c582a073
+    type: archive
+    url: file:///usr/src/packages/SOURCES/stockfish-10-src.zip
+- name: gnuchess
+  sources:
+  - sha256: 9a99e963355706cab32099d140b698eda9de164ebce40a5420b1b9772dd04802
+    type: archive
+    url: file:///usr/src/packages/SOURCES/gnuchess-6.2.5.tar.gz
+- buildsystem: meson
+  name: gnome-chess
+  sources:
+  - sha256: b195c9f17a59d7fcc892ff55e6a6ebdd16e7329157bf37e3c2fe593b349aab98
+    type: archive
+    url: file:///usr/src/packages/SOURCES/gnome-chess-3.36.1.tar.xz
+runtime: org.gnome.Platform
+runtime-version: '3.36'
+sdk: org.gnome.Sdk

--- a/t/data/flatpak.json
+++ b/t/data/flatpak.json
@@ -25,7 +25,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "file:///usr/src/packages/SOURCES/phalanx-XXV-source.tgz",
+                    "url": "https://example.org/phalanx-XXV-source.tgz",
                     "sha256": "b3874d5dcd22c64626b2c955b18b27bcba3aa727855361a91eab57a6324b22dd"
                 },
                 {
@@ -63,7 +63,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "file:///usr/src/packages/SOURCES/stockfish-10-src.zip",
+                    "url": "https://example.org/stockfish-10-src.zip",
                     "sha256": "29bd01e7407098aa9e851b82f6ea4bf2b46d26e9075a48a269cb1e40c582a073"
                 }
             ]
@@ -73,7 +73,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "file:///usr/src/packages/SOURCES/gnuchess-6.2.5.tar.gz",
+                    "url": "https://example.org/gnuchess-6.2.5.tar.gz",
                     "sha256": "9a99e963355706cab32099d140b698eda9de164ebce40a5420b1b9772dd04802"
                 }
             ]
@@ -84,7 +84,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "file:///usr/src/packages/SOURCES/gnome-chess-3.36.1.tar.xz",
+                    "url": "https://example.org/gnome-chess-3.36.1.tar.xz",
                     "sha256": "b195c9f17a59d7fcc892ff55e6a6ebdd16e7329157bf37e3c2fe593b349aab98"
                 }
             ]

--- a/t/data/flatpak.yaml
+++ b/t/data/flatpak.yaml
@@ -23,7 +23,7 @@ modules:
   - install -D eco.phalanx /app/share/phalanx/eco.phalanx
   sources:
   - type: archive
-    url: "file:///usr/src/packages/SOURCES/phalanx-XXV-source.tgz"
+    url: "https://example.org/phalanx-XXV-source.tgz"
     sha256: b3874d5dcd22c64626b2c955b18b27bcba3aa727855361a91eab57a6324b22dd
   - type: patch
     path: phalanx-books-path.patch
@@ -46,18 +46,18 @@ modules:
   - install -D stockfish /app/bin/stockfish
   sources:
   - type: archive
-    url: "file:///usr/src/packages/SOURCES/stockfish-10-src.zip"
+    url: "https://example.org/stockfish-10-src.zip"
     sha256: 29bd01e7407098aa9e851b82f6ea4bf2b46d26e9075a48a269cb1e40c582a073
 
 - name: gnuchess
   sources:
   - type: archive
-    url: "file:///usr/src/packages/SOURCES/gnuchess-6.2.5.tar.gz"
+    url: "https://example.org/gnuchess-6.2.5.tar.gz"
     sha256: 9a99e963355706cab32099d140b698eda9de164ebce40a5420b1b9772dd04802
 
 - name: gnome-chess
   buildsystem: meson
   sources:
   - type: archive
-    url: "file:///usr/src/packages/SOURCES/gnome-chess-3.36.1.tar.xz"
+    url: "https://example.org/gnome-chess-3.36.1.tar.xz"
     sha256: b195c9f17a59d7fcc892ff55e6a6ebdd16e7329157bf37e3c2fe593b349aab98


### PR DESCRIPTION
This allows users to keep the original url in the flatpak manifest
for reference.
At build time flatpak-builder will work with the file urls.