### PR TITLE
Preinstallimage build uid fix

### DIFF
--- a/build
+++ b/build
@@ -1686,8 +1686,10 @@ for RECIPEPATH in "${RECIPEFILES[@]}" ; do
 		egrep "^abuild:" <$BUILD_ROOT/etc/passwd
 		echo "build script attempting to use:"
 		echo "abuild::${ABUILD_UID}:${ABUILD_GID}:..."
-		echo "build aborting"
-		cleanup_and_exit 1
+		echo "fixing..."
+		sed -i -e "/^abuild:/d;iabuild:x:${ABUILD_UID}:${ABUILD_GID}:Autobuild:/home/abuild:/bin/bash" $BUILD_ROOT/etc/passwd
+		sed -i -e "/^abuild:/d;iabuild:x:${ABUILD_GID}:" $BUILD_ROOT/etc/group
+		chown "$ABUILD_UID:$ABUILD_GID" $BUILD_ROOT/home/abuild
 	    fi
 	fi
 	if test -f $BUILD_ROOT/etc/shadow ; then

--- a/build-recipe-preinstallimage
+++ b/build-recipe-preinstallimage
@@ -57,6 +57,11 @@ recipe_build_preinstallimage() {
       esac
       TOPDIRS="$TOPDIRS $DIR"
     done
+    # remove abuild user/group from passwd, will be recreated by build script anyway
+    for FILE in etc/passwd etc/shadow etc/gshadow etc/group; do
+	[ -e $FILE ] && sed -i -e '/^abuild:/d' $FILE
+    done
+    rm -fr home/abuild
     $TAR -cf .preinstallimage.tar --one-file-system $TOPDIRS || cleanup_and_exit 1
     echo "image created."
     TOPDIR=/usr/src/packages


### PR DESCRIPTION
Do not package abuild user in preinstallimage, so that build-uid=calller can work.
Fix it up in build script so that old preinstallimages also work.