### PR TITLE
Support OBS Debuginfo build flag for Red Hat variants

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -184,6 +184,11 @@ recipe_build_spec() {
 	rpmbopts[${#rpmbopts[@]}]='--define'
 	rpmbopts[${#rpmbopts[@]}]="_build_create_debug 1"
     fi
+    # OBS Debuginfo flag support for Red Hat family
+    if test -z "$BUILD_DEBUG" ; then
+	rpmbopts[${#rpmbopts[@]}]='--undefine'
+	rpmbopts[${#rpmbopts[@]}]="_enable_debug_packages"
+    fi
     if test -n "$DISTURL" ; then
 	rpmbopts[${#rpmbopts[@]}]='--define'
 	rpmbopts[${#rpmbopts[@]}]="disturl $DISTURL"


### PR DESCRIPTION
By undefining %_enable_debug_packages , debuginfo package will not be
created by rpmbuild on Red Hat variant Linux.

Signed-off-by: Kai Liu <kai.liu@suse.com>