### PR TITLE
Add ability to use file:/// uri's

### DIFF
--- a/build
+++ b/build
@@ -273,7 +273,7 @@ Known Parameters:
               Use sccache to speed up rebuilds. Conflicts with --ccache.
 
   --sccache-uri
-              Optional URI for remote sccache storage. Implies --sccache.
+              Optional URI for remote or archive sccache storage. Implies --sccache.
 
   --icecream N
               Use N parallel build jobs with icecream
@@ -563,6 +563,14 @@ setupsccache() {
         echo "SCCACHE_URI=${SCCACHE_URI}"
         if [[ ${SCCACHE_URI} = redis* ]] ; then
             echo "export SCCACHE_REDIS=${SCCACHE_URI}" >> "$BUILD_ROOT"/etc/profile.d/build_sccache.sh
+        fi
+        if [[ ${SCCACHE_URI} = file* ]] ; then
+            FILE_URI=${SCCACHE_URI:7}
+            mkdir -p "$BUILD_ROOT/.sccache"
+            test -e ${FILE_URI} && tar -xf ${FILE_URI} -C "$BUILD_ROOT/.sccache"
+            chown -R "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT/.sccache"
+            echo 'export SCCACHE_DIR="/.sccache"' >> "$BUILD_ROOT"/etc/profile.d/build_sccache.sh
+            echo 'export SCCACHE_CACHE_SIZE="8G"' >> "$BUILD_ROOT"/etc/profile.d/build_sccache.sh
         fi
         # Display sccache status at the start of the build.
         chroot $BUILD_ROOT su -c "sccache -s" - $BUILD_USER
@@ -1724,6 +1732,11 @@ fi
 if test -n "$SCCACHE" ; then
     # Display sccache statistics post build.
     chroot $BUILD_ROOT su -c "sccache -s" - $BUILD_USER
+    # wbrown - archive local sccache if file backed.
+    if [[ ${SCCACHE_URI} = file* ]] ; then
+        FILE_URI=${SCCACHE_URI:7}
+        tar -a -cf ${FILE_URI} -C "$BUILD_ROOT/.sccache" .
+    fi
 fi
 
 exitcode=0


### PR DESCRIPTION
This allows tar's to be used as uris in sccache, where the tar will be extracted to the build root, and subsequently extracted from the root to the original URI for persistence. 