### PR TITLE
set LANG=en_EN.UTF-8 for makepkg in Arch Linux

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -62,5 +62,5 @@ recipe_cleanup_arch() {
 }
 
 _arch_recipe_makepkg() {
-    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf --skippgpcheck $*" $BUILD_USER
+    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && LANG=en_US.UTF-8 makepkg --config ../makepkg.conf --skippgpcheck $*" $BUILD_USER
 }


### PR DESCRIPTION
Without this patch `bsdtar` exits with the following error:

```
[   68s] ==> WARNING: Skipping verification of source file PGP signatures.
[   68s]     obs-service-tar_scm-0.10.22.1615538418.07a353d.tar.gz ... Skipped
[   68s] bsdtar: Pathname can't be converted from UTF-8 to current locale.
[   68s] bsdtar: Error exit delayed from previous errors.
```