### PR TITLE
docker: support package installation calls inside of if conditions

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -306,6 +306,7 @@ sub parse {
 	s/%([a-fA-F0-9]{2})/chr(hex($1))/ge for @args;
 	next unless @args;
 	my $rcmd = shift @args;
+	$rcmd = shift @args if @args && ($rcmd eq 'then' || $rcmd eq 'else' || $rcmd eq 'elif' || $rcmd eq 'if' || $rcmd eq 'do');
 	if ($rcmd eq 'zypper') {
 	  cmd_zypper($ret, @args);
 	} elsif ($rcmd eq 'yum' || $rcmd eq 'dnf') {


### PR DESCRIPTION
Always parse them in if _and_ else conditions as we can not judge
about the runtime check