### PR TITLE
fix build of testsuite spec file

### DIFF
--- a/test/libdummy1.spec
+++ b/test/libdummy1.spec
@@ -3,8 +3,7 @@ Version:	0
 Release:	0
 Group:		None
 Summary:	Dummy
-License:	GPL
-BuildRoot:	%_tmppath/%name-%version-build
+License:	MIT
 
 %build
 gcc --version
@@ -13,16 +12,12 @@ echo "int dummy(void) {}" | gcc -shared -Wl,-soname=libdummy.so.1 -o libdummy.so
 mkdir -p %buildroot%_libdir
 install libdummy.so.1 %buildroot%_libdir
 
-%clean
-rm -rf %buildroot
-
 %description
 target_cpu %_target_cpu
 arch       %_arch
 build_arch %_build_arch
 
 %files
-%defattr(-,root,root)
 %_libdir/libdummy.so.1
 
 %changelog


### PR DESCRIPTION
"GPL" has never been a valid license string, and it is now a fatal error. use "MIT" from https://spdx.org/licenses/