### PR TITLE
Revert "avod aio=io_uring for now on SLE15-SP4 workers"

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -396,8 +396,7 @@ vm_fixup_kvm() {
 	    if test "${kvm_device%%-*}" = "virtio" ; then
 		kvm_options="$kvm_options -object iothread,id=io0"
 		kvm_device_opts=",iothread=io0"
-                # avoid SLE15-SP4 kernel as it is broken (bsc#1199011)
-                if ldd $kvm_bin | grep -E -q 'liburing.so.[2-9]' && test "$(uname -r | cut -d. -f1-2)" != "5.14" ; then
+                if ldd $kvm_bin | grep -E -q 'liburing.so.[2-9]' ; then
                     kvm_drive_opts="$kvm_drive_opts,aio=io_uring"
                 fi
 	    fi


### PR DESCRIPTION
The issue has been fixed in SLE15-SP4 Updates
(bsc#1199011, actually security update bsc#1198811 CVE-2022-29582)

This reverts commit 1a81d60cdb93f3486e12ae95e38d6df94fbe05c2.