### PR TITLE
Skip iothreads on QEMU 7.1.0

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -406,8 +406,12 @@ vm_fixup_kvm() {
 
     # move IO into separate I/O thread for some architectures
     if test "${kvm_device%%-*}" = "virtio" ; then
-        kvm_options="$kvm_options -object iothread,id=io0"
-        kvm_device_opts=",iothread=io0"
+        if $kvm_bin -version | grep -F -q 7.1.0; then
+            echo "QEMU 7.1.0 detected: Skipping iothreads because of bsc#1204082"
+        else
+            kvm_options="$kvm_options -object iothread,id=io0"
+            kvm_device_opts=",iothread=io0"
+        fi
         case $(uname -m) in
             ppc|ppcle|ppc64|ppc64le)
                 # PowerPC currently not reliably working


### PR DESCRIPTION
It appears there is a new regression on QEMU 7.1.0 (worked on 7.0) where iothreads together with aio=io_uring hang. As aio=io_uring is slightly faster, we disable iothreads to avoid the hang but still have some performance gain.