### PR TITLE
CI: Add package repository update

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          
+      - name: Update packages repository
+        run: |
+          sudo apt-get update
 
       - name: Install libyaml-libyaml-perl
         run: |

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
+
       - name: Update packages repository
         run: |
           sudo apt-get update


### PR DESCRIPTION
CI step "Install debdiff for debtransform test" fails with error.

`Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/l/lintian/lintian_2.62.0ubuntu2_all.deb   404  Not Found`

Updating the package indexes before installing the package will fix the error.