### PR TITLE
Fix typo in build-recipe-docker

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -32,7 +32,7 @@ recipe_setup_docker() {
         mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
         if test -z "$LINKSOURCES" ; then 
-	    copy_sources "$MYSRCDIR" "BUILD_ROOT$TOPDIR/SOURCES/"
+	    copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"
         else
             cp -lR "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
         fi


### PR DESCRIPTION
Use $BUILD_ROOT instead of BUILD_ROOT.

Fixes: 121b73960854ba4b041305acaab88caa4442309e ("Rework source
copying code")