### PR TITLE
[VM] Override address size limit to unlimited

### DIFF
--- a/build-vm-docker
+++ b/build-vm-docker
@@ -32,6 +32,9 @@ vm_startup_docker() {
     docker rm "$name" >/dev/null 2>&1 || true
     local docker_opts=
     test -n "$VM_TYPE_PRIVILEGED" && docker_opts="--privileged --cap-add=SYS_ADMIN --cap-add=MKNOD"
+    # Override memory restriction set by stage1. Docker does not support
+    # --ulimit as=... for some reason.
+    ulimit -v 'unlimited'
     docker run \
         --rm --name "$name" --net=none $docker_opts \
         --mount "type=bind,source=$BUILD_ROOT,destination=/mnt" \

--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -358,6 +358,8 @@ vm_startup_kvm() {
 	set -- linux64 "$@"
     fi
     export QEMU_AUDIO_DRV=none		# we do not want to have sound inside the VMs
+    # Allow overcommit, the total memory will already be constrained by qemu.
+    ulimit -v 'unlimited'
     echo "$@"
     "$@"
     qemu_ret=$?

--- a/build-vm-nspawn
+++ b/build-vm-nspawn
@@ -37,7 +37,7 @@ vm_startup_nspawn() {
     if test -n "$VM_TYPE_PRIVILEGED"; then
        privileged_opt=--privileged 
     fi
-    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network $pipe_opt $privileged_opt "$vm_init_script"
+    systemd-nspawn -D "$BUILD_ROOT" -M "$name" --private-network $pipe_opt $privileged_opt "$vm_init_script" --rlimit=RLIMIT_AS=infinity
     BUILDSTATUS="$?"
     cleanup_and_exit "$BUILDSTATUS"
 }

--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -200,6 +200,8 @@ vm_startup_qemu() {
         set -- linux64 "$@"
     fi
     export QEMU_AUDIO_DRV=none          # we do not want to have sound inside the VMs
+    # Allow overcommit, the total memory will already be constrained by qemu.
+    ulimit -v 'unlimited'
     echo "$@"
     "$@"
     qemu_ret=$?

--- a/build-vm-uml
+++ b/build-vm-uml
@@ -30,6 +30,9 @@ vm_verify_options_uml() {
 
 vm_startup_uml() {
     set -- $uml_kernel initrd=$uml_initrd root=ubda init="$vm_init_script" $vm_linux_always_append elevator=noop ubda=$VM_ROOT ubdb=$VM_SWAP ${VM_MEMSIZE:+mem=$VM_MEMSIZE}
+    # Allow overcommit, the total memory will (most of the time?) already be
+    # constrained by UML.
+    ulimit -v 'unlimited'
     echo "$@"
     "$@"
 }

--- a/build-vm-xen
+++ b/build-vm-xen
@@ -88,6 +88,8 @@ vm_startup_xen() {
 	# have to switch back to PER_LINUX to make xm work
 	set -- linux64 "$@"
     fi
+    # Allow overcommit, the total memory will already be constrained by Xen.
+    ulimit -v 'unlimited'
     echo "$@"
     "$@" || cleanup_and_exit 3
     rm -f "$XEN_CONF_FILE"

--- a/lxc.conf
+++ b/lxc.conf
@@ -18,3 +18,8 @@ lxc.cgroup.devices.allow = c 5:2 rw
 # console
 lxc.console = none
 lxc.console.logfile = /dev/stdout
+
+# Override build script limit (which is only supposed to trigger for non-VM
+# builds, but is actually also applied on package building initialization
+# time) and breaks address sanitizers.
+lxc.prlimit.as = unlimited


### PR DESCRIPTION
The "build" script limits PRLIMIT_AS to (2/3) * (mem_size + swap_size),
which breaks asan, which tries to opportunistically allocate multiple TB
of memory, but crucially never even closely uses this.

This commit eliminates the memory limit right before spawning VMs (and
containers) if necessary, so that stage2 can run unrestricted
(notwithstanding the memory limit imposed by hypervisors) and use memory
overcommitment within the build process.

See the linked bug for a discussion of this.

Fixes: https://github.com/openSUSE/obs-build/issues/826