### PR TITLE
Define _build_in_place if --rpm-build-in-place

### DIFF
--- a/build
+++ b/build
@@ -1378,6 +1378,9 @@ if test -n "$OBSURL" ; then
     initbuildsysstuff[${#initbuildsysstuff[@]}]="--obs"
     initbuildsysstuff[${#initbuildsysstuff[@]}]="$OBSURL"
 fi
+if test -n "$RPM_BUILD_IN_PLACE"; then
+    initbuildsysstuff+=("--define" "_build_in_place 1")
+fi
 
 if test -n "$DO_WIPE" ; then
     wipe_build_environment


### PR DESCRIPTION
RPM defines %_build_in_place which might have consequences for
buildrequires. So pass to init_buildsystem as well.