### PR TITLE
deb: defer dpkg triggers until all packages are installed, and disable man-db altogether

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -61,6 +61,17 @@ deb_setup() {
 exit 101
 EOF
     chmod 755 $BUILD_ROOT/usr/sbin/policy-rc.d
+
+    # Manpages database trigger takes a lot of time and is not useful in a build chroot
+    mkdir -p $BUILD_ROOT/var/cache/debconf/
+    cat >> $BUILD_ROOT/var/cache/debconf/config.dat <<EOF
+Name: man-db/auto-update
+Template: man-db/auto-update
+Value: false
+Owners: man-db
+Flags: seen
+
+EOF
 }
 
 pkg_initdb_deb() {

--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -22,6 +22,7 @@
 ################################################################
 
 DEB_UNSAFE_IO=
+DEB_NO_TRIGGERS=
 
 #
 # A wrapper around chroot to set the environment correctly for dpkg and
@@ -74,13 +75,15 @@ pkg_initdb_deb() {
 }
 
 pkg_prepare_deb() {
-    # test if dpkg knows --force-unsafe-io
+    # test if dpkg knows --force-unsafe-io and --no-triggers
     DEB_UNSAFE_IO=
+    DEB_NO_TRIGGERS=
     chroot $BUILD_ROOT dpkg --force-unsafe-io --version >/dev/null 2>&1 && DEB_UNSAFE_IO="--force-unsafe-io"
+    chroot $BUILD_ROOT dpkg --no-triggers --version >/dev/null 2>&1 && DEB_NO_TRIGGERS="--no-triggers"
 }
 
 pkg_install_deb() {
-    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
     # ugly workaround for upstart system. some packages (procps) try
     # to start a service in their configure phase. As we don't have
@@ -198,7 +201,7 @@ pkg_sysrootinstall_deb() {
 	return
     fi
 
-    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
 }
 


### PR DESCRIPTION
man-db takes a lot of time when a lot of packages are installed, and it's really pointless for package builds.
dpkg triggers are intended to be ran after a batch of packages have been installed, and that's how `apt` and friends run them, but here `dpkg --install` is ran manually so the triggers run after each individual package install, which is slow. Run dpkg with `--no-triggers` if it's available. The existing `dpkg --configure` call at the end of the installation will run the triggers.