### PR TITLE
Use faster VM shutdown alternative

### DIFF
--- a/build
+++ b/build
@@ -463,7 +463,7 @@ cleanup_and_exit () {
     fi
     test -n "$BUILD_DIST_TMP" && rm -f "$BUILD_DIST_TMP"
     if test -z "$BUILD_OPTIONS_PARSED" ; then
-	# if we haven't parsed the options yet we do
+	# if we have not yet parsed the options we do
 	# not know the correct build root. just exit.
 	exit $1
     fi

--- a/build
+++ b/build
@@ -506,7 +506,6 @@ cleanup_and_exit () {
     if test -n "$RUNNING_IN_VM" ; then
 	echo "$1" >  /.build/_exitcode
 	test -n "$browner" && chown "$browner" $BUILD_ROOT
-	vm_shutdown "$1"
     else
 	buildroot_umount /proc/sys/fs/binfmt_misc
 	buildroot_umount /proc
@@ -515,6 +514,9 @@ cleanup_and_exit () {
 	buildroot_umount /dev/shm
 	test -n "$VM_ROOT" -a "$VM_ROOT" != 1 && umount $BUILD_ROOT 2>/dev/null || true
 	test -n "$VM_TYPE" && vm_cleanup
+    fi
+    if test $$ -le 2 ; then
+        vm_shutdown "$1"
     fi
     exit $1
 }
@@ -1481,7 +1483,7 @@ if test -n "$LOGFILE" -a -z "$RUN_SHELL" ; then
 	:
     elif test -n "$RUNNING_IN_VM" -o -n "$NO_TIMESTAMPS" ; then
         # no additional timestamps in inner vm build system
-	exec 1> >(exec -a 'build logging' tee -a $LOGFILE) 2>&1
+	exec 1> >(echo "LOGGING_TEE_PID=$BASHPID" > $LOGFILE.pid ; exec -a 'build logging' tee -a $LOGFILE) 2>&1
     elif test -n "$VM_ROOT" ; then
         # external run of virtualization build
 	exec 1> >(exec -a 'build logging' perl -e 'open(F,">>",$ARGV[0])||die("$ARGV[0]: $!\n");$|=1;select(F);$|=1;while(<STDIN>){my $p=sprintf("[%5ds] ", time()-'$STARTTIME');print STDOUT $p.$_;s/^\r//s;s/\r\n/\n/gs;print F $p.$_}' $LOGFILE) 2>&1

--- a/build-vm
+++ b/build-vm
@@ -309,34 +309,48 @@ vm_set_buildstatus() {
 }
 
 #
+# Helper for vm_shutdown() to do the actual system halt
+#
+vm_shutdown_halt() {
+    kill -9 -1        # goodbye cruel world
+    mount -o remount,ro / || {
+        echo "Warning: 'remount -o ro /' failed. Triple Syncing.."
+        sync ; sync ; sync
+    }
+    sync	# halt from systemd is not syncing anymore.
+    if ! test -x /sbin/halt ; then
+	test -e /proc/sysrq-trigger || mount -n -tproc none /proc
+	echo o > /proc/sysrq-trigger
+	sleep 5 # wait for sysrq to take effect
+	echo "Warning: VM doesn't support sysrq and /sbin/halt not installed"
+    else
+	halt -f -p
+    fi
+}
+
+#
 # shutdown the system from inside the VM
 #
 vm_shutdown() {
     test -n "$VM_WATCHDOG" && echo "### VM INTERACTION START ###"
+    exec >&0 2>&0	# so that the logging tee finishes
     cd /
     test -n "$1" || set 1
     if test -n "$VM_SWAP" -a -e "$VM_SWAP" ; then
 	swapoff "$VM_SWAP" 2>/dev/null
 	echo -n "BUILDSTATUS$1" >"$VM_SWAP"
     fi
-    exec >&0 2>&0	# so that the logging tee finishes
-    sleep 1		# wait till tee terminates
     test "$VM_TYPE" = lxc -o "$VM_TYPE" = docker -o "$VM_TYPE" = nspawn && exit $1
-    kill -9 -1        # goodbye cruel world
-    if ! test -x /sbin/halt ; then
-	test -e /proc/sysrq-trigger || mount -n -tproc none /proc
-	sync
-	sleep 2	# like halt does
-	if test -e /proc/sysrq-trigger; then
-	    echo o > /proc/sysrq-trigger
-	    sleep 5 # wait for sysrq to take effect
-	else
-	    echo "Warning: VM doesn't support sysrq and /sbin/halt not installed"
-	fi
-    else
-	sync	# halt from systemd is not syncing anymore.
-	halt -f -p
+
+    # Wait for logging tee to finish
+    test -f "$LOGFILE.pid" && . "$LOGFILE.pid"
+    if test -n "$LOGGING_TEE_PID"; then
+        while kill -0 "$LOGGING_TEE_PID" 2>/dev/null; do
+            sleep 0.1
+        done
     fi
+    # shutdown from fresh shell to close out deleted inodes
+    exec -a "build: halt" -- $BASH -c "$(declare -f vm_shutdown_halt); vm_shutdown_halt"
     echo "Warning: clean shut down of the VM didn't work"
     exit $1	# init died...
 }
@@ -560,7 +574,7 @@ vm_detect_2nd_stage() {
 	return 1
     fi
     BUILD_OPTIONS_PARSED=true
-    if test $$ -eq 1 || test $$ -eq 2 ; then
+    if test $$ -le 2 ; then
 	# ignore special init signals if we're init
 	# we're using ' ' instead of '' so that the signal handlers
 	# are reset in the child processes


### PR DESCRIPTION
In most cases a remount -o ro / succeeds wwhich should force flushing
of writes. if it fails we can wait for dirty to be zero.

Typically this reduces the sleep 3 in that code path to 0.1-0.2s.