### PR TITLE
build-pkg-rpm: Disable checking file digests on CentOS Stream 9+

### DIFF
--- a/build-pkg-rpm
+++ b/build-pkg-rpm
@@ -71,6 +71,8 @@ rpm_set_checkopts() {
     # on Fedora 10 rpmbuild is in a separate package so we need something else to
     # detect rpm4
     test -x $BUILD_ROOT/usr/bin/rpmquery && RPMCHECKOPTS="--nodigest --nosignature"
+    # XXX: HACK: CentOS Stream 9 currently fails when file digests are checked, not sure why...
+    test -f $BUILD_ROOT/etc/os-release && . $BUILD_ROOT/etc/os-release && [ "$ID" = "centos" ] && [ "$VERSION_ID" -ge "9" ] && RPMCHECKOPTS="$RPMCHECKOPTS --nofiledigest"
 }
 
 rpm_init_cumulate() {


### PR DESCRIPTION
For some reason, rpm cannot install the packages without disabling
file digests, despite this working with Fedora Linux 34. It may have
something to do with RHEL/CentOS Stream 9 having IMA signatures,
which is the only major difference between CentOS Stream 9 and
Fedora Linux 34.

For the time being, this at least makes it work...

Fixes #721.