### PR TITLE
Unify debian release patching in debtransform

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -108,11 +108,6 @@ recipe_prepare_dsc() {
                 *)   # No debver, add the first such token
                     OBS_DCH_RELEASE="-$DEB_RELEASE" ;;
             esac
-            # "OBS_DCH_RELEASE" char offset aligned with "VERSION" in previous echo
-            echo "OBS-DCH-RELEASE: Suffixing DSC file with OBS respin number, to  ${VERSION}${OBS_DCH_RELEASE}"
-            sed -e 's,^\(OBS-DCH-RELEASE:.*\)$,# \1,' \
-                -e 's,^\(Version:\).*$,\1'" ${VERSION}${OBS_DCH_RELEASE}"',' \
-                -i $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE
           fi
         fi
         if ! debtransform $CHANGELOGARGS $RELEASEARGS $BUILD_ROOT$TOPDIR/SOURCES $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE $BUILD_ROOT$TOPDIR/SOURCES.DEB ; then

--- a/debtransform
+++ b/debtransform
@@ -488,7 +488,7 @@ if ($tarfile =~ /\.tgz$/) {
     system ( ("mv",  "$dir/$old",  "$tmptar" ) ) == 0 || die("cannot rename .tgz to .tar.gz");
 }
 
-if ($tags->{'DEBTRANSFORM-RELEASE'} && $release) {
+if (($tags->{'DEBTRANSFORM-RELEASE'} || $tags->{'OBS-DCH-RELEASE'}) && $release) {
     # the tag DEBTRANSFORM-RELEASE in .dsc file instructs
     # to append OBS build number to package version. The
     # number is passed in "release" command line parameter.


### PR DESCRIPTION
We also handle the OBS-DCH-RELEASE tag in debtransform now.