### PR TITLE
Enable tunings also for aarch64 and 32bit x86 builds

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -4,6 +4,7 @@
 ################################################################
 #
 # Copyright (c) 1995-2014 SUSE Linux Products GmbH
+# Copyright (c) 2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or 3 as
@@ -106,16 +107,13 @@ vm_verify_options_kvm() {
 		test -e /boot/Image.guest32 && vm_kernel=/boot/Image.guest32
 		test -e /boot/initrd.guest32 && vm_initrd=/boot/initrd.guest32
 	    fi
-	    # This option only exists with QEMU 2.5 or newer
-	    if $kvm_bin -machine 'virt,?' 2>&1 | grep -q gic-version ; then
-		# We want to use the host gic version in order to make use
-		# of all available features (e.g. more than 8 CPUs) and avoid
-		# the emulation overhead of vGICv2 on a GICv3 host.
-		kvm_options="$kvm_options -M virt,gic-version=host"
-	    else
-		kvm_options="$kvm_options -M virt"
-	    fi
+	    # We want to use the host gic version in order to make use
+	    # of all available features (e.g. more than 8 CPUs) and avoid
+	    # the emulation overhead of vGICv2 on a GICv3 host.
+            # move IO into separate I/O thread
+	    kvm_options="$kvm_options -M virt,accel=kvm,usb=off,gic-version=host -sandbox on -object iothread,id=io0"
 	    kvm_device=virtio-blk-device
+	    kvm_device_opts=",iothread=io0"
 	    kvm_rng_device=virtio-rng-device
 	    ;;
 	ppc|ppcle|ppc64|ppc64le)
@@ -159,7 +157,7 @@ vm_verify_options_kvm() {
 	    kvm_serial_device=virtio-serial-ccw
 	    kvm_rng_device=virtio-rng-ccw
 	    ;;
-	x86_64)
+	i586|i686|x86_64)
 	    test ! -x $kvm_bin -a -x /usr/bin/qemu-system-x86_64 && kvm_bin=/usr/bin/qemu-system-x86_64
 
             # build minimal machine - TODO enable sandbox on all architectures

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -57,6 +57,9 @@ Requires:       perl-TimeDate
 BuildRequires:  perl-TimeDate
 %endif
 Conflicts:      bsdtar < 2.5.5
+%if 0%{?suse_version}
+Conflicts:      qemu < 2.5.0
+%endif
 BuildRequires:  perl(Date::Parse)
 BuildRequires:  perl(Test::Harness)
 BuildRequires:  perl(Test::More)


### PR DESCRIPTION
Remove an outdated check for qemu 2.5 or older - that should
no longer be an issue.