### PR TITLE
Export ABUILD_UID to finalize scripts

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -1275,7 +1275,10 @@ if test -d $BUILD_ROOT/usr/lib/build/finalize-system ; then
     for PROG in $BUILD_ROOT/usr/lib/build/finalize-system/* ; do
 	test -e "$PROG" || continue
 	echo "... running ${PROG##*/}"
-	chroot $BUILD_ROOT "/usr/lib/build/finalize-system/${PROG##*/}" || cleanup_and_exit 1
+	(
+	    export ABUILD_UID ABUILD_GID
+	    chroot $BUILD_ROOT "/usr/lib/build/finalize-system/${PROG##*/}"
+	) || cleanup_and_exit 1
     done
 fi
 


### PR DESCRIPTION
SUSE post-build-checks create the abuild user. Need to export the
correct UID and GID for that.