### PR TITLE
source common_functions early

### DIFF
--- a/build
+++ b/build
@@ -838,6 +838,8 @@ umount_stuff() {
 
 trap fail_exit EXIT
 
+. $BUILD_DIR/common_functions || exit 1
+
 shopt -s nullglob
 
 export PATH=$BUILD_DIR:/sbin:/usr/sbin:/bin:/usr/bin:$PATH
@@ -846,8 +848,6 @@ if vm_detect_2nd_stage ; then
     set "/.build-srcdir/$RECIPEFILE"
     export PATH=/.build:$PATH
 fi
-
-. $BUILD_DIR/common_functions || exit 1
 
 export HOST
 


### PR DESCRIPTION
vm_detect_2nd_stage can call cleanup_and_exit before setting
RUNNING_IN_VM=true. Thus, buildroot_umount, which is defined in the
common_functions file, can be called by cleanup_and_exit. Hence,
source the common_functions file before calling vm_detect_2nd_stage.

Note: if sourcing the common_functions file fails, we still call
cleanup_and_exit and the umount fails. However, all other cleanup
actions are executed.