### PR TITLE
Run zstd without progress indicator

### DIFF
--- a/build-recipe-preinstallimage
+++ b/build-recipe-preinstallimage
@@ -94,7 +94,7 @@ preinstallimage_compress() {
     rm -f "$pimage".*
     if test -n "$(type -p zstd)" ; then
         echo "Compressing preinstallimage using 'zstd'."
-        zstd --rm -19 -T0 "$pimage"
+        zstd --no-progress --rm -19 -T0 "$pimage"
     else
         echo "Compressing preinstallimage using 'gzip'."
         gzip "$pimage"


### PR DESCRIPTION
This looks a bit weird in the build logs