### PR TITLE
add generic post build check script hook

### DIFF
--- a/build
+++ b/build
@@ -1649,6 +1649,13 @@ if test -n "$RPMS" -a -d "$BUILD_ROOT/usr/lib/build/checks" ; then
     test -e "$BUILD_ROOT/proc/self" || mount -n -tproc none $BUILD_ROOT/proc
 fi
 
+for CHECKSCRIPT in $BUILD_ROOT/usr/lib/build/post-build-checks/* ; do
+    if test -x "$CHECKSCRIPT"; then
+       echo "... running ${CHECKSCRIPT##*/}"
+       BUILD_ROOT=/ chroot "$BUILD_ROOT" "/usr/lib/build/post-build-checks/${CHECKSCRIPT##*/}" || cleanup_and_exit 1
+    fi
+done
+
 # checkscripts may have deleted some binaries
 RPMS=`find $BUILD_ROOT/$TOPDIR/RPMS -type f -name "*.rpm" 2>/dev/null || true`
 DEBS=`find $BUILD_ROOT/$TOPDIR/DEBS -type f -name "*.deb" 2>/dev/null || true`


### PR DESCRIPTION
Execute every script inside of /usr/lib/build/post-build-checks/ .

The check must validate that it runs for the right build type and fail
only when it finds a problem with a build result. No matter of which
type.

We already have usr/lib/build/checks/ but the existing checks are rpm
generic and fail on non rpm builds. Ideally these get migrated later on.

OBS-110