### PR TITLE
Declare armv8 and armv7 compatible

### DIFF
--- a/PBuild/Cando.pm
+++ b/PBuild/Cando.pm
@@ -32,8 +32,8 @@ our %cando = (
   'armv4l'  => [ 'armv4l'                                                                                                 ],
   'armv5l'  => [ 'armv4l', 'armv5l'                    , 'armv5el'                                                        ],
   'armv6l'  => [ 'armv4l', 'armv5l', 'armv6l'          , 'armv5el', 'armv6el'                                             ],
-  'armv7l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el' ], # armv8el is invented by MeeGo, it does not exist for real
-  'armv8l'  => [ 'armv8l' ],
+  'armv7l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el', 'armv8hl', 'armv8l' ], # armv8* is a subset of armv7hl
+  'armv8l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el', 'armv8hl', 'armv8l' ], # armv8l & armv7l are considered to be identical on rpm level
 
   'sh4'     => [ 'sh4' ],
 
@@ -85,6 +85,8 @@ for my $harch (keys %cando) {
 my %archfilter_extra = (
   'aarch64' => [ 'aarch64_ilp32', 'armv8l' ],
   'aarch64_ilp32' => [ 'aarch64', 'armv8l' ],
+  'armv8hl' => [ 'armv8l', 'armv7hl', 'armv7l', 'armv6hl', 'armv6l', 'armv5tel' ],
+  'armv8l' => [ 'armv7hl', 'armv7l', 'armv6hl', 'armv6l', 'armv5tel' ],
   'armv7hl' => [ 'armv7l', 'armv6hl', 'armv6l', 'armv5tel' ],
   'armv7l' => [ 'armv6l', 'armv5tel' ],
   'armv6hl' => [ 'armv6l', 'armv5tel' ],

--- a/common_functions
+++ b/common_functions
@@ -23,6 +23,7 @@
 build_host_arch() {
     : ${BUILD_HOST_ARCH:=`uname -m`}
     # the linux kernel only knows armv7l, armv7hl is a userland definition
+    test armv8l == "$BUILD_HOST_ARCH" && BUILD_HOST_ARCH=armv8hl
     test armv7l == "$BUILD_HOST_ARCH" && BUILD_HOST_ARCH=armv7hl
     test armv6l == "$BUILD_HOST_ARCH" && BUILD_HOST_ARCH=armv6hl
 
@@ -35,7 +36,8 @@ extend_build_arch() {
     case $BUILD_ARCH in
       aarch64) BUILD_ARCH="aarch64:aarch64_ilp32:armv8l" ;;
       aarch64_ilp32) BUILD_ARCH="aarch64_ilp32:aarch64:armv8l" ;;
-      armv8l) BUILD_ARCH="armv8l" ;; # armv8l is aarch64 in 32bit mode. not a superset of armv7
+      armv8hl) BUILD_ARCH="armv8hl:armv8l:armv7hl:armv7l:armv6hl:armv6l:armv5tel" ;;
+      armv8l) BUILD_ARCH="armv8l:armv7hl:armv7l:armv6hl:armv6l:armv5tel" ;;
       armv7hl) BUILD_ARCH="armv7hl:armv7l:armv6hl:armv6l:armv5tel" ;;
       armv7l) BUILD_ARCH="armv7l:armv6l:armv5tel" ;;
       armv6hl) BUILD_ARCH="armv6hl:armv6l:armv5tel" ;;


### PR DESCRIPTION
armv8 is considered meanwhile fully backward compatible to armv7
in latested tooling (rpm, zypper).

This may not be true for the concrete hardware implementation, but in
general armv8 is a subset of armv7 user land ABI.