### PR TITLE
setup rpmmacros for all build types and earlier

### DIFF
--- a/build
+++ b/build
@@ -1753,6 +1753,9 @@ for RECIPEFILE in "${RECIPEFILES[@]}" ; do
 	rm -f $BUILD_ROOT/.unpack.command
     done
 
+    # macros may be used by buildtime servies
+    recipe_setup_macros
+
     if  test -e _service; then
 	echo "Running build time source services..."
 	$BUILD_DIR/runservices --buildroot "$BUILD_ROOT" || cleanup_and_exit 1

--- a/build-recipe
+++ b/build-recipe
@@ -33,6 +33,33 @@ recipe_setup() {
     recipe_setup_$BUILDTYPE "$@"
 }
 
+recipe_setup_macros() {
+    # extract rpm macros from configuration
+    # these are potentialy also used in non-rpm builds
+    local rawcfgmacros=.rpmmacros
+    test "$BUILDTYPE" = debbuild && rawcfgmacros=.debmacros
+    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/$rawcfgmacros
+    if test -n "$BUILD_DEBUG" && test "$BUILDTYPE" != debbuild ; then
+	echo '
+%prep %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%prep
+%package %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%package
+%_build_insert_debug_package \
+%global __debug_package 1 \
+%undefine _enable_debug_packages \
+%debug_package
+
+' >> $BUILD_ROOT/root/$rawcfgmacros
+    fi
+
+    if test -n "$BUILD_JOBS" ; then
+	cat >> $BUILD_ROOT/root/$rawcfgmacros <<-EOF
+		%jobs $BUILD_JOBS
+		%_smp_mflags -j$BUILD_JOBS
+		EOF
+    fi
+    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/$rawcfgmacros $BUILD_ROOT/home/abuild/$rawcfgmacros
+}
+
 recipe_prepare() {
     recipe_prepare_$BUILDTYPE "$@"
 }

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -326,10 +326,6 @@ recipe_setup_kiwi() {
     fi
     chown -hR "$ABUILD_UID:$ABUILD_GID" "$BUILD_ROOT$TOPDIR"
 
-    # extract macros from configuration
-    # some post scripts might call rpm-build and rely on the macros
-    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/.rpmmacros
-
     if test -z "$ABUILD_TARGET"; then
         ABUILD_TARGET=$(queryconfig target --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" )
         test -z "$ABUILD_TARGET" || echo "build target is $ABUILD_TARGET"

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -65,31 +65,6 @@ recipe_prepare_spec() {
 	sed -e 's/^buildarchtranslate: athlon.*/buildarchtranslate: athlon: i686/' -e 's/^buildarchtranslate: i686.*/buildarchtranslate: i686: i686/' < $BUILD_ROOT/usr/lib/rpm/rpmrc_i586 > $BUILD_ROOT/usr/lib/rpm/rpmrc
     fi
 
-    # extract macros from configuration
-    rawcfgmacros=.rpmmacros
-    test "$BUILDTYPE" = debbuild && rawcfgmacros=.debmacros
-    queryconfig rawmacros --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" > $BUILD_ROOT/root/$rawcfgmacros
-    if test -n "$BUILD_DEBUG" && test "$BUILDTYPE" != debbuild ; then
-	echo '
-%prep %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%prep
-%package %{?!__debug_package:%{?_build_create_debug:%?_build_insert_debug_package}}%%package
-%_build_insert_debug_package \
-%global __debug_package 1 \
-%undefine _enable_debug_packages \
-%debug_package
-
-' >> $BUILD_ROOT/root/$rawcfgmacros
-    fi
-
-    if test -n "$BUILD_JOBS" ; then
-	cat >> $BUILD_ROOT/root/$rawcfgmacros <<-EOF
-		### from obs-build
-		%jobs $BUILD_JOBS
-		%_smp_mflags -j$BUILD_JOBS
-		EOF
-    fi
-    test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/$rawcfgmacros $BUILD_ROOT/home/abuild/$rawcfgmacros
-
     # extract optflags from configuration
     queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" optflags ${BUILD_DEBUG:+debug} > $BUILD_ROOT/root/.rpmrc
     test $BUILD_USER = abuild && cp -p $BUILD_ROOT/root/.rpmrc $BUILD_ROOT/home/abuild/.rpmrc


### PR DESCRIPTION
buildtime source services may need them

also non rpm builds may need them

code duplication in kiwi part can also be resolved.