### PR TITLE
turn off metadata_csm

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -21,10 +21,9 @@
 #
 ################################################################
 
-# ignore not backward compatible ext fs options like metadata_csum
 # Only protecting nonroot from root inside guest -> but anyone can be root inside guest
 # so disabling spectre/meltdown mitigations doesn't hurt security and gains performance
-vm_linux_kernel_parameter="ext4.allow_unsupported=1 mitigations=off"
+vm_linux_kernel_parameter="mitigations=off"
 # Make sure that dodgy kernels fail quickly and early
 vm_linux_always_append="oops=panic panic=1 quiet"
 
@@ -398,7 +397,7 @@ vm_img_mkfs() {
     esac
 
     # defaults for creating the filesystem
-    vm_img_mkfs_ext4_options='-O ^has_journal,^huge_file,^resize_inode,sparse_super'
+    vm_img_mkfs_ext4_options='-O ^has_journal,^huge_file,^resize_inode,sparse_super,^metadata_csum'
     vm_img_mkfs_ext4_extra='-E lazy_itable_init,discard'
     vm_img_mkfs_ext4="mkfs.ext4 -m 0 -q -F $vm_img_mkfs_ext4_options"
     vm_img_mkfs_ext3='mkfs.ext3 -m 0 -q -F'

--- a/build-vm
+++ b/build-vm
@@ -662,7 +662,7 @@ vm_detect_2nd_stage() {
     # set date to build start on broken systems (now < build start)
     if test $(date '+%s') -lt $(date -r /.build/.date '+%s') ; then
         echo -n "WARNING: system has a broken clock, setting it to a newer time: "
-        date -s `cat /.build/.date`
+        date -s $(</.build/.date)
     fi
 
     # Enable Core dump generation


### PR DESCRIPTION
not all older kernels support it, and it really doesn't matter
for build jobs..