### PR TITLE
only use aio=io_uring if built against new enough liburing

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -396,7 +396,7 @@ vm_fixup_kvm() {
 	    if test "${kvm_device%%-*}" = "virtio" ; then
 		kvm_options="$kvm_options -object iothread,id=io0"
 		kvm_device_opts=",iothread=io0"
-                if ldd $kvm_bin | grep -q liburing.so ; then
+                if ldd $kvm_bin | grep -E -q liburing.so.[2-9] ; then
                     kvm_drive_opts="$kvm_drive_opts,aio=io_uring"
                 fi
 	    fi


### PR DESCRIPTION
liburing.so.1 seems to have occassional locking races causing it
to hang on I/O. Accept liburing.so.2+