### PR TITLE
Revert "build-vm-kvm: enable l3-cache on i386/x86_64 builds"

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -168,7 +168,6 @@ vm_verify_options_kvm() {
             # build minimal machine - TODO enable sandbox on all architectures
             # options to evaluate: mem-merge=off
             kvm_options="-M pc,accel=kvm,usb=off,dump-guest-core=off,vmport=off -sandbox on"
-            kvm_cpu="-cpu host,l3-cache=on"
 
             # from qemu-microvm, minified and hardened PC bios (slightly faster than seabios)
             test -e /usr/share/qemu/qboot.rom && kvm_options="$kvm_options -bios /usr/share/qemu/qboot.rom"


### PR DESCRIPTION
Reverts openSUSE/obs-build#853

The usefulness of this patch is not clear, host-cache-info should be the default which provides actual information rather than emulated information.