### PR TITLE
Issue 695: Get the standard prjconf release_prefix to work for debs

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -49,7 +49,8 @@ recipe_prepare_dsc() {
     done
     # remove rpm macros (everything after "%")
     # they are not evaluated by the Debian build process
-    DEB_RELEASE=`sed 's/%.*$//' <<< $RELEASE`
+    RELEASE=`sed 's/%..release_prefix..//' <<< $RELEASE`
+    DEB_RELEASE=$RELEASE
     OBS_DCH_RELEASE=""
 
     if test -n "$DEB_TRANSFORM" ; then 


### PR DESCRIPTION
Standard one in the docs is:
  `Release: %%{?release_prefix}.<CI_CNT>.<B_CNT>`

That is both via `OBS-DCH-RELEASE` and `DEB_TRANSFORM` mechanisms.

Round 2, if anyone wants it, would be to make it smart enough to strip any macros.