### PR TITLE
Add Docker::query && Docker::queryhdrmd5

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1304,6 +1304,7 @@ sub query {
   return Build::Kiwi::queryiso($handle, %opts) if $do_kiwi && $binname =~ /\.iso$/;
   return Build::Arch::query($handle, %opts) if $do_arch && $binname =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)?$/;
   return Build::Arch::query($handle, %opts) if $do_arch && $binname =~ /\.arch$/;
+  return Build::Docker::query($handle, %opts) if $do_docker && $binname =~ /\.tar$/;
   return undef;
 }
 
@@ -1332,6 +1333,7 @@ sub queryhdrmd5 {
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.iso$/;
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.raw$/;
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.raw.install$/;
+  return Build::Docker::queryhdrmd5(@_) if $do_docker && $binname =~ /\.tar$/;
   return Build::Arch::queryhdrmd5(@_) if $do_arch && $binname =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)?$/;
   return Build::Arch::queryhdrmd5(@_) if $do_arch && $binname =~ /\.arch$/;
   return undef;

--- a/PBuild/BuildResult.pm
+++ b/PBuild/BuildResult.pm
@@ -28,7 +28,7 @@ use Build::SimpleXML;
 use PBuild::Util;
 use PBuild::Verify;
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz pkg.tar.zst};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz pkg.tar.zst tar};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 
 #

--- a/PBuild/LocalRepo.pm
+++ b/PBuild/LocalRepo.pm
@@ -27,7 +27,7 @@ use PBuild::Util;
 use PBuild::BuildResult;
 use PBuild::ExportFilter;
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz pkg.tar.zst};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz pkg.tar.zst tar};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 my $binsufsre_binlnk = join('|', map {"\Q$_\E"} (@binsufs, 'obsbinlnk'));
 

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -77,6 +77,8 @@ Recommends:     perl(URI)
 Recommends:     perl(XML::Parser)
 Recommends:     perl(Net::SSL)
 Recommends:     perl(YAML::LibYAML)
+# for querying docker & kiwi builds
+Recommends:     perl(JSON)
 Recommends:     bsdtar
 Recommends:     qemu-linux-user
 Recommends:     zstd


### PR DESCRIPTION
This is a draft/WIP to add support to write .bininfo files for docker based builds.

Currently this is very hacky and works only to a certain extend: `pbuild` writes the `.bininfo` files, but it is still not able to resolve dependencies from that. I have tested this against https://github.com/dcermak/bci-sle-15-sp4 where all containers except micro and base are unresolvable because they depend on base, but somehow nothing provides `container:suse/sle15:15.4`…