### PR TITLE
build: use ulimit -d instead of ulimit -v (#854)

### DIFF
--- a/build
+++ b/build
@@ -740,7 +740,7 @@ setmemorylimit() {
 	esac
     done < <(cat /proc/meminfo) # cat for proc stuff
 
-    ulimit -v $limit
+    ulimit -d $limit
     echo "Memory limit set to ${limit}KB"
 }
 


### PR DESCRIPTION
build uses ulimit -v (RLIMIT_AS) to limit the memory of the build
environment but that limits the size of the virtual address space
rather than how much memory is allocated.  Prior to Linux 4.7,
the RLIMIT_DATA limit which does limit process memory allocation only
covered brk() and sbrk().  "Modern" malloc implementations usually use
anonymous mmap ranges to ask the kernel for memory.  In Linux v4.7,
the RLIMIT_DATA limit was extended to include those.  ulimit -d
controls the RLIMIT_DATA limit, so let's use that instead.

This fixes build failures due to "Out of Memory" when the project
being built does lots of read-only file mmaps, which claims lots
of address space, but uses very little memory.