### PR TITLE
build-vm-kvm: enable l3-cache on i386/x86_64 builds

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -168,6 +168,7 @@ vm_verify_options_kvm() {
             # build minimal machine - TODO enable sandbox on all architectures
             # options to evaluate: mem-merge=off
             kvm_options="-M pc,accel=kvm,usb=off,dump-guest-core=off,vmport=off -sandbox on"
+            kvm_cpu="-cpu host,l3-cache=on"
 
             # from qemu-microvm, minified and hardened PC bios (slightly faster than seabios)
             test -e /usr/share/qemu/qboot.rom && kvm_options="$kvm_options -bios /usr/share/qemu/qboot.rom"


### PR DESCRIPTION
This reduces the IPIs on NUMA machines, which should stabilize
performance. See https://git.qemu.org/?p=qemu.git;a=commit;h=14c985cffa6cb177fc01a163d8bcf227c104718c
for details.