### PR TITLE
fix initvm executable flag handling

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -1049,7 +1049,7 @@ vm_first_stage() {
     buildroot_umount /mnt
 
     vm_init_script="/.build/build"
-    if check_use_emulator ; then
+    if set_initvm_name_for_emulator_in "$BUILD_ROOT/.build" ; then
         vm_init_script="/.build/$INITVM_NAME"
     fi
 

--- a/common_functions
+++ b/common_functions
@@ -106,7 +106,8 @@ check_native_arch() {
     return 1
 }
 
-check_use_emulator() {
+set_initvm_name_for_emulator_in() {
+    local initvmdir="$1"
     INITVM_NAME=
     # check if the extended host arch contains the build arch
     if check_native_arch "${BUILD_ARCH%%:*}" ; then
@@ -117,14 +118,15 @@ check_use_emulator() {
     # to run the qemu initialization in the vm, we need to
     # register it with a static program or shell script
     INITVM_NAME="initvm.$BUILD_INITVM_ARCH"
-    if test -e "$BUILD_DIR/$INITVM_NAME" -a -e "$BUILD_DIR/qemu-reg" ; then
-	chmod 0755 "$BUILD_DIR/$INITVM_NAME"
-	return 0	# chroot build, we need to run
+    if test -e "$initvmdir/$INITVM_NAME" -a -e "$initvmdir/qemu-reg" ; then
+        # it exists, assume we need to run it
+	return 0
     fi
+    INITVM_NAME=
+
     # XXX: error?
     echo "Warning: cross compile not possible due to missing static binaries. please install build-initvm package for that purpose."
     echo "         check that the right architecture is available for your build host, you need $INITVM_NAME for this one."
-    INITVM_NAME=
     return 1
 }
 

--- a/dist/build.spec
+++ b/dist/build.spec
@@ -164,7 +164,6 @@ make CFLAGS="$RPM_BUILD_FLAGS" initvm-all
 make DESTDIR=%{buildroot} initvm-install
 strip %{buildroot}/usr/lib/build/initvm.*
 export NO_BRP_STRIP_DEBUG="true"
-chmod 0644 %{buildroot}/usr/lib/build/initvm.*
 %endif
 
 # main

--- a/init_buildsystem
+++ b/init_buildsystem
@@ -682,7 +682,7 @@ else
     # (we do not need this for the prepare step, as we do not run scripts in this case)
     #
     if test -z "$PREPARE_VM" ; then
-	if check_use_emulator ; then
+	if set_initvm_name_for_emulator_in "$BUILD_DIR" ; then
 	    echo "registering binfmt handlers for cross build"
 	    "$BUILD_DIR/$INITVM_NAME"
 	    echo 0 > /proc/sys/vm/mmap_min_addr


### PR DESCRIPTION
The code was setting the executable flag on the host system not inside the build environment where it is needed, hence it didn't work.