### PR TITLE
Set LC_ALL to C.UTF-8

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -95,7 +95,7 @@ dsc_build() {
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="LC_ALL=C.UTF-8 dpkg-buildpackage -us -uc"
     if test -e $buildroot/$TOPDIR/SOURCES/build.script ; then
 	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"


### PR DESCRIPTION
Multiple packages have run into build failures on our OBS. On closer
inspection, it was concluded to be issues with the locale settings.
These issues were never seen on the Debian buildd infrastructure because
there the locale setting `LC_ALL=C.UTF-8` is in use.

This change keeps us closer to what is used in Debian buildds.

Signed-off-by: Ritesh Raj Sarraf <ritesh.sarraf@collabora.com>