### PR TITLE
init_buildsystem: make /etc/mtab a symlink

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -1166,9 +1166,7 @@ cd $BUILD_ROOT || cleanup_and_exit 1
 #
 # setup /etc/mtab
 #
-rm -f $BUILD_ROOT/etc/mtab
-cp /proc/mounts $BUILD_ROOT/etc/mtab
-chmod 644 $BUILD_ROOT/etc/mtab
+ln -sf ../proc/self/mounts $BUILD_ROOT/etc/mtab
 
 #
 # make sure that our nis is not present in the chroot system


### PR DESCRIPTION
/etc/mtab of the build root should be a symlink of /proc/self/mounts,
like on a real root, to reflect the actual mount status instead of the
static (outdated) information of when the build root is started. One
Known failure due to outdated mount inforamtion is when executing the
tests of ostree package, which calls fusermount command, which checks
/etc/mtab. This is also reported in isseu #535.

Signed-off-by: Kai Liu <kai.liu@suse.com>