### PR TITLE
Don't imply --noprep when building in place

### DIFF
--- a/build
+++ b/build
@@ -1378,6 +1378,9 @@ if test -n "$OBSURL" ; then
     initbuildsysstuff[${#initbuildsysstuff[@]}]="--obs"
     initbuildsysstuff[${#initbuildsysstuff[@]}]="$OBSURL"
 fi
+if test -n "$RPM_BUILD_IN_PLACE"; then
+    initbuildsysstuff+=("--define" "_build_in_place 1")
+fi
 
 if test -n "$DO_WIPE" ; then
     wipe_build_environment

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -104,6 +104,7 @@ spec_init_topdir() {
 	-b[ci]\ --short-circuit) keepbuild=BUILD ;;
 	-bb\ --short-circuit | -bl) keepbuild=BUILD keepbuildroot=BUILDROOT ;;
     esac
+    [ -n "$RPM_BUILD_IN_PLACE" ] && unset keepbuild
     if test -n "$keepbuild$keepbuildroot" ; then
 	for d in $keepbuild $keepbuildroot ; do
 	    spec_is_empty_dir "$BUILD_ROOT$TOPDIR/$d" && cleanup_and_exit 1 "need files in $TOPDIR/$d for '${rpmstages[0]}'"
@@ -131,13 +132,11 @@ spec_setup_stages() {
 	*)           cleanup_and_exit 1 "unknown stage '$stage'" ;;
     esac
     stage=${stage//s/a}
-    # drop p/a stages in build-in-place mode unless requested
-    test -n "$RPM_BUILD_IN_PLACE" -a "$stage" != p -a "$origstage" = "${origstage/p/}" && stage="${stage#p}"
+    # drop a stage in build-in-place mode unless requested
     test -n "$RPM_BUILD_IN_PLACE" -a "$stage" != a -a "$origstage" = "${origstage/[as]/}" && stage="${stage%a}"
     rpmstages=()
     case $stage in
 	p | pc | pci | pcib | pciba) rpmstages[${#rpmstages[@]}]="-b${stage: -1}" ; stage= ;;
-	c | ci | cib | ciba) rpmstages[${#rpmstages[@]}]="--noprep -b${stage: -1}" ; stage= ;;
     esac
     while test -n "$stage" ; do
 	local opt="-b${stage:0:1}"

--- a/build-vm
+++ b/build-vm
@@ -996,6 +996,7 @@ vm_first_stage() {
     echo "OBS_PACKAGE='$OBS_PACKAGE'" >> $BUILD_ROOT/.build/build.data
     echo "BUILD_SKIP_BUNDLE='$BUILD_SKIP_BUNDLE'" >> $BUILD_ROOT/.build/build.data
     echo "RPM_BUILD_IN_PLACE='$RPM_BUILD_IN_PLACE'" >> $BUILD_ROOT/.build/build.data
+    echo "BUILD_RPM_BUILD_STAGE='$BUILD_RPM_BUILD_STAGE'" >> $BUILD_ROOT/.build/build.data
     # fallback time for broken hosts
     rm -rf $BUILD_ROOT/.build/.date
     date '+@%s' > $BUILD_ROOT/.build/.date

--- a/t/test-stage.t
+++ b/t/test-stage.t
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+
+failed=0
+num=0
+
+cleanup_and_exit() {
+	shift
+	echo "not ok $num - $s: $*"
+	exit 1
+}
+
+. ${0%/*}/../build-recipe-spec
+
+_assert() {
+	local s="$1"
+	spec_setup_stages "$s"
+	shift
+	if test "$#" != "${#rpmstages[@]}"; then
+		echo "not ok $num - $s: '$*' != '${rpmstages[*]}'"
+		((++failed))
+		return
+	fi
+	local i=0
+	while test -n "$1"; do
+		if test "$1" != "${rpmstages[i]}"; then
+			echo "not ok $num - $s: '$1' != '${rpmstages[i]}'"
+			((++failed))
+			return
+		fi
+		shift
+		((++i))
+	done
+	echo "ok $num - $s => ${rpmstages[*]}"
+}
+
+assert() {
+	((++num))
+	(_assert "$@") || { ((++failed)); }
+}
+
+echo 1..20
+
+assert a -ba
+assert a= -bs
+assert a+ -bs
+assert b -bb
+assert b= "-bb --short-circuit"
+assert b+ "-bb --short-circuit" "-bs"
+assert i -bi
+assert i= "-bi --short-circuit"
+assert i+ "-bi --short-circuit" "-bb --short-circuit" "-bs"
+assert c -bc
+assert c= "-bc --short-circuit"
+assert c+ "-bc --short-circuit" "-bi --short-circuit" "-bb --short-circuit" "-bs"
+assert p -bp
+assert p= -bp
+assert p+ -ba
+
+assert l -bl
+assert r -br
+assert s -bs
+assert s= -bs
+assert s+ -bs
+
+exit 0
+
+# vim: syntax=bash


### PR DESCRIPTION
Even in build-in-place mode we cannot make assumptions about what is in
%prep so we can't just skip it automatically. While for many current
packages --noprep might be convenient to skip applying patches, that is
not the only use case of %prep. Morever, build can be called with eg
--stage=c+ to run only stages starting from c ie skipping prep.
However it would be possible to change the code to convert c+ to eg
--noprep -bb instead of calling rpmbuild individually for c, i, b with
--short-circuit.

Also, the stage needs to be actually passed to the VM to work :-)