### PR TITLE
build-vm set LIBGUESTFS_CACHEDIR to prevent deadlocks

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -979,6 +979,7 @@ vm_first_stage() {
 		cleanup_and_exit 4
 	    fi
         else
+	    export LIBGUESTFS_CACHEDIR=$BUILD_ROOT/.guestfs
             /usr/bin/virt-make-fs --format=raw -t ext3 --size="$VMDISK_ROOTSIZE"M $BUILD_ROOT $VM_ROOT || cleanup_and_exit 4
 	    #rm -rf -- "$BUILD_ROOT"/*
 	fi


### PR DESCRIPTION
otherwise all workers try to lock /var/tmp/.guestfs-0/lock (and deadlock) and we do not just want to cluttter / of the worker machine anyway