### PR TITLE
Fix Mageia Build

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -62,5 +62,5 @@ recipe_cleanup_arch() {
 }
 
 _arch_recipe_makepkg() {
-    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && makepkg --config ../makepkg.conf --skippgpcheck $*" $BUILD_USER
+    chroot $BUILD_ROOT su -lc "source /etc/profile; cd $TOPDIR/SOURCES && LANG=en_US.UTF-8 makepkg --config ../makepkg.conf --skippgpcheck $*" $BUILD_USER
 }

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -26,8 +26,13 @@
 
 Name:           %{__pkg_name}
 Summary:        A Script to Build SUSE Linux RPMs
+%if 0%{?mageia}
+License:        GPLv2+
+Group:          Development/Tools
+%else
 License:        GPL-2.0-only OR GPL-3.0-only
 Group:          Development/Tools/Building
+%endif
 Version:        20200131
 Release:        0
 Source:         obs-build-%{version}.tar.gz
@@ -55,6 +60,10 @@ BuildRequires:  perl(Test::More)
 Requires:       perl-MD5
 Requires:       perl-TimeDate
 BuildRequires:  perl-TimeDate
+%endif
+# On Mageia tests need this package to be successful
+%if 0%{?mageia}
+BuildRequires:  perl(YAML::PP)
 %endif
 Conflicts:      bsdtar < 2.5.5
 BuildRequires:  perl(Date::Parse)


### PR DESCRIPTION
- Tests fail in %check phase of build process on Mageia GNU Linux due to missing perl(YAML::PP) package. This commit adds missing build requires. (Also see declined 900291 submit request on OBS)
- Both License and Group tags are incompatible with Mageia packaging system. This commit fixes also this issue