### PR TITLE
Avoid calling external commands in a loop

### DIFF
--- a/build-pkg-rpm
+++ b/build-pkg-rpm
@@ -158,16 +158,17 @@ pkg_finalize_rpm() {
 	echo "now installing cumulated packages"
 	for ((num=0; num<=cumulate; num++)) ; do
 	    echo ${CUMULATED_LIST[$num]}
+	done > $BUILD_ROOT/.init_b_cache/manifest
+	for ((num=0; num<=cumulate; num++)) ; do
 	    PKG=${CUMULATED_LIST[$num]##*/}
 	    test "$BUILD_ROOT/.init_b_cache/rpms/$PKG" -ef "$BUILD_ROOT/${CUMULATED_LIST[$num]}" && continue
-	    rm -f $BUILD_ROOT/${CUMULATED_LIST[$num]}
-	    cp $BUILD_ROOT/.init_b_cache/rpms/$PKG $BUILD_ROOT/${CUMULATED_LIST[$num]} || cleanup_and_exit 1
-	done > $BUILD_ROOT/.init_b_cache/manifest
-	( cd $BUILD_ROOT && chroot $BUILD_ROOT rpm --ignorearch --nodeps -Uh --oldpackage --ignoresize --verbose $RPMCHECKOPTS \
+	    cp --remove-destination $BUILD_ROOT/.init_b_cache/rpms/$PKG $BUILD_ROOT/${CUMULATED_LIST[$num]} || cleanup_and_exit 1
+	done
+	( cd $BUILD_ROOT && chroot $BUILD_ROOT rpm --ignorearch --nodeps -Uvh --oldpackage --ignoresize $RPMCHECKOPTS \
 		$ADDITIONAL_PARAMS .init_b_cache/manifest 2>&1 || touch $BUILD_ROOT/exit )
 	for ((num=0; num<=cumulate; num++)) ; do
-	    rm -f $BUILD_ROOT/${CUMULATED_LIST[$num]}
-	done
+            echo "$BUILD_ROOT/${CUMULATED_LIST[$num]}"
+        done | xargs -r rm -f
 	rm -f $BUILD_ROOT/.init_b_cache/manifest
 	check_exit
 	for ((num=0; num<=cumulate; num++)) ; do

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -37,6 +37,7 @@ BuildArch:      noarch
 # Keep the following dependencies in sync with obs-worker package
 Requires:       bash
 Requires:       binutils
+Requires:       findutils
 Requires:       perl
 Requires:       tar
 # needed for fuser

--- a/dist/debian.control
+++ b/dist/debian.control
@@ -7,12 +7,11 @@ Standards-Version: 3.7.2
 
 Package: obs-build
 Architecture: all
-Depends: ${perl:Depends}, rpm, libarchive-tools | bsdtar
+Depends: ${perl:Depends}, rpm, findutils, libarchive-tools | bsdtar
 Recommends: rpm2cpio
 Conflicts: build
 Replaces: build
 Provides: build
-Description: A script to build SUSE Linux RPMs
- This package provides a script for building RPMs for SUSE Linux
+Description: A script to build SUSE RPMs
+ This package provides a script for building RPMs for SUSE
  in a chroot environment.
-

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -232,8 +232,8 @@ preinstall_setup() {
 	    .build.kernel.*|.build.hostarch.*|.build.initrd.*|.build.console.*) ;;
 	    .build*|.init_b_cache|.preinstallimage*|.srcfiles*|.pkgs|.rpm-cache|installed-pkg|proc|sys) continue ;;
 	esac
-	mv "./$i" build-preinstall || cleanup_and_exit 1
-    done
+	echo "./$i"
+    done | xargs -r mv -t build-preinstall || cleanup_and_exit 1
     cd build-preinstall || cleanup_and_exit 1
 }
 
@@ -245,8 +245,8 @@ preinstall_integrate() {
 	    .build.kernel.*|.build.hostarch.*|.build.initrd.*|.build.console.*) ;;
 	    .build*|.init_b_cache|.preinstallimage*|.srcfiles*|.pkgs|.rpm-cache|installed-pkg|proc|sys) continue ;;
 	esac
-	mv "./$i" .. || cleanup_and_exit 1
-    done
+	echo "./$i"
+    done | xargs -r mv -t .. || cleanup_and_exit 1
     cd "$BUILD_ROOT" || cleanup_and_exit 1
     assert_dirs
 }
@@ -850,12 +850,9 @@ else
     pkg_set_type
 
     if test -n "$PREINSTALL_IMAGE" ; then
-	for PKG in $PACKAGES_FROM_PREINSTALLIMAGE ; do
-	    # touch the file so that the copying works
-	    touch $BUILD_ROOT/.init_b_cache/rpms/"$PKG.$PSUF"
-	done
+       # touch the file so that the copying works
+       for PKG in $PACKAGES_FROM_PREINSTALLIMAGE; do echo "$BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF"; done | xargs -r touch
     fi
-
 fi
 
 # XXX: should use an option instead of looking at the recipe?
@@ -936,12 +933,14 @@ fi
 
 if test -n "$PREPARE_VM" ; then
     echo "copying packages..."
-    for PKG in $PACKAGES_TO_ALL $PACKAGES_TO_SYSROOTINSTALL ; do
-	rm -rf $BUILD_ROOT/.init_b_cache/$PKG.$PSUF
-	cp $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF $BUILD_ROOT/.init_b_cache/$PKG.$PSUF || cleanup_and_exit 1
-	ln -s -f ../$PKG.$PSUF $BUILD_ROOT/.init_b_cache/rpms/$PKG.$PSUF
-	check_exit
-    done
+
+    PKGS="$PACKAGES_TO_ALL $PACKAGES_TO_SYSROOTINSTALL"
+    rm -f $(for P in $PKGS; do echo $BUILD_ROOT/.init_b_cache/$P.$PSUF; done)
+    for P in $PKGS; do echo $BUILD_ROOT/.init_b_cache/rpms/$P.$PSUF; done | \
+        xargs -r cp -L -p -t $BUILD_ROOT/.init_b_cache || cleanup_and_exit 1
+    ln -s -f $(for P in $PKGS ; do echo "../$P.$PSUF"; done) -t $BUILD_ROOT/.init_b_cache/rpms
+    check_exit
+
     # alreadyinstalled check will not work, but we have to live with that...
     echo -n 'reordering...'
     PACKAGES_TO_INSTALL=`reorder $PACKAGES_TO_INSTALL`


### PR DESCRIPTION
We can use xargs(1) to batch up invocations, which significantly
improves performance as we reduce the overhead of external
command invocation.