### PR TITLE
copy source directories also when marked with .build.assets file

### DIFF
--- a/PBuild/Util.pm
+++ b/PBuild/Util.pm
@@ -58,6 +58,19 @@ sub readstr {
   return $d;
 }
 
+sub touch($) {
+  my ($file) = @_;
+  if (-e $file) {
+    my $t = time();
+    utime($t, $t, $file);
+  } else {
+    # create new file, mtime is anyway current
+    my $f;
+    open($f, '>>', $file) || die("$file: $!\n");
+    close($f) || die("$file close: $!\n");
+  }
+}
+
 sub ls {
   my $d;
   opendir($d, $_[0]) || return ();

--- a/build
+++ b/build
@@ -846,7 +846,7 @@ copy_sources() {
 	    local ii="${i##*/}"
 	    test "$ii" = . -o "$ii" = .. -o "$ii" = .git && continue
 	    if test -L "$i" -o -d "$i" -o "${ii#.}" != "$ii" ; then
-		if git -C "$1" --noglob-pathspecs ls-files --error-unmatch -- "$ii" >& /dev/null ; then
+		if test -e "$i/.build.asset" || git -C "$1" --noglob-pathspecs ls-files --error-unmatch -- "$ii" >& /dev/null ; then
 		    cp -pRd "$i" "$2"
 		    continue
 		fi

--- a/download_assets
+++ b/download_assets
@@ -158,5 +158,12 @@ for my $dir (@dirs) {
   } else {
     $assetmgr->copy_assets($p, $dir, $opts->{'unpack'});
   }
+  # mark directories as assets for build script
+  if ($opts->{'unpack'}) {
+    my $af = $p->{'asset_files'} || {};
+    for (keys %$af) {
+      PBuild::Util::touch("$dir/$_/.build.asset") if $af->{$_}->{'isdir'};
+    }
+  }
 }
 


### PR DESCRIPTION
We currently use these marker files for remote assets. A more descriptive
file may replace this this later.