### PR TITLE
Add a Travis CI test for building a flatpak app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+virt: vm
+os: linux
+dist: focal
+services:
+- docker
+script:
+- docker pull registry.opensuse.org/opensuse/leap:15.2 && docker images
+- docker run -t --rm -v$PWD:/obs-build --privileged
+    --cap-add SYS_ADMIN --device /dev/fuse
+    registry.opensuse.org/opensuse/leap:15.2 /obs-build/t/data/flatpak.sh

--- a/build-recipe-flatpak
+++ b/build-recipe-flatpak
@@ -98,7 +98,6 @@ recipe_build_flatpak() {
     export TOPDIR
     export RELEASE
 
-    modprobe fuse
     chroot "$BUILD_ROOT" su -c "flatpak list"
 
     $BUILD_DIR/call-flatpak-builder --root "$BUILD_ROOT"

--- a/t/data/flatpak.sh
+++ b/t/data/flatpak.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -ex
+
+cd /obs-build
+
+zypper -n install git hostname tar gzip fuse wget \
+  perl perl-XML-Parser perl-libwww-perl perl-YAML-LibYAML perl-LWP-Protocol-https
+
+export BUILD_DIR=$PWD BUILD_ROOT=/var/tmp/obs-build
+cd t/data/mahjongg
+wget https://download.gnome.org/sources/gnome-mahjongg/3.38/gnome-mahjongg-3.38.2.tar.xz
+# We need at least flatpak-1.6.3-lp152.3.3.1.src from the update repo because
+# flatpak-1.6.3-lp152.2.1.x86_64 has a packaging bug
+$BUILD_DIR/build --nosignature \
+  --repo http://download.opensuse.org/update/leap/15.2/oss/ \
+  --repo http://download.opensuse.org/distribution/leap/15.2/repo/oss/ \
+  --repo http://download.opensuse.org/repositories/OBS:/Flatpak/openSUSE_Leap_15.2/ \
+  flatpak.yaml -release 23
+
+flatpakfile="$BUILD_ROOT/usr/src/packages/OTHER/org.gnome.Mahjongg-3.38.2-23.flatpak"
+if [[ -e "$flatpakfile" ]] ; then
+  echo OK
+else
+  echo NOT OK
+  exit 1
+fi
+
+zypper -n install flatpak
+
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+flatpak install --noninteractive "$flatpakfile"
+
+flatpak list
+
+flatpak list | grep org.gnome.Mahjongg
+
+find / -type l -name org.gnome.Mahjongg | xargs ls -l
+
+/var/lib/flatpak/exports/bin/org.gnome.Mahjongg --version
+
+# It reports its version on stderr
+/var/lib/flatpak/exports/bin/org.gnome.Mahjongg --version 2>&1 | grep 'gnome-mahjongg 3.38.2'
+

--- a/t/data/mahjongg/flatpak.yaml
+++ b/t/data/mahjongg/flatpak.yaml
@@ -1,0 +1,47 @@
+######################################################
+# Flatpak manifest example for Open Build Service
+# https://docs.flatpak.org/en/latest/manifests.html
+# Input should be YAML, even though the file can have
+# a .json suffix (JSON is a subset of YAML).
+# Don't use '//' comments!
+# Copied from https://github.com/flathub/org.gnome.Mahjongg
+######################################################
+
+# Special OBS field because flatpak does not have a version field
+# Default will be '0' if the field is missing.
+#!BuildVersion: 3.38.2
+---
+app-id: org.gnome.Mahjongg
+runtime: org.gnome.Platform
+sdk: org.gnome.Sdk
+runtime-version: '3.38'
+command: gnome-mahjongg
+
+finish-args:
+- --share=ipc
+- --socket=fallback-x11
+- --socket=wayland
+- --device=dri
+- --metadata=X-DConf=migrate-path=/org/gnome/Mahjongg/
+
+cleanup:
+- "/share/man"
+
+modules:
+- name: gnome-mahjongg
+  buildsystem: meson
+  config-opts:
+  - -Dcompile-schemas=enabled
+  - -Dupdate-icon-cache=enabled
+  sources:
+  - type: archive
+
+    # Source archives should be put into the OBS package, but you can
+    # keep the original URL from where it was downloaded here.
+    url: https://download.gnome.org/sources/gnome-mahjongg/3.38/gnome-mahjongg-3.38.2.tar.xz
+
+    # You can also just specify a simple filename
+    # url: gnome-mahjongg-3.36.2.tar.xz
+
+    # flatpak-builder will do a checksum
+    sha256: '928708b4c625cad4b05199ca2948f6a545bfab368a1fc576feed0a7432e454f3'


### PR DESCRIPTION
Also remove the explicit modprobe call, as this shouldn't be necessary.

This test builds the Mahjongg app, and if successful, it installs
it via flatpak and checks if the version output of the app
is as expected.

travis CI probably needs to be enabled here first. Here is the successful build from my fork:
https://travis-ci.com/github/perlpunk/obs-build/builds/219863126

edit: Oh, Travis CI is already active