### PR TITLE
Pass VM-specific extra args to VM using --vm-args option

### DIFF
--- a/build
+++ b/build
@@ -345,6 +345,11 @@ Known Parameters:
               Use virtual machine instead of chroot
               TYPE is one of xen|kvm|uml|qemu|lxc|zvm|openstack|ec2|docker|pvm|nspawn
 
+  --vm-args ARGS
+              Pass extra arguments to virtual machine
+              To pass multiple arguments, separate them with spaces
+              Use regular shell quotes if arguments contain spaces
+
   --vm-worker GUEST
               GUEST is a z/VM build worker controlled by the controlling
 	      z/VM build machine. 

--- a/build-vm
+++ b/build-vm
@@ -32,6 +32,7 @@ VM_ROOTDEV=/dev/hda1
 VM_SWAPDEV=/dev/hda2
 
 VM_TYPE=
+declare -a VM_ARGS
 VM_TYPE_PRIVILEGED=
 VM_ROOT=
 VM_SWAP=
@@ -159,6 +160,11 @@ vm_parse_options() {
 	    ;;
 	esac
 	shift
+      ;;
+      -vm-args)
+	needarg
+	eval "VM_ARGS=($ARG)"
+        shift
       ;;
       -vm-worker)
         needarg
@@ -1096,7 +1102,7 @@ vm_first_stage() {
 	echo "### VM INTERACTION START ###"
     fi
 
-    vm_startup
+    vm_startup "${VM_ARGS[@]}"
 
     # kill watchdog again
     if test -n "$VM_WATCHDOG" ; then

--- a/build-vm-docker
+++ b/build-vm-docker
@@ -37,7 +37,7 @@ vm_startup_docker() {
         --mount "type=bind,source=$BUILD_ROOT,destination=/mnt" \
         --mount "type=bind,source=/proc,destination=/mnt/proc" \
         --mount "type=bind,source=/dev/pts,destination=/mnt/dev/pts" \
-        busybox chroot /mnt "$vm_init_script"
+        "$@" busybox chroot /mnt "$vm_init_script"
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"

--- a/build-vm-emulator
+++ b/build-vm-emulator
@@ -36,7 +36,7 @@ vm_startup_emulator() {
     elif test "${EMULATOR_SCRIPT:0:1}" != / ; then
        EMULATOR_SCRIPT="./$EMULATOR_SCRIPT"
     fi
-    set -- "$EMULATOR_SCRIPT" "$VM_ROOT" "$VM_SWAP"
+    set -- "$EMULATOR_SCRIPT" "$@" "$VM_ROOT" "$VM_SWAP"
     echo "$@"
     if ! "$@"; then
 	 popd

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -291,7 +291,7 @@ kvm_add_console_args() {
 
 vm_startup_kvm() {
     qemu_bin="$kvm_bin"
-    qemu_args=(-drive file="$VM_ROOT",format=raw,if=none,id=disk,$kvm_drive_opts -device "$kvm_device$kvm_device_opts",drive=disk,serial=0)
+    qemu_args=("$@" -drive file="$VM_ROOT",format=raw,if=none,id=disk,$kvm_drive_opts -device "$kvm_device$kvm_device_opts",drive=disk,serial=0)
     if [ -n "$VM_USER" ] ; then
 	getent passwd "$VM_USER" > /dev/null || cleanup_and_exit 3 "cannot find KVM user '$VM_USER'"
     elif test $UID = 0 ; then

--- a/build-vm-lxc
+++ b/build-vm-lxc
@@ -45,7 +45,7 @@ vm_startup_lxc() {
     lxc_get_id
     LXCCONF="$BUILD_ROOT/.build.lxc.conf"
     buildroot_rm .build.lxc.conf
-    vm_startup_lxc_$LXC_TYPE
+    vm_startup_lxc_$LXC_TYPE "$@"
     BUILDSTATUS="$?"
     test "$BUILDSTATUS" != 255 || BUILDSTATUS=3
     cleanup_and_exit "$BUILDSTATUS"
@@ -83,11 +83,11 @@ vm_startup_lxc_standalone() {
     case "$LXCVERSION" in
         1.0.8|1.1.*|[234].*)
            lxc-create -n "$LXCID" -f "$LXCCONF" -t none || cleanup_and_exit 1
-           lxc-start -n "$LXCID" -F "$vm_init_script"
+           lxc-start -n "$LXCID" -F "$@" "$vm_init_script"
            ;;
         1.0.*)
            lxc-create -n "$LXCID" -f "$LXCCONF" || cleanup_and_exit 1
-           lxc-start -n "$LXCID" "$vm_init_script"
+           lxc-start -n "$LXCID" "$@" "$vm_init_script"
            ;;
         *)
            echo "Unsupported lxc version $LXCVERSION!" >&2
@@ -152,7 +152,7 @@ vm_startup_lxc_libvirt() {
     buildroot_rm /etc/mtab
     echo "rootfs / rootfs rw 0 0" > $BUILD_ROOT/etc/mtab
     # could LOGFILE be used instead?
-    lxcsh create --console $LXCCONF | sed -ure 's/\x0d//g;:redo /.\x08/{s/.\x08//; b redo}'
+    lxcsh create --console "$@" $LXCCONF | sed -ure 's/\x0d//g;:redo /.\x08/{s/.\x08//; b redo}'
     exitcode="${PIPESTATUS[0]}"
     if [ "$exitcode" -gt 0 ]; then
         return $exitcode # libvirt errors

--- a/build-vm-nspawn
+++ b/build-vm-nspawn
@@ -37,7 +37,7 @@ vm_startup_nspawn() {
     if test -n "$VM_TYPE_PRIVILEGED"; then
        privileged_opt=--privileged 
     fi
-    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network $pipe_opt $privileged_opt "$vm_init_script"
+    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network $pipe_opt $privileged_opt "$@" "$vm_init_script"
     BUILDSTATUS="$?"
     cleanup_and_exit "$BUILDSTATUS"
 }

--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -144,7 +144,7 @@ vm_startup_qemu() {
         qemu_options="$qemu_options -object rng-random,filename=$rng_dev,id=rng0 -device $qemu_rng_device,rng=rng0"
     fi
 
-    qemu_args=(-drive file="$VM_ROOT",format=raw,if=none,id=disk,cache=unsafe -device "$qemu_device",drive=disk,serial=0)
+    qemu_args=($@ -drive file="$VM_ROOT",format=raw,if=none,id=disk,cache=unsafe -device "$qemu_device",drive=disk,serial=0)
     if [ -n "$VM_USER" ] ; then
         getent passwd "$VM_USER" > /dev/null || cleanup_and_exit 3 "cannot find KVM user '$VM_USER'"
     elif test $UID = 0 ; then

--- a/build-vm-uml
+++ b/build-vm-uml
@@ -29,7 +29,7 @@ vm_verify_options_uml() {
 }
 
 vm_startup_uml() {
-    set -- $uml_kernel initrd=$uml_initrd root=ubda init="$vm_init_script" $vm_linux_always_append elevator=noop ubda=$VM_ROOT ubdb=$VM_SWAP ${VM_MEMSIZE:+mem=$VM_MEMSIZE}
+    set -- $uml_kernel "$@" initrd=$uml_initrd root=ubda init="$vm_init_script" $vm_linux_always_append elevator=noop ubda=$VM_ROOT ubdb=$VM_SWAP ${VM_MEMSIZE:+mem=$VM_MEMSIZE}
     echo "$@"
     "$@"
 }

--- a/build-vm-xen
+++ b/build-vm-xen
@@ -82,7 +82,7 @@ vm_startup_xen() {
 	XLDISK=
 	XLDISK="\"${XMROOT#disk=}\""
 	test -n "$XMSWAP" && XLDISK="$XLDISK, \"${XMSWAP#disk=}\""
-	set -- xl create -c $XEN_CONF_FILE name="\"build_$XENID\"" "disk=[ $XLDISK ]" extra=\""$vm_linux_always_append init="$vm_init_script" rd.driver.pre=binfmt_misc $vm_linux_kernel_parameter console=$VM_CONSOLE"\"
+	set -- xl create -c $XEN_CONF_FILE "$@" name="\"build_$XENID\"" "disk=[ $XLDISK ]" extra=\""$vm_linux_always_append init="$vm_init_script" rd.driver.pre=binfmt_misc $vm_linux_kernel_parameter console=$VM_CONSOLE"\"
     fi
     if test "$PERSONALITY" != 0 ; then
 	# have to switch back to PER_LINUX to make xm work


### PR DESCRIPTION
Works only if `--vm-type` option is specified.

Sometimes it's necessary to add extra options to a VM running on a specific worker. For example, Oracle Linux 8 runs quite old `systemd-nspawn` that knows nothing about faccessat2 system call and filters it out using `seccomp` system call filter, breaking newer `glibc`. A workaround is to pass `--system-call-filter=faccessat2` option to `nspawn` VM on OBS workers running on these systems.

This change implements `--vm-args` option that allows to pass extra arguments to many (but not all) VM types. Other VM types just ignore this option.

Corresponding PR for OBS to utilise this feature is here: openSUSE/open-build-service#12660