### PR TITLE
Fix macro %if statements

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -558,7 +558,7 @@ sub read_config {
 	} else {
 	  push @macros, '...';
 	}
-      } elsif ($rm !~ /^%/) {
+      } elsif ($rm !~ /^%/ || $rm =~ /^%(if|endif|else|elif)(\s|$)/) {
 	push @macros, $rm;
       } else {
 	push @macros, "%define ".substr($rm, 1);


### PR DESCRIPTION
it broke parsing, since %if got replaced by macro definition, leading
to break all other %if statements in build description

github issue 12127