### PR TITLE
Stop building aarch64_ilp32 baselibs for aarch64

### DIFF
--- a/baselibs_configs/baselibs_global.conf
+++ b/baselibs_configs/baselibs_global.conf
@@ -9,7 +9,6 @@ arch sparcv9	targets sparc64:32bit
 arch sparcv9v	targets sparc64v:32bit
 arch sparc64	targets sparcv9:64bit
 arch sparc64v	targets sparcv9v:64bit
-arch aarch64	targets aarch64_ilp32:64bit
 arch aarch64_ilp32	targets aarch64:32bit
 
 configdir /usr/lib/baselibs-<targettype>/bin


### PR DESCRIPTION
We stopped the aarch64 ilp32 efforts some time ago,
so we can stop building the ilp32 baselibs