### PR TITLE
Remove subshell usage for determining timing

### DIFF
--- a/build
+++ b/build
@@ -570,7 +570,7 @@ ccache_setup() {
 	return
     fi
     if test -n "$CCACHE" -a "$CCACHE_TYPE" = ccache ; then
-        CCACHE_SETUP_START_TIME=`date +%s`
+        CCACHE_SETUP_START_TIME=$SECONDS
 	if mkdir -p $BUILD_ROOT/var/lib/build/ccache/bin; then
 	    for i in $(ls $BUILD_ROOT/usr/bin | grep -E '^(cc|gcc|[cg][+][+]|clang|clang[+][+])([-]?[.0-9])*$'); do
 		rm -f $BUILD_ROOT/var/lib/build/ccache/bin/$i
@@ -610,7 +610,7 @@ ccache_wrapup() {
 	if test -n "$CCACHE_CLEAN" ; then
 	    echo "... cleaning ccache"
 	    test_cmd="ccache -h | grep -c evict-older-than"
-	    clean_cmd="ccache --evict-older-than $(($(date +%s) - $CCACHE_SETUP_START_TIME))s"
+	    clean_cmd="ccache --evict-older-than $(( $SECONDS - $CCACHE_SETUP_START_TIME ))s"
 	    chroot $BUILD_ROOT su -c "$test_cmd && $clean_cmd" - $BUILD_USER
 	fi
 	test -n "$CCACHE_CREATE_ARCHIVE" && ccache_pack "$BUILD_ROOT/.ccache" ccache
@@ -619,7 +619,7 @@ ccache_wrapup() {
 
 sccache_setup() {
     if test -n "$CCACHE" -a "$CCACHE_TYPE" = sccache ; then
-        CCACHE_SETUP_START_TIME=`date +%s`
+        CCACHE_SETUP_START_TIME=$SECONDS
         # This first redir clears the file.
         echo 'export CARGO_INCREMENTAL=false' > "$BUILD_ROOT"/etc/profile.d/build_sccache.sh
         echo 'export RUSTC_WRAPPER=sccache' >> "$BUILD_ROOT"/etc/profile.d/build_sccache.sh
@@ -796,8 +796,7 @@ create_baselibs() {
 	fi
     fi
     echo "... creating baselibs$whichone"
-    while read line
-    do
+    while read line; do
 	chroot $BUILD_ROOT su -c "$mkbaselibs $BASELIBS_GLOBAL $BASELIBS_CFG $line" - $BUILD_USER || cleanup_and_exit 1
     done < <(IFS=$'\n'; echo "${pkgs[*]#$BUILD_ROOT}" | xargs -n 1024)
     rm -rf "$BUILD_ROOT/.mkbaselibs"
@@ -1522,7 +1521,7 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	echo
 	test -n "$REASON" && echo "$REASON"
 	echo
-        TIME_START_TIME=`date +%s` # for statistics
+        TIME_START_TIME=$SECONDS # for statistics
     fi
 
     #
@@ -1564,7 +1563,7 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
     fi
 
     if test "$DO_INIT" = true ; then
-        start_time=`date +%s`
+        start_time=$SECONDS
 	#
 	# create legacy .buildenv file
 	#
@@ -1579,10 +1578,10 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	fi
 	set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" "${initbuildsysstuff[@]}" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $DLNOSIGNATURE $USEUSEDFORBUILD $CREATE_BUILD_BINARIES $RPMLIST "$MYSRCDIR/$RECIPEFILE" $ADDITIONAL_PACKS
 	echo "$* ..."
-        start_time=`date +%s`
+        start_time=$SECONDS
 	"$@" || cleanup_and_exit 1
 	check_exit
-        TIME_INSTALL=$(( `date +%s` - $start_time ))
+        TIME_INSTALL=$(( $SECONDS - $start_time ))
         unset start_time
 	# arbitrary limit of 10MB
 	if test $((`stat -f -c "%a*%S/1024/1024" $BUILD_ROOT`)) -lt 10; then
@@ -1837,12 +1836,12 @@ if test -n "$RPMS" -a -d "$BUILD_ROOT/usr/lib/build/checks" ; then
     for SRPM in $BUILD_ROOT/$TOPDIR/SRPMS/*src.rpm ; do
 	test -f "$SRPM" && PNAME=`rpm --nodigest --nosignature -qp --qf "%{NAME}" $SRPM`
     done
-    TIME_POSTCHECKS=`date +%s`
+    TIME_POSTCHECKS=$SECONDS
     for CHECKSCRIPT in $BUILD_ROOT/usr/lib/build/checks/* ; do
 	echo "... running ${CHECKSCRIPT##*/}"
 	BUILD_ROOT=/ chroot "$BUILD_ROOT" "/usr/lib/build/checks/${CHECKSCRIPT##*/}" || cleanup_and_exit 1
     done
-    TIME_POSTCHECKS=$(( `date +%s` - $TIME_POSTCHECKS ))
+    TIME_POSTCHECKS=$(( $SECONDS - $TIME_POSTCHECKS ))
     # workaround for broken 13.1 check scripts which umount /proc
     test -e "$BUILD_ROOT/proc/self" || mount -n -tproc none $BUILD_ROOT/proc
 fi
@@ -1859,9 +1858,9 @@ RPMS=`find $BUILD_ROOT/$TOPDIR/RPMS -type f -name "*.rpm" 2>/dev/null || true`
 DEBS=`find $BUILD_ROOT/$TOPDIR/DEBS -type f -name "*.deb" 2>/dev/null || true`
 
 if test -n "$RPMS" -a "$DO_CHECKS" != false ; then
-    TIME_RPMLINT=`date +%s`
+    TIME_RPMLINT=$SECONDS
     recipe_run_rpmlint
-    TIME_RPMLINT=$(( `date +%s` - $TIME_RPMLINT ))
+    TIME_RPMLINT=$(( SECONDS - $TIME_RPMLINT ))
 fi
 
 BUILD_SUCCEEDED=
@@ -1885,14 +1884,14 @@ exitcode=0
 # post build work
 # TODO: don't hardcode. instead run scripts in a directory as it's done for the checks
 if test -n "$RPMS" -a -d "$BUILD_ROOT/.build.oldpackages" ; then
-    TIME_BUILDCMP=`date +%s`
+    TIME_BUILDCMP=$SECONDS
     recipe_compare_oldpackages
-    TIME_BUILDCMP=$(( `date +%s` - $TIME_BUILDCMP ))
+    TIME_BUILDCMP=$(( $SECONDS - $TIME_BUILDCMP ))
     # no need to create deltas if the build is the same
     if test ! -e $BUILD_ROOT/.build/.same_result_marker ; then
-	TIME_DELTARPMS=`date +%s`
+	TIME_DELTARPMS=$SECONDS
 	recipe_create_deltarpms
-	TIME_DELTARPMS=$(( `date +%s` - $TIME_DELTARPMS ))
+	TIME_DELTARPMS=$(( $SECONDS - $TIME_DELTARPMS ))
     fi
 fi
 

--- a/build-vm
+++ b/build-vm
@@ -490,12 +490,11 @@ background_watchdog() {
     while sleep 5 ; do
 	WATCH=$(grep -a "### VM INTERACTION" "$LOGFILE" | tr '\0' a | tail -n 1)
 	case $WATCH in
-	    *VM\ INTERACTION\ START*) test -n "$WATCHDOG_START" || WATCHDOG_START=`date +%s` ;;
+	    *VM\ INTERACTION\ START*) test -n "$WATCHDOG_START" || WATCHDOG_START=$SECONDS ;;
 	    *VM\ INTERACTION\ END*) WATCHDOG_START= ;;
 	esac
 	if test -n "$WATCHDOG_START" ; then
-	    NOW=`date +%s`
-	    ELAPSED=$((NOW-WATCHDOG_START))
+	    ELAPSED=$(( $SECONDS - $WATCHDOG_START ))
 	    if test $ELAPSED -gt $WATCHDOG_TIMEOUT ; then
 		# kill the VM
 		echo
@@ -876,10 +875,10 @@ vm_first_stage() {
 	rm -f $BUILD_ROOT/.build.success
 	set -- init_buildsystem --configdir "$CONFIG_DIR" --cachedir "$CACHE_DIR" --prepare "${initbuildsysstuff[@]}" "${definesnstuff[@]}" "${repos[@]}" $CLEAN_BUILD $USEUSEDFORBUILD $RPMLIST "$MYSRCDIR/$RECIPEFILE" $ADDITIONAL_PACKS
 	echo "$* ..."
-	start_time=`date +%s`
+	start_time=$SECONDS
 	"$@" || cleanup_and_exit 1
 	check_exit
-	TIME_PREINSTALL=$(( `date +%s` - $start_time ))
+	TIME_PREINSTALL=$(( $SECONDS - $start_time ))
 	unset start_time
 	if test ! -w /root ; then
 	    # remove setuid bit if files belong to user to make e.g. mount work
@@ -1079,7 +1078,7 @@ vm_first_stage() {
 	    extractbuild --disk "$VM_ROOT" --input "$VM_SWAP" --skip 512 -v || cleanup_and_exit 3
 	    if test "$DO_STATISTICS" = 1 ; then
 		mkdir -p OTHER
-		TIME_TOTAL=$(( `date +%s` - $TIME_START_TIME ))
+		TIME_TOTAL=$(( $SECONDS - $TIME_START_TIME ))
 		echo "TIME_total: $TIME_TOTAL"  >> OTHER/_statistics
 	    fi
 	    cleanup_and_exit ${BUILDSTATUS#BUILDSTATUS}


### PR DESCRIPTION
the bash builtin $SECONDS allows access to the same
information without having to go through a fork/exec()
path