### PR TITLE
avoid printing transfer output

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -358,7 +358,7 @@ vm_img_create() {
 
     mkdir -p "${img%/*}" || cleanup_and_exit 4
     # truncate file to the desired size
-    dd if=/dev/zero of="$img" bs=1M count=0 seek="$size" || cleanup_and_exit 4
+    dd if=/dev/zero of="$img" bs=1M count=0 seek="$size" status=noxfer || cleanup_and_exit 4
     echo "$size" > "${img}.size"
     # allocate blocks
     if type -p fallocate > /dev/null ; then
@@ -750,7 +750,7 @@ vm_setup_swap() {
     fi
     if test -n "$VM_SWAP" ; then
 	vm_attach_swap
-	dd if=/dev/zero of="$VM_SWAP" bs=1024 count=1 conv=notrunc 2>/dev/null || cleanup_and_exit 4
+	dd if=/dev/zero of="$VM_SWAP" bs=1024 count=1 conv=notrunc status=noxfer || cleanup_and_exit 4
 	if test "$VM_SWAPDEV" != "${VM_SWAPDEV#LABEL=}"; then
 	    # call mkswap to set a label
 	    mkswap -L "${VM_SWAPDEV#LABEL=}" "$VM_SWAP" || cleanup_and_exit 4
@@ -1071,7 +1071,7 @@ vm_first_stage() {
     vm_attach_root
     if test -n "$VM_SWAP" -a -z "$RUN_SHELL" ; then
 	vm_attach_swap
-	BUILDSTATUS=$(dd if="$VM_SWAP" bs=12 count=1 2>/dev/null | tr '\0' a)
+	BUILDSTATUS=$(dd if="$VM_SWAP" bs=12 count=1 status=noxfer | tr '\0' a)
 	case $BUILDSTATUS in
 	  BUILDSTATUS[029])
 	    mkdir -p $BUILD_ROOT/.build.packages


### PR DESCRIPTION
But still show all the errors like running out of disk space
and the like.