### PR TITLE
build-vm allow overwriting kernel cmdline params

### DIFF
--- a/build
+++ b/build
@@ -382,7 +382,9 @@ Known Parameters:
 
   --vm-kernel FILE
   --vm-initrd FILE
+  --vm-cmdline STRING
               Kernel and initrd to use for VM (kvm and qemu only)
+              Cmdline to specify additional arguments
 
   --vm-user   USERNAME
               User name to run qemu/kvm process

--- a/build-vm
+++ b/build-vm
@@ -38,6 +38,7 @@ VM_ROOT_TYPE=
 VM_SWAP_TYPE=
 VM_KERNEL=
 VM_INITRD=
+VM_CMDLINE=
 VM_WORKER=
 VM_SERVER=
 # the qemu default size is not able to run our default kernel anymore
@@ -199,6 +200,11 @@ vm_parse_options() {
       -vm-initrd)
 	needarg
 	VM_INITRD="$ARG"
+	shift
+      ;;
+      -vm-cmdline)
+	needarg
+	VM_CMDLINE="$ARG"
 	shift
       ;;
       -vm-disk-size|-vmdisk-rootsize)
@@ -1013,6 +1019,9 @@ vm_first_stage() {
 	    cp "$BUILD_ROOT/.build.kernel.$vm_type" "$KERNEL_TEMP_DIR/kernel"
 	    if test -f "$BUILD_ROOT/.build.initrd.$vm_type" -a ! -L "$BUILD_ROOT/.build.initrd.$vm_type" ; then
 	        cp "$BUILD_ROOT/.build.initrd.$vm_type" "$KERNEL_TEMP_DIR/initrd"
+	    fi
+	    if test -f "$BUILD_ROOT/.build.cmdline.$vm_type" -a ! -L "$BUILD_ROOT/.build.cmdline.$vm_type" ; then
+	        vm_cmdline="$(cat $BUILD_ROOT/.build.cmdline.$vm_type)"
 	    fi
 	fi
 	check_exit

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -63,6 +63,7 @@ vm_verify_options_kvm() {
 
     vm_kernel=
     vm_initrd=
+    vm_cmdline=
     
     # newer Ubuntu versions have only kvm executable
     if test -x "/usr/bin/kvm" -a ! -x "$kvm_bin"; then
@@ -177,6 +178,7 @@ vm_verify_options_kvm() {
 
     # set initrd
     test -n "$VM_INITRD" && vm_initrd="$VM_INITRD"
+    test -n "$VM_CMDLINE" && vm_cmdline="$VM_CMDLINE"
     if test -z "$vm_initrd" ; then
 	# find a nice default
 	if test -e /boot/initrd.obs.guest ; then
@@ -295,6 +297,9 @@ vm_startup_kvm() {
             ;;
     esac
 
+    if test -n "$vm_cmdline" ; then
+        vm_linux_kernel_parameter="$vm_cmdline"
+    fi
     if test -n "$BUILD_JOBS" -a "$icecream" = 0 -a -z "$BUILD_THREADS" ; then
 	qemu_args=("${qemu_args[@]}" "-smp" "$BUILD_JOBS")
     elif test -n "$BUILD_JOBS" -a -n "$BUILD_THREADS" ; then

--- a/configs/sle15.4.conf
+++ b/configs/sle15.4.conf
@@ -1,0 +1,1 @@
+sles15sp4.conf

--- a/configs/sles15sp4.conf
+++ b/configs/sles15sp4.conf
@@ -1,0 +1,890 @@
+
+%define gcc_version 7
+
+Substitute: kiwi python3-kiwi
+
+Substitute: kiwi-packagemanager:instsource product-builder-plugin-SLE_15
+Substitute: system-packages:kiwi-product product-builder
+Substitute: kiwi-packagemanager: kiwi-packagemanager:zypper
+
+%ifarch s390
+Substitute: valgrind
+Substitute: valgrind-devel
+Substitute: pkgconfig(valgrind)
+%endif
+%ifarch s390 s390x
+Substitute: libunwind-devel
+Substitute: pkgconfig(libunwind)
+%endif
+
+%ifarch s390 s390x
+Ignore: libsensors4-devel
+%endif
+
+%define _without_mono          1
+Macros:
+%_without_mono          1
+:Macros
+
+Prefer: rpm
+Prefer: lua53 liblua5_3-5 lua53-devel libtolua++-5_3-devel
+Prefer: -liblua5_3 -liblua5_1 -liblua5_2
+
+Preinstall: aaa_base attr bash coreutils diffutils
+Preinstall: filesystem fillup glibc grep
+Preinstall: libbz2-1 libgcc_s1 libncurses6 pam
+Preinstall: permissions libreadline7 rpm sed tar libz1 libselinux1
+Preinstall: liblzma5 libcap2 libacl1 libattr1
+Preinstall: libpopt0 libelf1 liblua5_3-5
+Preinstall: libpcre1
+
+Runscripts: aaa_base
+
+Prefer: libdb-4_8-devel
+Prefer: cdrkit-cdrtools-compat genisoimage
+VMinstall: util-linux libmount1 perl-base libdb-4_8 libsepol1 libblkid1 libuuid1 libsmartcols1
+VMinstall: kernel-obs-build
+VMInstall: iproute2
+
+# Needed with latest rpm (Use libgcrypt as crypto library for SP2 [jsc#SLE-9552])
+Preinstall: libgcrypt20 libgpg-error0
+
+# Needed with latest rpm (Added zstd support in SLE-15-SP2 [bsc#1162668])
+Preinstall: libzstd1
+
+FileProvides: /bin/csh tcsh
+FileProvides: /bin/logger util-linux-systemd
+FileProvides: /sbin/netconfig sysconfig-netconfig
+FileProvides: /sbin/setcap libcap-progs
+FileProvides: /usr/bin/csh tcsh
+FileProvides: /usr/bin/docbook2man docbook-utils
+FileProvides: /usr/bin/eu-nm elfutils
+FileProvides: /usr/bin/fipscheck fipscheck
+FileProvides: /usr/bin/killall psmisc
+FileProvides: /usr/bin/mimencode metamail
+FileProvides: /usr/bin/mkisofs cdrkit-cdrtools-compat
+FileProvides: /usr/bin/pkg-config pkg-config
+FileProvides: /usr/bin/python python-base
+FileProvides: /usr/bin/setfacl acl
+FileProvides: /usr/bin/sg_inq sg3_utils
+FileProvides: /usr/bin/tput ncurses-utils
+FileProvides: /usr/bin/xmllint libxml2-tools
+FileProvides: /usr/bin/Xvfb xorg-x11-server
+FileProvides: /usr/sbin/groupadd shadow
+FileProvides: /usr/sbin/lockdev lockdev
+FileProvides: /usr/sbin/useradd shadow
+FileProvides: /usr/sbin/usermod shadow
+
+Required: rpm-build
+# Build all packages with -pie enabled
+Required: gcc-PIE
+
+# the basic stuff
+Support: perl
+Support: brp-check-suse post-build-checks rpmlint-Factory
+
+### Branding related preferences
+Prefer: awesome:awesome-branding-upstream
+Prefer: bundle-lang-gnome:gnome-session-branding-openSUSE
+Prefer: cinnamon-gschemas:cinnamon-gschemas-branding-upstream
+Prefer: enlightenment-theme-upstream
+Prefer: exo-data:exo-branding-upstream
+Prefer: fcitx:fcitx-branding-openSUSE
+Prefer: gdm:gdm-branding-upstream
+Prefer: gfxboot-branding-openSUSE -gfxboot-branding-basedonopensuse
+Prefer: glib2:glib2-branding-upstream
+Prefer: gnome-panel:gnome-panel-branding-upstream
+Prefer: gnome-session:gconf2-branding-openSUSE
+Prefer: gnome-session:gnome-session-branding-openSUSE
+Prefer: icewm-theme-branding
+Prefer: kde4-kdm:kde4-kdm-branding-upstream
+Prefer: kdebase4-workspace:kdebase4-workspace-branding-upstream
+Prefer: kdelibs4-branding:kdelibs4-branding-upstream
+Prefer: kdelibs4:kdelibs4-branding-upstream
+Prefer: kdm:kdm-branding-upstream
+Prefer: libcinnamon-desktop-data:libcinnamon-desktop-data-branding-upstream
+Prefer: libexo-1-0:libexo-1-0-branding-upstream
+Prefer: libgarcon-1-0:libgarcon-branding-upstream
+Prefer: libgarcon-data:libgarcon-branding-upstream
+Prefer: libgio-2_0-0:gio-branding-upstream
+Prefer: libglib-2_0-0:glib2-branding-upstream
+Prefer: libpurple-branding-upstream
+Prefer: libreoffice:libreoffice-branding-upstream
+Prefer: libsocialweb:libsocialweb-branding-upstream
+Prefer: libxfce4ui:libxfce4ui-branding-upstream
+Prefer: lightdm-gtk-greeter:lightdm-gtk-greeter-branding-upstream
+Prefer: mate-desktop-gschemas:mate-desktop-gschemas-branding-upstream
+Prefer: NetworkManager-branding-upstream
+Prefer: PackageKit:PackageKit-branding-upstream
+Prefer: plasma5-desktop:plasma5-desktop-branding-upstream
+Prefer: plasma5-workspace:plasma5-workspace-branding-upstream
+Prefer: sddm:sddm-branding-upstream
+Prefer: systemd-presets-branding-SLE
+Prefer: wallpaper-branding-openSUSE
+Prefer: xfce4-notifyd:xfce4-notifyd-branding-upstream
+Prefer: xfce4-settings:xfce4-settings-branding-upstream
+Prefer: xfdesktop:xfdesktop-branding-upstream
+Prefer: yast2-branding-openSUSE
+Prefer: yast2-qt:yast2-qt-branding-openSUSE
+Prefer: yast2-theme-openSUSE
+
+# Build cycle handling - prefer -mini packages were possible, break deps as needed
+
+Conflict: krb5-devel:krb5-mini
+Conflict: krb5:krb5-mini-devel
+Prefer: gettext-tools-mini gettext-runtime-mini
+Prefer: ghostscript-mini
+Prefer: krb5-mini-devel:krb5-mini
+Prefer: krb5-mini krb5-mini-devel
+Prefer: libudev-mini-devel libudev-mini1 udev-debuginfo libudev1-debuginfo
+Prefer: libunbound-devel-mini
+Prefer: log4j-mini
+Prefer: systemd-mini-devel:systemd-mini
+Prefer: systemd-mini systemd-mini-devel libsystemd0-mini
+Prefer: udev-mini libcom_err2-mini libext2fs2-mini
+Prefer: -harfbuzz-bootstrap -harfbuzz-bootstrap-devel
+
+# break dependency of the -mini packages: they are valid for OBS, but not for end-user-installation
+Ignore: erlang-rebar-obs:this-is-only-for-build-envs
+Ignore: harfbuzz-bootstrap:this-is-only-for-build-envs
+Ignore: jdk-bootstrap:this-is-only-for-build-envs
+Ignore: libsystemd0-mini:this-is-only-for-build-envs
+Ignore: libudev-mini1:this-is-only-for-build-envs
+Ignore: libunbound-devel-mini:this-is-only-for-build-envs
+Ignore: systemd-mini:this-is-only-for-build-envs
+Ignore: udev-mini:this-is-only-for-build-envs
+Ignore: curl-mini:this-is-only-for-build-envs
+Ignore: libcurl-mini-devel:this-is-only-for-build-envs
+Ignore: libcurl4-mini:this-is-only-for-build-envs
+
+# Ring0 packages should not pull in 'info' - making the base VM smaller
+Ignore: binutils:info
+Ignore: bison:info
+Ignore: coreutils:info
+Ignore: cpio:info
+Ignore: diffutils:info
+Ignore: findutils:info
+Ignore: flex:info
+Ignore: gawk:info
+Ignore: gettext-runtime:info
+Ignore: gettext-tools:info
+Ignore: grep:info
+Ignore: groff:info
+Ignore: gzip:info
+Ignore: help2man:info
+Ignore: libgcrypt-devel:info
+Ignore: m4:info
+Ignore: make:info
+Ignore: sed:info
+Ignore: tar:info
+Ignore: util-linux:info
+Ignore: which:info
+
+# Let's speed up things: We don't need Mesa-dri and Mesa-gallium in the build system
+Ignore: Mesa:Mesa-dri
+Ignore: Mesa:Mesa-gallium
+
+# When kiwi comes into play, we do not want the -mini packages; -mini does not target end user systems
+Conflict: kiwi:curl-mini
+Conflict: kiwi:libudev-mini1
+Conflict: kiwi:systemd-mini
+
+# udev: -full and -mini packages don't mingle well
+Prefer: libudev1:udev
+Conflict: libudev1:udev-mini
+Conflict: udev:libudev-mini1
+
+# systemd: -full and -mini packages don't mingle well
+Conflict: systemd:libsystemd0-mini
+Conflict: systemd-mini-devel:systemd
+
+# curl: there is a -mini package to bootstrap and a full; some programs decide on what they want to build in based on what curl can do, so let's prefer full curl
+Prefer: -curl-mini -libcurl-mini-devel -libcurl4-mini
+
+#Prefer: -openSUSE-build-key
+# Set postfix as the 'default' smtp_daemon (virtual symbol provided by all MTAs)
+Prefer: postfix
+# Give the worker any default apache2-MPM for apache2- chosing 'prefork' (alternatives are -event and -worker, dep-wise they are equal)
+
+# prefer the PHP5 variants over PHP7
+Prefer: php5-ctype
+Prefer: php5-devel
+Prefer: php5-dom
+Prefer: php5-ftp
+Prefer: php5-gd
+Prefer: php5-gettext
+Prefer: php5-mbstring
+Prefer: php5-pear
+Prefer: php5-pear-Archive_Tar
+Prefer: php5-pear-Horde
+Prefer: php5 php5-json
+Prefer: php5-tokenizer
+Prefer: php5-zip
+
+# go exists in mutliple versions by now - we prefer the 'unversioned package'
+Prefer: go
+
+# python([23])-pep8 is provided by python\1-pep8 and python\1-pycodestyle - favoring 'the real one'
+Prefer: python2-pep8 python3-pep8
+
+# When perl provides a module that is also in a different package, but the consumer specifies no version, we go with perl
+Prefer: perl
+
+# Assist migration to python-pycups (python3-cups is going to be removed)
+Prefer: python3-pycups python-pycups
+
+# Apache requires a MPM - we pick prefork
+Prefer: apache2:apache2-prefork
+
+# for symbol syslog (syslogd is best as it has the least dependencies)
+Prefer: syslogd
+
+# rmt is provided by tar-rmt and star-rmt - we prefer star-rmt, which was the one in the past providing rmt
+Prefer: star-rmt
+
+# A couple packares require a dbus daemon to show notifications - unless oterhwise specified, we prefer the 'standalong notification-daemon;
+Prefer: notification-daemon
+
+# Stuff that wants to have /etc/os-release available should require distribution-release, which we then offer dummy-release for (openSUSE-release changes daily for TW)
+Prefer: dummy-release
+
+# Tumbleweed ships nodejs4 for compatibility reasons - but it's not the preferred version
+Prefer: -nodejs4
+
+# have choice for libpulse.so.0 needed by wine-32bit: apulse-32bit libpulse0-32bit - prefering the 'original'
+Prefer: libpulse0-32bit
+
+# do not used openmpi variant to build against netcdf
+Prefer: netcdf-devel
+
+# Below list still needs to be reviewed
+
+Prefer: xorg-x11-Xvnc:icewm
+Prefer: cracklib-dict-small
+Prefer: libstdc++6 libgcc_s1 libquadmath0
+Prefer: libstdc++6-32bit libstdc++6-64bit
+Prefer: libstdc++6-x86
+Prefer: libmpx2 libmpxwrappers2 libmpx2-32bit libmpxwrappers2-32bit
+%ifarch s390x
+Prefer: -libstdc++41
+%endif
+Prefer: syslog-service
+Prefer: poppler-tools
+Prefer: libjpeg8-devel libjpeg-turbo
+Prefer: microcode_ctl:kernel-default
+Prefer: gnu-jaf yast2-control-center-qt
+Prefer: vim-normal myspell-american wine
+Prefer: amarok:amarok-xine
+Prefer: kdenetwork3-vnc:tightvnc
+Prefer: libgweather0 jessie ndesk-dbus ndesk-dbus-glib tomcat-jsp-2_2-api tomcat-jsp-2_3-api tomcat-servlet-2_5-api
+Prefer: -dbus-1-nox11
+Prefer: -servletapi3 -servletapi4 -servletapi5
+Prefer: icewm-lite
+Prefer: yast2-ncurses-pkg
+Prefer: monodevelop: mono-addins
+Prefer: texlive-xmltex texlive-tools texlive-jadetex
+Prefer: libesd-devel:esound
+Prefer: libesd0:esound-daemon
+Prefer: package-lists-openSUSE-KDE-cd: esound-daemon
+Prefer: librest-0_7-0
+
+Prefer: rhino:xmlbeans-mini
+Prefer: -geronimo-jta-1_0_1B-api -geronimo-jms-1_1-api -geronimo-el-1_0-api -java-1_5_0-gcj-compat -geronimo-jta-1_1-api classpathx-mail
+Prefer: mx4j:log4j-mini
+
+Prefer: rpcbind  eclipse-source
+Prefer: libcdio_cdda0 libcdio_paranoia0
+Prefer: boo tog-pegasus
+Prefer: sysvinit(network) wicked-service
+Prefer: kdebase4-workspace:kdebase4-workspace-ksysguardd
+Prefer: kdebase4-openSUSE:kdebase4-workspace
+Prefer: ant:xerces-j2
+Prefer: dhcp-client:dhcp
+Prefer: libGLw1
+# provides typelib(St)
+Prefer: -cinnamon
+Prefer: -bundle-lang-kde-de -bundle-lang-kde-en -bundle-lang-kde-es
+Prefer: -bundle-lang-kde-fr -bundle-lang-kde-pt -bundle-lang-kde-el
+Prefer: -bundle-lang-kde-zh -bundle-lang-kde-ja -bundle-lang-kde-ru -bundle-lang-kde-pl
+Prefer: -bundle-lang-kde-sv -bundle-lang-kde-ko -bundle-lang-kde-fi -bundle-lang-kde-da
+Prefer: -bundle-lang-kde-cs -bundle-lang-kde-nl -bundle-lang-kde-hu -bundle-lang-kde-nb
+Prefer: -bundle-lang-kde-it -bundle-lang-kde-ca -bundle-lang-kde-ar
+Prefer: -bundle-lang-gnome-es -bundle-lang-gnome-de -bundle-lang-gnome-fr
+Prefer: -bundle-lang-gnome-pt -bundle-lang-gnome-en -bundle-lang-gnome-el
+Prefer: -bundle-lang-gnome-zh -bundle-lang-gnome-ja -bundle-lang-gnome-ru -bundle-lang-gnome-cs
+Prefer: -bundle-lang-gnome-ko -bundle-lang-gnome-da -bundle-lang-gnome-nl -bundle-lang-gnome-hu
+Prefer: -bundle-lang-gnome-pl -bundle-lang-gnome-fi -bundle-lang-gnome-nb -bundle-lang-gnome-sv
+Prefer: -bundle-lang-gnome-it -bundle-lang-gnome-ca -bundle-lang-gnome-ar
+Prefer: -bundle-lang-gnome-extras-es -bundle-lang-gnome-extras-de -bundle-lang-gnome-extras-fr
+Prefer: -bundle-lang-gnome-extras-pt -bundle-lang-gnome-extras-en -bundle-lang-gnome-extras-el
+Prefer: -bundle-lang-gnome-extras-zh -bundle-lang-gnome-extras-ja -bundle-lang-gnome-extras-ru -bundle-lang-gnome-extras-cs
+Prefer: -bundle-lang-gnome-extras-ko -bundle-lang-gnome-extras-da -bundle-lang-gnome-extras-nl -bundle-lang-gnome-extras-hu
+Prefer: -bundle-lang-gnome-extras-pl -bundle-lang-gnome-extras-fi -bundle-lang-gnome-extras-nb -bundle-lang-gnome-extras-sv
+Prefer: -bundle-lang-gnome-extras-it -bundle-lang-gnome-extras-ca -bundle-lang-gnome-extras-ar
+Prefer: -bundle-lang-common-es -bundle-lang-common-de -bundle-lang-common-fr
+Prefer: -bundle-lang-common-pt -bundle-lang-common-en -bundle-lang-common-el
+Prefer: -bundle-lang-common-ja -bundle-lang-common-zh -bundle-lang-common-cs -bundle-lang-common-ru
+Prefer: -bundle-lang-common-nl -bundle-lang-common-hu -bundle-lang-common-pl -bundle-lang-common-da
+Prefer: -bundle-lang-common-ko -bundle-lang-common-nb -bundle-lang-common-fi -bundle-lang-common-sv
+Prefer: -bundle-lang-common-it -bundle-lang-common-ca -bundle-lang-common-ar
+Prefer: -libgcc-mainline -libstdc++-mainline -gcc-mainline-c++
+Prefer: -libgcj-mainline -viewperf -compat -compat-openssl097g
+Prefer: -libreoffice -pam-laus -libgcc-tree-ssa -busybox-links
+Prefer: -python-setuptools
+Prefer: -kdenetwork3-InstantMessenger
+Prefer: -icc-profiles
+Prefer: vala
+# in doubt, take xerces
+Prefer: -crimson
+# in doubt, take higher versions
+Prefer: -rubygem-rack-1_1 -rubygem-rack-1_2 -rubygem-rack-1_3 -rubygem-tilt-1_1 -rubygem-rack-1_4
+Prefer: -rubygem-method_source-0_7 -rubygem-rails-2_3 -rubygem-activerecord-2_3
+Prefer: -rubygem-json_pure-1_5
+Prefer: geronimo-servlet-2_4-api
+Prefer: -libhdf5-0-openmpi -libhdf5_hl0-openmpi -libhdf5_hl8-openmpi -libhdf5-8-openmpi -libhdf5_hl9-openmpi -libhdf5-9-openmpi -libhdf5-10-openmpi -libhdf5_hl10-openmpi -libhdf5-11-openmpi -libhdf5_hl11-openmpi -libhdf5-100-openmpi -libhdf5_hl100-openmpi
+# python-scimpy: have choice for fftw-devel: fftw3-devel fftw3_3_3_6-gnu-hpc-devel fftw3_3_...
+Prefer: fftw3-devel
+# prefer the small systemd for building
+Prefer: star
+Prefer: xmlgraphics-commons:apache-commons-io
+# the -32bit stuff provides things it shouldn't (hopefully temporary)
+Prefer: -typelib-1_0-GdkPixbuf-2_0-32bit -typelib-1_0-Pango-1_0-32bit -glib2-devel-32bit
+Prefer: -typelib-1_0-GdkPixbuf-2_0-64bit -typelib-1_0-Pango-1_0-64bit -glib2-devel-64bit
+Prefer: postgresql postgresql-server postgresql-devel
+Prefer: -unzip-rcc
+Prefer: -primus -primus-32bit
+Prefer: -staging-build-key
+Prefer: -sssd-wbclient
+Prefer: -clutter-gst-devel
+Prefer: -opencv-qt5-devel
+# ffmpeg and its fork libav both provide libswscale; prefer the 'original' ffmpeg
+Prefer: -libswscale-libav-devel -libavformat-libav-devel -libavresample-libav-devel -libavcodec-libav-devel -libavdevice-libav-devel -libavfilter-libav-devel -libpostproc-libav-devel -libavutil-libav-devel
+Prefer: -ffmpeg2-devel -python-configparser2
+# as long as kactivities4 exists and is provided
+Prefer: kactivities5
+# oxygen5-icon-theme osboletes oxygen-icon-theme
+Prefer: oxygen5-icon-theme
+Prefer: npm6
+
+# kernel bug (coolo)
+Prefer: kernel-default-devel
+
+# have choice for mysql-devel: libmariadb-devel libmysqlclient-devel
+#    Prefer: libmariadb-devel 
+Prefer: libmysqlclient-devel 
+
+Prefer: wxWidgets-3_0-devel
+Prefer: libopenssl-devel
+
+Prefer: -NX -xaw3dd -db43
+Prefer: -xerces-j2-xml-resolver -xerces-j2-xml-apis
+Prefer: libgcc_s1 libgcc_s1-32bit libgcc_s1-64bit
+Prefer: libffi-devel
+Prefer: libatomic1 libcilkrts5 libitm1 liblsan0 libtsan0 libubsan0
+Prefer: libatomic1-32bit libcilkrts5-32bit libitm1-32bit libubsan0-32bit
+Prefer: libatomic1-64bit libcilkrts5-64bit libitm1-64bit libubsan0-64bit
+Prefer: libgcc_s1-x86 libgcj_bc1
+Prefer: libgomp1 libgomp1-32bit libgomp1-64bit
+Prefer: libmudflap4 libmudflap4-32bit libmudflap4-64bit
+Prefer: libobjc4 libgfortran3 libquadmath0
+Prefer: -libnetpbm -libcdio7-mini -libiso9660-5-mini -libiso9660-7-mini -libcdio10-mini -libcdio12-mini
+Prefer: -libcdio-mini -faac-mini -libcdio-mini-devel
+Prefer: -seamonkey
+Prefer: -libdb-4_4-devel -libdb-4_5-devel -libevoldap-2_4-2
+Prefer: libopenal0-soft openal-soft -lsb-buildenv
+Prefer: -libevent
+Prefer: gnu-crypto libusb-compat-devel
+Prefer: libusb-0_1-4
+Prefer: libreoffice:xerces-j2
+Prefer: k3b:libdvdread4
+Prefer: glibc-devel
+Prefer: -libpcap -libiniparser -loudmouth -libkonq4 -libnetcdf-4
+Prefer: NetworkManager:dhcp-client
+Prefer: kdebase3-SuSE:kdebase3
+Prefer: pcre-tools
+Prefer: libpopt0 makeinfo
+Prefer: -apache2-mod_perl -otrs -qa_apache_testsuite -ctcs2
+Prefer: libgnome-keyring-devel
+Prefer: gnome-keyring-32bit
+Prefer: linux-glibc-devel
+Prefer: squid sysvinit
+Prefer: libpng16-compat-devel
+Prefer: -python3 -python3-gobject-devel -python3-gobject2-devel -x11-video-fglrxG02 -libpng12-0
+Prefer: python3-docutils
+Prefer: perl-Mail-SPF:perl-Error libldb0 -audit-libs mysql-community-server mysql-community-server-client
+#needed because new xml-commons package
+Prefer: xml-commons-resolver12 xml-commons-jaxp-1.3-apis
+Prefer: xmlgraphics-fop:xerces-j2
+Prefer: cogl-devel
+Prefer: -perl-XML-SAX perl-Test-YAML -perl-Pod-Usage
+Prefer: libpsm2-compat
+# choice p11-kit-nss-trust
+Prefer: mozilla-nss-certs
+# amarok dependency resolution
+Prefer: phonon-backend-gstreamer
+# replacing mkinitrd
+Prefer: dracut
+# replacing module-init-tools
+Prefer: kmod-compat
+# Temporary
+Prefer: oxygen5-cursors
+# Temporary
+Prefer: -perl-App-cpanminus
+# libmediaart is prepared for a larger update; for now favor mediaart-1.0
+Prefer: -typelib-1_0-MediaArt-2_0
+Prefer: -typelib-1_0-Gtk-2_0 -typelib-1_0-Gtk-4_0
+Prefer: -python-atspi
+Prefer: gettext-its-gtk3 gtk3-schema
+# for pkgconfig(ijs) and no one actually rely on ghostscript-mini-devel in Factory
+Prefer: ghostscript-devel
+# for pkgconfig(libotf) libotf-devel and libotf-devel-32bit both provides it
+Prefer: libotf-devel
+
+Ignore: installation-images-openSUSE:cracklib-dict-full
+Ignore: systemd-sysvinit:systemd
+Ignore: openSUSE-release:openSUSE-release-ftp,openSUSE-release-dvd5,openSUSE-release-biarch,openSUSE-release-livecdkde,openSUSE-release-livecdgnome
+Ignore: cracklib:cracklib-dict
+Ignore: aaa_base:aaa_skel,suse-release,logrotate,ash,distribution-release,udev
+Ignore: sysvinit:mingetty
+Ignore: gettext-tools:libgcj,libstdc++-devel,libgcj41,libstdc++41-devel,libgcj42,libstdc++42-devel
+Ignore: libgcj43,libstdc++43-devel
+Ignore: libgcj44,libstdc++44-devel
+Ignore: libgcj45,libstdc++45-devel
+Ignore: libgcj46,libstdc++46-devel
+Ignore: libgcj47,libstdc++47-devel
+Ignore: librtas:util-linux
+Ignore: pwdutils:openslp
+Ignore: rpm:suse-build-key,build-key
+Ignore: cloud-init:cloud-init-config
+# python-pyudev requires libudev1 in normal situations
+Ignore: python-pyudev:libudev1
+Ignore: python-SPARQLWrapper:python-rdflib
+Ignore: python3-SPARQLWrapper:python3-rdflib
+Ignore: bind-utils:bind-libs
+Ignore: portmap:syslogd
+Ignore: xorg-x11:x11-tools,resmgr,xkeyboard-config,xorg-x11-Mesa,libusb,freetype2,libjpeg,libpng
+Ignore: xorg-x11-server:xorg-x11-driver-input,xorg-x11-driver-video
+Ignore: apache2:logrotate
+Ignore: arts:alsa,audiofile,resmgr,libogg,libvorbis
+Ignore: kdelibs3:alsa,arts,OpenEXR,aspell,cups-libs,mDNSResponder-lib,krb5,libjasper
+Ignore: kdelibs3-devel:libvorbis-devel
+Ignore: kdebase3:kdebase3-ksysguardd,OpenEXR,dbus-1,dbus-1-qt,hal,powersave,openslp,libusb
+Ignore: kdebase3-SuSE:release-notes
+Ignore: jack:alsa,libsndfile
+Ignore: libxml2-devel:readline-devel
+Ignore: gnome-vfs2:gnome-mime-data,desktop-file-utils,cdparanoia,dbus-1,dbus-1-glib,hal,libsmbclient,fam,file_alteration
+Ignore: libgda:file_alteration
+Ignore: gnutls:lzo,libopencdk
+Ignore: gnutls-devel:lzo-devel,libopencdk-devel
+Ignore: pango:cairo,glitz,libpixman,libpng
+Ignore: pango-devel:cairo-devel
+Ignore: cairo-devel:libpixman-devel
+Ignore: libgnomeprint:libgnomecups
+Ignore: libgnomeprintui:libgnomecups
+Ignore: orbit2-devel:indent
+Ignore: qt3:libmng
+Ignore: qt-sql:qt_database_plugin
+Ignore: libgnomecanvas-devel:glib-devel
+Ignore: libgnomeui:gnome-icon-theme,shared-mime-info
+Ignore: scrollkeeper:docbook_4
+Ignore: gnome-desktop:libgnomesu,startup-notification
+Ignore: python-devel:python-tk
+Ignore: libgtk-3-0:adwaita-icon-theme
+Ignore: libgtk-3-0:gdk-pixbuf-loader-rsvg
+Ignore: samba-libs:krb5
+Ignore: libbonoboui:gnome-desktop
+Ignore: libxfce4ui-1-0:exo-tools
+Ignore: docbook_4:iso_ent,xmlcharent
+Ignore: control-center2:nautilus,evolution-data-server,gnome-menus,gstreamer-plugins,gstreamer,metacity,mozilla-nspr,mozilla,libxklavier,gnome-desktop,startup-notification
+Ignore: docbook-xsl-stylesheets:xmlcharent
+Ignore: liby2util-devel:libstdc++-devel,openssl-devel
+Ignore: yast2:yast2-ncurses,yast2_theme,perl-Config-Crontab,yast2-xml,SuSEfirewall2
+Ignore: yast2-core:netcat,hwinfo,wireless-tools,sysfsutils
+Ignore: yast2-core-devel:libxcrypt-devel,hwinfo-devel,blocxx-devel,sysfsutils,libstdc++-devel
+Ignore: yast2-packagemanager-devel:rpm-devel,curl-devel,openssl-devel
+Ignore: yast2-devtools:libxslt
+Ignore: yast2-iscsi-lio-server:lio-utils
+Ignore: yast2-installation:yast2-update,yast2-mouse,yast2-country,yast2-bootloader,yast2-packager,yast2-network,yast2-online-update,yast2-users,release-notes,autoyast2-installation
+Ignore: yast2-bootloader:bootloader-theme
+Ignore: yast2-packager:yast2-x11,libyui_pkg
+Ignore: autoyast2:yast2-schema
+# not during build
+Ignore: yui_backend
+Ignore: yast2-x11:sax2-libsax-perl
+Ignore: yast2-network:yast2-inetd
+Ignore: openslp-devel:openssl-devel
+Ignore: tetex:xorg-x11-libs,expat,fontconfig,freetype2,libjpeg,ghostscript-x11,xaw3d,gd,dialog,ed
+Ignore: texlive-bin:ghostscript-x11
+Ignore: texlive-bin-omega:ghostscript-x11
+Ignore: yast2-country:yast2-trans-stats
+Ignore: tpb:tpctl-kmp
+Ignore: tpctl:tpctl-kmp
+Ignore: zaptel:zaptel-kmp
+Ignore: mkinitrd:pciutils
+Ignore: pciutils:pciutils-ids
+Ignore: postfix:iproute2
+Ignore: aaa_base:systemd
+Ignore: gpm:systemd
+Ignore: openssh:systemd
+Ignore: cronie:systemd
+Ignore: systemd:kbd
+Ignore: systemd:kmod
+Ignore: systemd:systemd-presets-branding
+Ignore: systemd:dbus-1
+Ignore: systemd:pam-config
+Ignore: systemd:udev
+Ignore: pesign:systemd
+Ignore: logrotate:cron
+Ignore: texlive-filesystem:cron
+Ignore: xinit:xterm
+Ignore: xdm:xterm
+Ignore: gnome-control-center:gnome-themes-accessibility
+
+
+Ignore: man:groff-full
+Ignore: git-core:rsync
+Ignore: apache2:systemd
+Ignore: icewm-lite:icewm
+Ignore: cluster-glue:sudo
+Ignore: libgcc:glibc-32bit
+Ignore: libgcc41:glibc-32bit
+Ignore: libgcc42:glibc-32bit
+Ignore: libgcc43:glibc-32bit
+Ignore: libgcc44:glibc-32bit
+Ignore: libgcc45:glibc-32bit
+Ignore: libgcc46:glibc-32bit
+Ignore: libgcc47:glibc-32bit
+Ignore: libstdc++:glibc-32bit
+Ignore: libstdc41++:glibc-32bit
+Ignore: libstdc42++:glibc-32bit
+Ignore: libstdc43++:glibc-32bit
+Ignore: libstdc44++:glibc-32bit
+Ignore: libstdc45++:glibc-32bit
+Ignore: libstdc46++:glibc-32bit
+Ignore: libstdc47++:glibc-32bit
+Ignore: ncurses-32bit
+
+Ignore: susehelp:susehelp_lang,suse_help_viewer
+Ignore: mailx:smtp_daemon
+Ignore: cron:smtp_daemon
+Ignore: hotplug:syslog
+Ignore: pcmcia:syslog
+Ignore: openct:syslog
+Ignore: postfix:sysvinit(syslog)
+Ignore: cups:sysvinit(syslog)
+Ignore: jython:servlet
+Ignore: ispell:ispell_dictionary,ispell_english_dictionary
+Ignore: aspell:aspel_dictionary,aspell_dictionary
+Ignore: smartlink-softmodem:kernel,kernel-nongpl
+Ignore: libreoffice-de:myspell-german-dictionary
+Ignore: libreoffice:libreoffice-i18n
+Ignore: libreoffice:libreoffice-icon-themes
+Ignore: mediawiki:php-session,php-gettext,php-zlib,php-mysql,mod_php_any
+Ignore: squirrelmail:mod_php_any,php-session,php-gettext,php-iconv,php-mbstring,php-openssl
+Ignore: perl-Log-Log4perl:rrdtool
+
+Ignore: simias:mono(log4net)
+Ignore: horde:mod_php_any,php-gettext,php-mcrypt,php-imap,php-pear-log,php-pear,php-session,php
+
+Ignore: xerces-j2:xml-commons-apis,xml-commons-resolver
+Ignore: xdg-menu:desktop-data
+Ignore: nessus-libraries:nessus-core
+Ignore: evolution:yelp
+Ignore: e17:e17-branding e17:e17-theme
+
+Ignore: mono-tools:mono(gconf-sharp),mono(glade-sharp),mono(gnome-sharp),mono(gtkhtml-sharp),mono(atk-sharp),mono(gdk-sharp),mono(glib-sharp),mono(gtk-sharp),mono(pango-sharp)
+Ignore: gecko-sharp2:mono(glib-sharp),mono(gtk-sharp)
+
+Ignore: vcdimager:libcdio.so.6,libcdio.so.6(CDIO_6),libiso9660.so.4,libiso9660.so.4(ISO9660_4)
+Ignore: libcdio:libcddb.so.2
+
+Ignore: coreutils:coreutils-lang
+Ignore: cpio:cpio-lang
+Ignore: glib2:glib2-lang
+Ignore: gtk2:gtk2-lang
+Ignore: gtk:gtk-lang
+Ignore: atk:atk-lang
+Ignore: MozillaThunderbird:pinentry-dialog
+Ignore: seamonkey:pinentry-dialog
+Ignore: pinentry:pinentry-dialog
+Ignore: gpg2:gpg2-lang
+Ignore: util-linux:util-linux-lang
+Ignore: suseRegister:distribution-release
+Ignore: compiz:compiz-decorator
+Ignore: icecream:gcc-c++
+Ignore: no
+Ignore: package
+Ignore: provides
+Ignore: j9vm/libjvm.so()(64bit)
+Ignore: kdepim3:suse_help_viewer
+Ignore: kdebase3-SuSE:kdebase3-SuSE-branding
+Ignore: kio_sysinfo:kdebase3-SuSE-branding
+Ignore: gnome-menus:gnome-menus-branding
+Ignore: epiphany:epiphany-branding
+Ignore: gnome-control-center:gnome-control-center-branding
+Ignore: phonon:phonon-backend
+Ignore: openwbem-devel
+Ignore: MozillaFirefox:MozillaFirefox-branding
+Ignore: yast2:yast2-branding
+Ignore: plymouth:plymouth-branding 
+Ignore: plymouth:suspend
+Ignore: yast2-qt:yast2-branding
+Ignore: yast2-theme-SLE:yast2-branding
+Ignore: yast2-registration:yast2-registration-branding
+Ignore: compiz:compiz-branding
+Ignore: texlive:perl-Tk texlive-bin:perl-Tk
+Ignore: xfce4-desktop:xfce4-desktop-branding
+Ignore: xfce4-panel:xfce4-panel-branding
+Ignore: xfce4-session:xfce4-session-branding
+Ignore: kdebase4-runtime:kdebase4-runtime-branding
+Ignore: kwin:kdebase4-workspace-branding
+Ignore: transmission-common:transmission-ui
+Ignore: sysvinit-tools:mkinitrd cifs-utils:mkinitrd
+Ignore: mkinitrd:sbin_init samba-client:cifs-utils
+Ignore: opensc:pinentry
+Ignore: gpg2:pinentry
+Ignore: NetworkManager:dhcp
+Ignore: NetworkManager:iproute2
+# sysconfig requires it at runtime, not buildtime
+Ignore: sysconfig:dbus-1
+Ignore: sysconfig:procps
+Ignore: sysconfig:iproute2
+Ignore: sysconfig-network:iproute2
+Ignore: sysconfig:tunctl
+Ignore: sysconfig:sysvinit(network)
+# no build dependencies
+Ignore: libksuseinstall1:yast2-packager
+Ignore: libksuseinstall1:zypper
+Ignore: syslog-service:logrotate
+Ignore: libglue-devel:cluster-glue
+Ignore: libqca2:gpg2
+Ignore: NetworkManager:wpa_supplicant
+Ignore: NetworkManager:dhcp-client
+Ignore: openSUSE-release:product_flavor(openSUSE)
+Ignore: libgio-2_0-0:dbus-1-x11
+Ignore: weather-wallpaper:inkscape
+Ignore: libgamin-1-0:gamin-server
+Ignore: libfam0-gamin:gamin-server
+Ignore: python3:python3-pip
+Ignore: avahi:sysvinit(network)
+Ignore: cluster-glue:sysvinit(network)
+Ignore: dracut:systemd-sysvinit
+# actually a workaround for installation-images requiring 
+# gettext-runtime-mini and getting conflict because systat
+# requires gettext (which is only provided by !-mini)
+Ignore: saptune:sysstat
+
+Macros:
+# RUBY - UNVERSIONED STUFF
+#
+# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
+#
+#  if you change any macros here you have to update the copy in the
+#  prjconf aswell.
+#
+# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
+#
+%rubygem() %{expand:%%{rubygems%rb_build_versions STOP %*}}
+%rubygemsSTOP() %nil
+%rubygemsxSTOP() %{expand:%%rubygemsxxSTOP -a %*}
+%rubygemsxxSTOP(a:) %{-a*}) %*
+
+%rubySTOP() %nil
+%rubyxSTOP() %*
+
+%ruby() %{expand:%%{ruby%rb_build_versions STOP %*}}
+
+%rubydevel() %{expand:%%{rubydevel%rb_build_versions STOP %*}}
+
+%rubydevelSTOP() %nil
+%rubydevelxSTOP() %*
+#
+
+#
+# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
+#
+#  if you change any macros here you have to update the copy in
+#  ruby2.5 aswell.
+#
+# IMPORTANT IMPORTANT IMPORTANT IMPORTANT  IMPORTANT IMPORTANT
+#
+%rubygemsruby25() rubygem(ruby:2.5.0:%{expand:%%rubygemsx%*} %{expand:%%{rubygems%*}}
+%rubygemsxruby25() %{expand:%%{rubygemsx%*}}
+
+%rubyruby25() ruby2.5 %{expand:%%rubyx%*} %{expand:%%{ruby%*}}
+%rubyxruby25() %{expand:%%{rubyx%*}}
+
+%rubydevelruby25() ruby2.5-devel %{expand:%%rubydevelx%*} %{expand:%%{rubydevel%*}}
+%rubydevelxruby25() %{expand:%%{rubydevelx%*}}
+
+
+### Things to define default ruby stuff for the distro
+%rb_default_ruby        ruby25
+%rb_default_ruby_suffix ruby2.5
+%rb_default_ruby_abi    ruby:2.5.0
+:Macros
+
+Macros:
+%rb_build_ruby_abis     ruby:2.5.0
+%rb_build_versions      ruby25
+
+%_with_ruby25               1
+:Macros
+
+%define rb_default_ruby        ruby25
+%define rb_default_ruby_suffix ruby2.5
+%define rb_default_ruby_abi    ruby:2.5.0
+
+%define rb_build_ruby_abis     ruby:2.5.0
+%define rb_build_versions      ruby25
+
+%define _with_ruby25         1
+
+Prefer: -ruby-stdlib
+Prefer: %{rb_default_ruby_suffix}-rubygem-gem2rpm
+Prefer: %{rb_default_ruby_suffix}-rubygem-ruby-dbus
+Prefer: %{rb_default_ruby_suffix}-rubygem-yard
+Prefer: %{rb_default_ruby_suffix}-rubygem-rspec
+Prefer: %{rb_default_ruby_suffix}-rubygem-yast-rake
+Prefer: %{rb_default_ruby_suffix}-rubygem-cheetah
+Prefer: %{rb_default_ruby_suffix}-rubygem-inifile
+Prefer: %{rb_default_ruby_suffix}-rubygem-bundler
+Prefer: %{rb_default_ruby_suffix}-rubygem-sass
+Prefer: %{rb_default_ruby_suffix}-rubygem-cfa
+Prefer: %{rb_default_ruby_suffix}-rubygem-mime-types
+
+# END RUBY STUFF
+
+# PYTHON STUFF
+
+Macros:
+%pythons  %{?!skip_python2:python2} %{?!skip_python3:python3}
+
+# This method for generating python_modules gets too deep to expand at about 5 python flavors.
+# It is replaced by a Lua macro in macros.lua
+# However, OBS has a much higher expansion depth, so this works fine.
+%python_module_iter(a:) %{-a*}-%{args} %{expand:%%{?!python_module_iter_%1:%%{python_module_iter -a%*}}}
+%python_module_iter_STOP stop
+%python_module() %{expand:%%define args %{**}} %{expand:%%{python_module_iter -a %{pythons} STOP}}
+
+%add_python() %{expand:%%define pythons %pythons %1}
+:Macros
+
+# END PYTHON STUFF
+
+Prefer: java-9-openjdk java-9-openjdk-devel java-9-openjdk-javadoc java-9-openjdk-headless
+# Prefer java 8 if java 9 was no option
+Prefer: java-1_8_0-openjdk java-1_8_0-openjdk-devel java-1_8_0-openjdk-javadoc java-1_8_0-openjdk-headless
+# And then fall back to jaba 7 if needed
+Prefer: java-1_7_0-openjdk java-1_7_0-openjdk-devel java-1_7_0-openjdk-javadoc java-1_7_0-openjdk-headless
+Substitute: java2-devel-packages java-devel
+
+%ifarch x86_64 ppc64 s390x sparc64
+Substitute: glibc-devel-32bit glibc-devel-32bit glibc-32bit
+%else
+ %ifarch ppc sparc sparcv9
+Substitute: glibc-devel-32bit glibc-devel-64bit
+ %else
+Substitute: glibc-devel-32bit
+ %endif
+%endif
+
+%ifarch %ix86
+Substitute: kernel-binary-packages kernel-default kernel-smp kernel-bigsmp kernel-debug kernel-xen
+%endif
+%ifarch ia64
+Substitute: kernel-binary-packages kernel-default kernel-debug
+%endif
+%ifarch x86_64
+Substitute: kernel-binary-packages kernel-default kernel-smp kernel-xen
+%endif
+%ifarch ppc
+Substitute: kernel-binary-packages kernel-default kernel-ppc64 kernel-ps3
+%endif
+%ifarch ppc64
+Substitute: kernel-binary-packages kernel-default kernel-ppc64
+%endif
+%ifarch s390
+Substitute: kernel-binary-packages kernel-s390
+%endif
+%ifarch s390x
+Substitute: kernel-binary-packages kernel-default
+%endif
+
+Optflags: i586 -fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches
+# no longer needed according to Richard Biener
+#  Optflags: i686 -fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches -fstack-protector
+Optflags: x86_64 -fmessage-length=0 -grecord-gcc-switches
+Optflags: ppc -fmessage-length=0 -grecord-gcc-switches
+Optflags: ppc64 -fmessage-length=0 -grecord-gcc-switches
+Optflags: ia64 -fmessage-length=0 -grecord-gcc-switches
+Optflags: s390 -fmessage-length=0 -grecord-gcc-switches
+Optflags: s390x -fmessage-length=0 -grecord-gcc-switches
+Optflags: armv7l -fmessage-length=0 -grecord-gcc-switches
+Optflags: armv7hl -fmessage-length=0 -grecord-gcc-switches
+Optflags: armv6l -fmessage-length=0 -grecord-gcc-switches
+Optflags: armv6hl -fmessage-length=0 -grecord-gcc-switches
+Optflags: aarch64 -fmessage-length=0 -grecord-gcc-switches
+Optflags: ppc64le -fmessage-length=0 -grecord-gcc-switches
+# need mcpu=ultrasparc to complete sparcv8plus to sparcv9 (adds, for example, atomic ops)
+Optflags: sparcv9 -fmessage-length=0 -grecord-gcc-switches -mcpu=ultrasparc
+Optflags: sparc64 -fmessage-length=0 -grecord-gcc-switches -mcpu=ultrasparc
+
+%ifarch armv7l armv7hl
+Target: armv7hl-suse-linux
+%endif
+
+Optflags: * -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection
+
+%define suse_version 1500
+%define sle_version 150400
+
+%define is_susecaasp 1
+%define is_susesap 1
+
+Macros:
+%suse_version 1500
+%sle_version 150400
+%is_susecaasp 1 
+%is_susesap 1
+
+%insserv_prereq insserv sed
+%fillup_prereq fillup coreutils grep diffutils
+%suseconfig_fonts_prereq perl aaa_base
+%install_info_prereq info
+%kernel_module_package_buildreq kmod-compat kernel-syms
+%kernel_module_package_buildreqs kmod-compat kernel-syms
+
+%sles_version 0
+%do_profiling 1
+%_vendor suse
+
+# Reproducible builds
+%source_date_epoch_from_changelog Y
+
+# define which gcc package builds the system libraries
+%product_libs_gcc_ver 7
+# The following shlibs have latest versions built from GCC 6 sources
+%product_libs_gcc_ver_libasan3 6
+%product_libs_gcc_ver_libgo9 6
+%product_libs_gcc_ver_libgfortran3 6
+# reminded by richi 2017 4/3
+%product_libs_gcc_ver_libgcj_bc1 6
+# The following shlibs have been introduced with GCC 7
+%product_libs_gcc_ver_libmpxwrappers2 7
+%product_libs_gcc_ver_libmpx2 7
+%product_libs_gcc_ver_libasan4 7
+%product_libs_gcc_ver_libgo11 7
+%product_libs_gcc_ver_libgfortran4 7
+%gcc_version 7
+
+%ext_info .gz
+%ext_man .gz
+
+%info_add(:-:) test -x /sbin/install-info -a -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
+%{nil}
+
+%info_del(:-:) test -x /sbin/install-info -a ! -f %{?2}%{?!2:%{_infodir}}/%{1}%ext_info && /sbin/install-info --quiet --delete --info-dir=%{?2}%{?!2:%{_infodir}} %{?2}%{?!2:%{_infodir}}/%{1}%ext_info \
+%{nil}
+:Macros
+


### PR DESCRIPTION
allow overwriting the currently hardcoded kernel parameters, some kernels fail to load modules on unknonw params:
[   14s] [    1.177944] dracut-pre-udev[124]: modprobe: ERROR: could not insert 'ext4': Unknown symbol in module, or unknown parameter (see dmesg)
[   15s] [    1.247111] ext4: Unknown parameter `allow_unsupported'
