### PR TITLE
build-recipe-dsc: avoid publishing duplicate dsc files

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -114,9 +114,9 @@ dsc_build() {
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
     DSC_BUILD_CMD="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" substitute dsc:build_cmd)"
-    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc"
+    test -z "$DSC_BUILD_CMD" && DSC_BUILD_CMD="dpkg-buildpackage -us -uc -b"
     if test -e $buildroot/$TOPDIR/SOURCES/build.script ; then
-	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc'"
+	echo "Sourcing build.script to build - it should normally run 'dpkg-buildpackage -us -uc -b'"
 	DSC_BUILD_CMD="source $TOPDIR/SOURCES/build.script"
 	chmod +x $buildroot/$TOPDIR/SOURCES/build.script
     fi
@@ -124,7 +124,7 @@ dsc_build() {
     chroot $buildroot su -c "export DEB_BUILD_OPTIONS=${DSC_BUILD_OPTIONS} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
     if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
 	DEB_CHANGESFILE=${DEB_DSCFILE%.dsc}$OBS_DCH_RELEASE"_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes"
-	chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
+	chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE $DEB_SOURCEDIR/$DEB_DSCFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false
     fi
 }
 


### PR DESCRIPTION
With "OBS-DCH-RELEASE: 1" set two *.dsc files might be published,
which seems to confuse the src_server or scheduler and avoids
correct triggering of rebuilds.

This is most probably an unintended behavior change introduced by
d995de1d71e33.