### PR TITLE
Call ls using its full name

### DIFF
--- a/PBuild/Job.pm
+++ b/PBuild/Job.pm
@@ -122,7 +122,7 @@ sub collect_result {
   push @d, 'SRPMS';
   @d = ('DEBS') if $p->{'recipe'} =~ /(?:\.dsc|build\.collax)$/ || $p->{'recipe'} eq 'debian/control' || $p->{'recipe'} eq 'debian.control';
   if (-d "$buildroot/.build.packages/SDEBS") {
-    @d = map {"DEBS/$_"} sort(ls("$buildroot/.build.packages/DEBS"));   # assume debbuild
+    @d = map {"DEBS/$_"} sort(PBuild::Util::ls("$buildroot/.build.packages/DEBS"));   # assume debbuild
     push @d, 'SDEBS';
   }
   @d = ('ARCHPKGS') if $p->{'recipe'} =~ /PKGBUILD$/;
@@ -345,7 +345,7 @@ sub createjob {
       push @kiwiargs, '--add-repotype', 'rpm-md';
       push @kiwiargs, '--add-repoprio', '1';
       if (-d "$srcdir/containers") {
-	for my $containerfile (grep {/\.tar$/} sort(ls("$srcdir/containers")))  {
+	for my $containerfile (grep {/\.tar$/} sort(PBuild::Util::ls("$srcdir/containers")))  {
 	  push @kiwiargs, "--set-container-derived-from=dir://./containers/$containerfile";
 	}
       }


### PR DESCRIPTION
`ls` from `PBuild::Util` is not in the global namespace and referencing it without the full namespace results in errors like:
```
Undefined subroutine &PBuild::Job::ls called at /usr/lib/build/PBuild/Job.pm line 348.
```