### PR TITLE
build-recipe-dsc: support optional "OBS-DCH-RELEASE: 1" also in …

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -59,6 +59,25 @@ recipe_prepare_dsc() {
         if [ "$RELEASE" ]; then
           echo "release: ($RELEASE), release (DEB) ($DEB_RELEASE)"
                  RELEASEARGS="--release $DEB_RELEASE"
+          if grep -Eq '^OBS-DCH-RELEASE: 1' $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE \
+          && grep -Eq '^Version:' $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE \
+          ; then
+            WSCHAR="`printf '\t '`"
+            # https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version
+            VERSION="`grep -E '^Version:' $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE | sed -e 's,^Version:'"[$WSCHAR][$WSCHAR]"'*,,' -e 's,'"[$WSCHAR]"'*$,,'`"
+            echo "OBS-DCH-RELEASE: DSC file originally spelled package version as ${VERSION}"
+            case "$VERSION" in
+                *-*) # Got a debver or more already, add a plus-suffix to debver
+                    OBS_DCH_RELEASE="+$DEB_RELEASE" ;;
+                *)   # No debver, add the first such token
+                    OBS_DCH_RELEASE="-$DEB_RELEASE" ;;
+            esac
+            # "OBS_DCH_RELEASE" char offset aligned with "VERSION" in previous echo
+            echo "OBS-DCH-RELEASE: Suffixing DSC file with OBS respin number, to  ${VERSION}${OBS_DCH_RELEASE}"
+            sed -e 's,^\(OBS-DCH-RELEASE:.*\)$,# \1,' \
+                -e 's,^\(Version:\).*$,\1'" ${VERSION}${OBS_DCH_RELEASE}"',' \
+                -i $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE
+          fi
         fi
         if ! debtransform $CHANGELOGARGS $RELEASEARGS $BUILD_ROOT$TOPDIR/SOURCES $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE $BUILD_ROOT$TOPDIR/SOURCES.DEB ; then
 	    cleanup_and_exit 1 "debian transforming failed."


### PR DESCRIPTION
…debtransform-ed sources to append an OBS release number during respins

This allows automatically rebuilt packages (same source and recipe, rebuild happens because of manual trigger or changed dependencies and config requesting to rebuild due to those) to be discernible from earlier built artifacts by virtue of changed version. This is optional, to be used at OBS packagers' discretion, because it goes against reproducible builds (same source and same dependencies and frozen timestamps might produce identical binaries otherwise), but for others it allows to see that a package was "respun" due to changed circumstances. 

It may make sense to augment (or replace?) this option with some pkgconf setting, e.g. to enable such behavior in development project and disable it in release using the same (copied or obs-branched) sources and recipes. For the starting point, I used the same syntax (magic line in recipe file) as already processed for recipes without explicit debian content.

Tested that this also changes the version reflected in the debian.changelog, although debtransform only prepends one entry about itself to the content that may be available in the uploaded recipe and so the *whole* history of respin numbers for unmodified recipe is not known - just the latest build:

````
packagename (0.1.2-1+5.6) stable; urgency=low

  * version number update by debtransform

 -- debtransform <build@opensuse.org>  Mon, 10 May 2021 20:12:02 +0000


packagename (0.1.1-1) stable; urgency=low

  * Initial commit
...
````

Thanks to @adrianschroeter for pointing from IRC in the right direction :)