### PR TITLE
build-recipe-docker: Fix builds with podman

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -164,7 +164,7 @@ recipe_build_docker() {
 
     if test "$DOCKER_TOOL" = podman ; then
 	test -n "$squashopt" && squashopt="--layers=false"
-	if ! $BUILD_DIR/call-podman --root "$BUILD_ROOT" build $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
+	if ! $BUILD_DIR/call-podman --root "$BUILD_ROOT" build $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --cgroup-manager=cgroupfs --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
 	    cleanup_and_exit 1 "$DOCKER_TOOL build command failed"
 	fi
     else


### PR DESCRIPTION
Pass --cgroup-manager=cgroupfs to podman as the default is "systemd" which is
not available in the build env.

Tested with a local `osc build` after patching `/usr/lib/build/build-recipe-docker`.