### PR TITLE
Change KVM Console to ttyS1 for s390x (bbc#1187264)

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -146,7 +146,7 @@ vm_verify_options_kvm() {
 	s390|s390x)
 	    kvm_bin="/usr/bin/qemu-system-s390x"
 	    kvm_options="-enable-kvm"
-	    kvm_console=hvc0
+	    kvm_console=ttyS1
 	    vm_kernel=/boot/image
 	    vm_initrd=/boot/initrd
 	    test -e /boot/kernel.obs.guest && vm_kernel=/boot/kernel.obs.guest


### PR DESCRIPTION
IBM is recommending ttyS0 and ttyS1 (together) as types of kvm console in bbc#1187264. Before hvc0 (the same as for Power) has been used.
ttyS0 and ttyS1 have got the benefit that we can receive get kernel messages on both consoles.
ttyS0 is used as a default setting for all architectures (above of the file). I have changed hvc0 to ttyS1 for s390x.