### PR TITLE
add download_assets --clean option

### DIFF
--- a/PBuild/RemoteAssets.pm
+++ b/PBuild/RemoteAssets.pm
@@ -53,7 +53,7 @@ sub recipe_parse {
     }
     next unless $s->{'url'} =~ /(?:^|\/)([^\.\/][^\/]+)$/s;
     my $file = $1;
-    next if $p->{'files'}->{$file};
+    next if $p->{'files'}->{$file} && !$p->{'keep_all_assets'};
     undef $url unless $url =~ /^https?:\/\/.*\/([^\.\/][^\/]+)$/s;
     my $digest = $s->{'digest'};
     next unless $digest || $url;
@@ -88,6 +88,7 @@ sub fedpkg_parse {
       warn("unparsable line in 'sources' file: $_\n");
       next;
     }
+    next if $p->{'files'}->{$asset->{'file'}} && !$p->{'keep_all_assets'};
     push @assets, $asset if $asset->{'file'} =~ /^[^\.\/][^\/]*$/s;
   }
   close $fd;

--- a/download_assets
+++ b/download_assets
@@ -48,6 +48,7 @@ my %known_options = (
   'assetdir' => ':',
   'assets' => '::',
   'noassetdir' => '',
+  'clean' => '',
   'unpack' => '',
 
   'create-cpio' => '',
@@ -102,6 +103,8 @@ for my $dir (@dirs) {
     'dir' => $dir,
     'files' => $files,
   };
+  $p->{'keep_all_assets'} = 1 if $opts->{'clean'};
+
   my $assetmgr = PBuild::AssetMgr::create($assetdir);
   $assetmgr->add_assetshandler($_) for @{$opts->{'assets'} || []};
   $assetmgr->add_assetshandler($fedpkg) if !$opts->{'assets'} && $files->{'sources'};
@@ -122,6 +125,18 @@ for my $dir (@dirs) {
     $p->{'remoteassets'} = $d->{'remoteassets'} if $d && $d->{'remoteassets'};
     $p->{'name'} ||= $d->{'name'} if $d->{'name'};
     $assetmgr->find_assets($p);
+  }
+  if ($opts->{'clean'}) {
+    my $af = $p->{'asset_files'} || {};
+    for (values %$af) {
+      if ($_->{'isdir'}) {
+        PBuild::Util::rm_rf("$dir/$_->{'file'}") if -d "$dir/$_->{'file'}";
+        unlink "$dir/$_->{'file'}.obscpio" if -e "$dir/$_->{'file'}.obscpio";
+      } else {
+        unlink "$dir/$_->{'file'}" if -e "$dir/$_->{'file'}";
+      }
+    }
+    next;
   }
   if ($opts->{'unpack'} && $opts->{'noassetdir'}) {
     my $af = $p->{'asset_files'} || {};


### PR DESCRIPTION
to remove all files and directories which are referenced by remote asset urls.