### PR TITLE
Avoid calling rm X just before cp A X

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -66,8 +66,7 @@ pkg_initdb_deb() {
     deb_setup
     # force dpkg into database to make epoch test work
     if ! test "$BUILD_ROOT/.init_b_cache/rpms/dpkg.deb" -ef "$BUILD_ROOT/.init_b_cache/dpkg.deb" ; then
-	rm -f $BUILD_ROOT/.init_b_cache/dpkg.deb
-	cp $BUILD_ROOT/.init_b_cache/rpms/dpkg.deb $BUILD_ROOT/.init_b_cache/dpkg.deb || cleanup_and_exit 1
+	cp --remove-destination $BUILD_ROOT/.init_b_cache/rpms/dpkg.deb $BUILD_ROOT/.init_b_cache/dpkg.deb || cleanup_and_exit 1
     fi
     DEB_UNSAFE_IO=
     chroot $BUILD_ROOT dpkg --force-unsafe-io --version >/dev/null 2>&1 && DEB_UNSAFE_IO="--force-unsafe-io"

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -709,8 +709,7 @@ postprocess_kiwi_containers() {
 	    for rr in $r*.containerinfo ; do
 		test -e "$rr" || continue
 		echo "creating base package information"
-		rm -f "$BUILD_ROOT/tmp/create_derived_package_list"
-		cp "$BUILD_DIR/create_container_package_list" "$BUILD_ROOT/tmp/create_container_package_list"
+		cp --remove-destination "$BUILD_DIR/create_container_package_list" "$BUILD_ROOT/tmp/create_container_package_list"
 		chroot "$BUILD_ROOT" /bin/bash /tmp/create_container_package_list "${KIWI_DERIVED_CONTAINER#$BUILD_ROOT}" > "$r.basepackages"
 		rm -f "$BUILD_ROOT/tmp/create_derived_package_list"
 		break

--- a/build-vm
+++ b/build-vm
@@ -920,8 +920,7 @@ vm_first_stage() {
     if test -n "$CCACHE" -a -n "$CCACHE_ARCHIVE" -a "$CCACHE_ARCHIVE" = "${CCACHE_ARCHIVE#redis://}"; then
 	mkdir -p "$BUILD_ROOT/.build.oldpackages"
 	if ! test "$BUILD_ROOT/.build.oldpackages/_ccache.tar" -ef "$CCACHE_ARCHIVE" ; then
-	    rm -f "$BUILD_ROOT/.build.oldpackages/_ccache.tar"
-	    cp -a "$CCACHE_ARCHIVE" "$BUILD_ROOT/.build.oldpackages/_ccache.tar"
+	    cp --remove-destination -a "$CCACHE_ARCHIVE" "$BUILD_ROOT/.build.oldpackages/_ccache.tar"
 	fi
 	CCACHE_ARCHIVE="/.build.oldpackages/_ccache.tar"
     fi

--- a/build-vm-zvm
+++ b/build-vm-zvm
@@ -378,8 +378,7 @@ vm_fixup_zvm() {
     vm_initrd="${vm_initrd}-${kernel_version}"
     # copy initrd to build worker:
     echo "copy $vm_initrd to $BUILD_ROOT"
-    rm -rf "${BUILD_ROOT}/boot/${vm_initrd}"
-    cp -a "${vm_initrd}" "${BUILD_ROOT}/boot"
+    cp --remove-destination -a "${vm_initrd}" "${BUILD_ROOT}/boot/${vm_initrd}"
     # finally, install bootloader to the worker disk
     # XXX/TODO: does zipl read or write ${BUILD_ROOT}${vm_initrd}? Either
     # rm -rf the file or check for a symlink

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -915,8 +915,7 @@ if test ! -e $BUILD_ROOT/installed-pkg -a ! -e $BUILD_ROOT/.build/init_buildsyst
 	touch $BUILD_ROOT/etc/fstab
     fi
     if test ! -e $BUILD_ROOT/etc/ld.so.conf -a -f $BUILD_ROOT/etc/ld.so.conf.in -a ! -L $BUILD_ROOT/etc/ld.so.conf.in ; then
-	rm -rf $BUILD_ROOT/etc/ld.so.conf
-	cp $BUILD_ROOT/etc/ld.so.conf.in $BUILD_ROOT/etc/ld.so.conf
+	cp --remove-destination $BUILD_ROOT/etc/ld.so.conf.in $BUILD_ROOT/etc/ld.so.conf
     fi
     if test -z "$PREPARE_VM" ; then
 	mount_stuff
@@ -1127,8 +1126,7 @@ for PKG in $MAIN_LIST ; do
     # install the package
     echo "installing ${PKGID%% *}"
     if ! test "$BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF" -ef "$BUILD_ROOT/.init_b_cache/$PKG.$PSUF" ; then
-	rm -f $BUILD_ROOT/.init_b_cache/$PKG.$PSUF
-	cp $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF $BUILD_ROOT/.init_b_cache/$PKG.$PSUF || cleanup_and_exit 1
+	cp --remove-destination $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF $BUILD_ROOT/.init_b_cache/$PKG.$PSUF || cleanup_and_exit 1
     fi
     pkg_install
     check_exit
@@ -1157,8 +1155,7 @@ if test -n "$PACKAGES_TO_SYSROOTINSTALL" ; then
 	fi
 	echo "installing ${PKGID%% *}"
 	if ! test "$BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF" -ef "$BUILD_ROOT/.init_b_cache/$PKG.$PSUF" ; then
-	    rm -f $BUILD_ROOT/.init_b_cache/$PKG.$PSUF
-	    cp $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF $BUILD_ROOT/.init_b_cache/$PKG.$PSUF || cleanup_and_exit 1
+	    cp --remove-destination $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF $BUILD_ROOT/.init_b_cache/$PKG.$PSUF || cleanup_and_exit 1
 	fi
 	pkg_sysrootinstall
 	check_exit


### PR DESCRIPTION
cp(1) has a --remove-destination which does that implicitely,
which avoids calling rm and thereby reducing overhead of
execution