### PR TITLE
Fix "Can't locate PBuild/Download.pm"

### DIFF
--- a/pbuild
+++ b/pbuild
@@ -47,7 +47,7 @@ use PBuild::Link;
 use PBuild::Checker;
 use PBuild::Options;
 use PBuild::Result;
-use PBuild::Download;
+use Build::Download;
 use PBuild::Preset;
 use PBuild::Distro;
 use PBuild::Repoquery;
@@ -164,7 +164,7 @@ for my $dist (@{$opts->{'dist'} || []}) {
     push @{$opts->{'repo'}}, 'zypp:/' unless @{$opts->{'repo'} || []};
   }
   if ($dist =~ /^https?:\/\//) {
-    my ($config) = PBuild::Download::fetch($dist);
+    my ($config) = Build::Download::fetch($dist);
     push @baseconfigs, $config;
   } elsif ($dist =~ /^obs:\//) {
     my $islast = $distcnt == @{$opts->{'dist'} || []} ? 1 : 0;


### PR DESCRIPTION
Download.pm has been moved to Build via 55450de8c4b219bdf63358ee2840cfad55409838