### PR TITLE
[lxc] Update AppArmor profile name

### DIFF
--- a/lxc.conf
+++ b/lxc.conf
@@ -1,4 +1,4 @@
-lxc.aa_profile = lxc-default-with-mounting
+lxc.aa_profile = lxc-container-default-with-mounting
 
 lxc.cgroup.devices.deny = a
 # null


### PR DESCRIPTION
The AppArmor profile name changed from `lxc-default-with-mounting` to
`lxc-container-default-with-mounting`, so reflect that in `lxc.conf`.

Fixes: https://github.com/openSUSE/obs-build/issues/524

Note that this probably breaks older systems, where the AppArmor profile name was still `lxc-default-with-mounting`, but that's likely not relevant to the current development version of `obs-build`.