### PR TITLE
configs/*.conf: Stop using rpmlint-mini and rpmlint-Factory.

### DIFF
--- a/configs/sl11.1.conf
+++ b/configs/sl11.1.conf
@@ -27,7 +27,7 @@ Support: texinfo timezone util-linux login
 Support: libgomp43 libuuid1 psmisc
 Support: terminfo-base
 
-Support: build brp-check-suse post-build-checks rpmlint-Factory
+Support: build brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse
 
 %ifarch ia64

--- a/configs/sl11.2.conf
+++ b/configs/sl11.2.conf
@@ -45,7 +45,7 @@ Support: terminfo-base
 
 # build tools packages
 Support: build brp-check-suse post-build-checks
-Support: rpmlint-Factory
+Support: rpmlint
 Keep: brp-check-suse
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare

--- a/configs/sl11.3.conf
+++ b/configs/sl11.3.conf
@@ -44,7 +44,7 @@ Support: net-tools pam-modules patch perl-base sysvinit-tools
 Support: texinfo timezone util-linux login
 Support: libgomp%{gcc_version} libuuid1 psmisc
 Support: terminfo-base update-alternatives pwdutils build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare

--- a/configs/sl11.4.conf
+++ b/configs/sl11.4.conf
@@ -134,7 +134,7 @@ Support: net-tools pam-modules patch perl-base sysvinit-tools
 Support: texinfo timezone util-linux libmount1 login
 Support: libgomp%{gcc_version} libuuid1 psmisc
 Support: terminfo-base update-alternatives pwdutils build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare

--- a/configs/sl12.1.conf
+++ b/configs/sl12.1.conf
@@ -139,7 +139,7 @@ Support: net-tools pam-modules patch perl-base sysvinit-tools
 Support: texinfo timezone util-linux libmount1 login
 Support: libgomp%{gcc_version} libuuid1 psmisc
 Support: terminfo-base update-alternatives pwdutils build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse 
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare

--- a/configs/sl12.2.conf
+++ b/configs/sl12.2.conf
@@ -77,7 +77,7 @@ Support: man netcfg
 Support: net-tools pam-modules sysvinit-tools
 Support: texinfo timezone util-linux login psmisc
 Support: terminfo-base update-alternatives pwdutils build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse 
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare

--- a/configs/sl12.3.conf
+++ b/configs/sl12.3.conf
@@ -69,7 +69,7 @@ Support: pam-modules
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
 # Extracting appdata.xml from desktop files

--- a/configs/sl13.1.conf
+++ b/configs/sl13.1.conf
@@ -70,7 +70,7 @@ Support: pam-modules
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
 # Extracting appdata.xml from desktop files

--- a/configs/sl13.2.conf
+++ b/configs/sl13.2.conf
@@ -72,7 +72,7 @@ Support: pam-modules
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
 # Extracting appdata.xml from desktop files

--- a/configs/sl13.3.conf
+++ b/configs/sl13.3.conf
@@ -56,7 +56,7 @@ Required: rpm-build
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
 # Extracting appdata.xml from desktop files

--- a/configs/sl15.0.conf
+++ b/configs/sl15.0.conf
@@ -61,7 +61,7 @@ Required: gcc-PIE
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 %ifarch ia64
 Support: libunwind libunwind-devel

--- a/configs/sl15.1.conf
+++ b/configs/sl15.1.conf
@@ -103,7 +103,7 @@ Required: gcc-PIE
 Support: perl build-mkbaselibs
 Prefer:  build-mkbaselibs
 Support: brp-check-suse
-Support: post-build-checks rpmlint-Factory
+Support: post-build-checks rpmlint
 # Add hostname so that OBS/build will have a chance to identify the hostname (instead of localhost)
 Support: hostname
 

--- a/configs/sl15.2.conf
+++ b/configs/sl15.2.conf
@@ -107,7 +107,7 @@ Required: gcc-PIE
 Support: perl build-mkbaselibs
 Prefer:  build-mkbaselibs
 Support: brp-check-suse
-Support: post-build-checks rpmlint-Factory
+Support: post-build-checks rpmlint
 # Add hostname so that OBS/build will have a chance to identify the hostname (instead of localhost)
 Support: hostname
 

--- a/configs/sl15.3.conf
+++ b/configs/sl15.3.conf
@@ -160,11 +160,10 @@ Support: pam-modules
 # the basic stuff
 Support: perl build-mkbaselibs
 Prefer: build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 Support: hostname
 Support: brp-extract-appdata
 Support: brp-extract-translations
-Support: rpmlint-Factory-strict
 
 %ifarch ia64
 Support: libunwind libunwind-devel
@@ -1608,7 +1607,7 @@ RepoType: rpm-md:rsyncable splitdebug:_debug
 
 # whenever something (rpmlint-mini!) wants rpmlint we also install
 # our extra policy check
-#Substitute: rpmlint rpmlint rpmlint-backports rpmlint-backports-data
+#Substitute: rpmlint rpmlint-backports rpmlint-backports-data
 
 # rpmlint-backports-data is only available for SLE architectures
 %ifarch x86_64 ppc64le s390x aarch64
@@ -2305,21 +2304,14 @@ Macros:
 :Macros
 %endif
 
-# do not pull rpmlint-Factory-strict unless openSUSE:Leap:15.3
-# not sure this would work as my expectation - maxlin
-Support: !rpmlint-Factory-strict
-%if "%_project" == "openSUSE:Leap:15.3"
-Support: rpmlint-Factory-strict
-%endif
-
 # temporary for bootstrap
-# Support: !rpmlint-mini !rpmlint-Factory !rpmlint-Factory-strict
+# Support: !rpmlint
 
 Support: !rpmlint-backports
 Support: perl build-mkbaselibs
 Prefer:  build-mkbaselibs
 Support: brp-check-suse
-Support: post-build-checks rpmlint-Factory
+Support: post-build-checks rpmlint
 
 # bsc#1182698
 Preinstall: rpm-config-SUSE
@@ -2483,7 +2475,6 @@ Macros:
 %if "%_project" == "openSUSE:Leap:15.3"
 %ifarch i586 i686
 BuildFlags: onlybuild:gstreamer-plugins-bad
-BuildFlags: onlybuild:rpmlint-mini
 %endif
 %endif
 

--- a/configs/sl15.4.conf
+++ b/configs/sl15.4.conf
@@ -3,18 +3,14 @@ Substitute: kiwi-packagemanager:instsource product-builder-plugin-Tumbleweed
 # debug tools for local osc debugging
 Substitute: obs:cli_debug_packages gdb vim strace less rzsz
 
-# do not pull rpmlint-Factory-strict unless openSUSE:Leap:15.3
-# not sure this would work as my expectation - maxlin
-Support: !rpmlint-Factory-strict
-
 # temporary for bootstrap
-# Support: !rpmlint-mini !rpmlint-Factory !rpmlint-Factory-strict
+# Support: !rpmlint
 
 Support: !rpmlint-backports
 Support: perl build-mkbaselibs
 Prefer:  build-mkbaselibs
 Support: brp-check-suse
-Support: post-build-checks rpmlint-Factory
+Support: post-build-checks !rpmlint
 
 # bsc#1182698
 Preinstall: rpm-config-SUSE
@@ -243,7 +239,7 @@ Support: hostname
 Support: perl build-mkbaselibs
 Prefer: build-mkbaselibs
 
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks !rpmlint
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream

--- a/configs/sl42.1.conf
+++ b/configs/sl42.1.conf
@@ -111,7 +111,7 @@ Support: pam-modules
 Support: perl build-mkbaselibs
 Support: brp-check-suse post-build-checks
 %ifnarch armv6hl armv6l aarch64
-Support: rpmlint-Factory
+Support: rpmlint
 %endif
 
 %ifarch ia64

--- a/configs/sl42.2.conf
+++ b/configs/sl42.2.conf
@@ -119,7 +119,7 @@ Required: rpm-build
 Support: perl build-mkbaselibs
 Support: brp-check-suse post-build-checks
 %ifnarch armv6hl armv6l
-Support: rpmlint-Factory
+Support: rpmlint
 %endif
 
 # testing deltas (only for O:F for now!)

--- a/configs/sl42.3.conf
+++ b/configs/sl42.3.conf
@@ -119,7 +119,7 @@ Required: rpm-build
 Support: perl build-mkbaselibs
 Support: brp-check-suse post-build-checks
 %ifnarch armv6hl armv6l
-Support: rpmlint-Factory
+Support: rpmlint
 %endif
 
 # testing deltas (only for O:F for now!)

--- a/configs/sles11sp2.conf
+++ b/configs/sles11sp2.conf
@@ -31,7 +31,7 @@ Support: texinfo timezone util-linux login
 Support: libgomp43 libuuid1 psmisc
 Support: terminfo-base
 
-Support: build brp-check-suse post-build-checks rpmlint-Factory
+Support: build brp-check-suse post-build-checks rpmlint
 Keep: brp-check-suse
 
 %ifarch ia64

--- a/configs/sles12.conf
+++ b/configs/sles12.conf
@@ -48,7 +48,7 @@ Support: pam-modules
 
 # the basic stuff
 Support: perl build-mkbaselibs
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 Prefer: libblkid1-mini libuuid1-mini libmount1-mini libsmartcols1-mini libdb-4_8-devel
 Prefer: krb5-mini krb5-mini-devel

--- a/configs/sles15.conf
+++ b/configs/sles15.conf
@@ -75,7 +75,7 @@ Required: gcc-PIE
 
 # the basic stuff
 Support: perl
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream

--- a/configs/sles15sp2.conf
+++ b/configs/sles15sp2.conf
@@ -81,7 +81,7 @@ Required: gcc-PIE
 
 # the basic stuff
 Support: perl
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream

--- a/configs/sles15sp3.conf
+++ b/configs/sles15sp3.conf
@@ -81,7 +81,7 @@ Required: gcc-PIE
 
 # the basic stuff
 Support: perl
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream

--- a/configs/sles15sp4.conf
+++ b/configs/sles15sp4.conf
@@ -91,7 +91,7 @@ Support: hostname
 Support: perl build-mkbaselibs
 Prefer: build-mkbaselibs
 
-Support: brp-check-suse post-build-checks rpmlint-Factory
+Support: brp-check-suse post-build-checks rpmlint
 
 ### Branding related preferences
 Prefer: awesome:awesome-branding-upstream

--- a/configs/tumbleweed.conf
+++ b/configs/tumbleweed.conf
@@ -318,7 +318,7 @@ Support: post-build-checks
 # remove build-compare support to disable "same result" package dropping
 Support: build-compare
 
-Support: rpmlint-mini
+Support: rpmlint
 # In the actual Tumbleweed repos, we want to be stricter with rpmlint
 %if "%_project" == "openSUSE:Factory" || "%_project" == "openSUSE:Factory:PowerPC" || "%_project" == "openSUSE:Factory:ARM" || "%_project" == "openSUSE:Factory:Rebuild" || "%_project" == "openSUSE:Factory:Live" || "%_project" == "openSUSE:Factory:NonFree"
 Support: rpmlint-strict


### PR DESCRIPTION
 This relates to https://bugzilla.opensuse.org/show_bug.cgi?id=1187749

 It resolves failing dependency resolving during build env setup:

 This is also reproducible on an openSUSE 15.4 system:

 ```
 Loading repository data...
 Reading installed packages...
 Resolving package dependencies...

 Problem: nothing provides 'rpmlint-mini' needed by the to be installed rpmlint-Factory-1.0-3.19.noarch
  Solution 1: do not install rpmlint-Factory-1.0-3.19.noarch
  Solution 2: break rpmlint-Factory-1.0-3.19.noarch by ignoring some of its dependencies

 Choose from above solutions by number or cancel [1/2/c/d/?] (c): Resolving dependencies...
 Resolving package dependencies...
 Nothing to do.
 ```