### PR TITLE
Fix permissions of /dev/pts/ptmx to make virtual terminals usable

### DIFF
--- a/build
+++ b/build
@@ -978,7 +978,7 @@ mount_stuff() {
 	mkdir -p $BUILD_ROOT/dev/shm
 	mount -n -tproc none $BUILD_ROOT/proc
 	mount -n -tsysfs none $BUILD_ROOT/sys
-	mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/dev/pts
+	mount -n -tdevpts -omode=0620,ptmxmode=0666,gid=5 none $BUILD_ROOT/dev/pts
 	mount -n -ttmpfs none $BUILD_ROOT/dev/shm
     fi
 }

--- a/build-vm
+++ b/build-vm
@@ -657,7 +657,7 @@ vm_detect_2nd_stage() {
     test -d /dev/shm || rm -f /dev/shm
     mkdir -p /dev/pts
     mkdir -p /dev/shm
-    mount -n -tdevpts -omode=0620,gid=5 none /dev/pts
+    mount -n -tdevpts -omode=0620,ptmxmode=0666,gid=5 none /dev/pts
     mount -n -ttmpfs none /dev/shm
 
     if test -n "$VM_SWAP" ; then


### PR DESCRIPTION
The default permissions of `ptmx` device in `devpts` filesystem are `000` (none), making virtual terminals not available to regular users.

This causes some packages (like `pytest`) to fail tests that need virtual terminals.

This change adds a mount option specifying permissions of `ptmx` device in `devpts` filesystem, making virtual terminals vailable to regular users.