### PR TITLE
enforce use of runc

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -164,7 +164,7 @@ recipe_build_docker() {
 
     if test "$DOCKER_TOOL" = podman ; then
 	test -n "$squashopt" && squashopt="--layers=false"
-	if ! $BUILD_DIR/call-podman --root "$BUILD_ROOT" build $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --cgroup-manager=cgroupfs --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
+	if ! $BUILD_DIR/call-podman --root "$BUILD_ROOT" build $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
 	    cleanup_and_exit 1 "$DOCKER_TOOL build command failed"
 	fi
     else

--- a/call-podman
+++ b/call-podman
@@ -77,7 +77,9 @@ fi
 # setup mounts
 test -e "$BUILD_ROOT/proc/self" || mount -n -tproc none $BUILD_ROOT/proc
 
+# use runc if crun is not available (SLE..)
+RUNTIME_OPT=""
+[ -x "$BUILD_ROOT/usr/bin/crun" ] || RUNTIME_OPT="--runtime runc"
+
 # run the command
-exec chroot "$BUILD_ROOT" podman --cgroup-manager=cgroupfs "$@"
-
-
+exec chroot "$BUILD_ROOT" podman $RUNTIME_OPT --cgroup-manager=cgroupfs "$@"

--- a/call-podman
+++ b/call-podman
@@ -77,7 +77,8 @@ fi
 # setup mounts
 test -e "$BUILD_ROOT/proc/self" || mount -n -tproc none $BUILD_ROOT/proc
 
-# use runc if crun is not available (SLE..)
+# If the host kernel defaults to cgroupsv2, podman tries to run `crun` instead, even if not available.
+# As a workaround, force use of runc.
 RUNTIME_OPT=""
 [ -x "$BUILD_ROOT/usr/bin/crun" ] || RUNTIME_OPT="--runtime runc"
 


### PR DESCRIPTION
on a tumbleweed host, podman defaults to use crun, which is able to deal with the enabled unified cgroupv2. However older versions of podman (like SLE) don't have support. so detect in which situation we are, and hardcode runc if crun is not available inside the buildroot.