### PR TITLE
Update configs/arch.conf

### DIFF
--- a/configs/arch.conf
+++ b/configs/arch.conf
@@ -1,25 +1,54 @@
 Repotype: arch
 
 ExpandFlags: preinstallexpand
+
 VMinstall: util-linux
 Preinstall: pacman pacman-mirrorlist sed grep
 
-Required: binutils gcc glibc libtool
+###############################################################################
+# Minimal package set to define a basic Arch Linux installation. Based on
+# https://archlinux.org/packages/core/any/base/, with the exclusion of
+# non-useful packages due to the hermetic nature of our own build system.
 
-Support: acl autoconf automake zlib bzip2 filesystem curl
-Support: libtool ncurses perl gpgme libarchive openssl libssh2
-Support: libassuan libgpg-error attr expat xz pacman pacman-mirrorlist
-Support: fakeroot file sudo patch make net-tools pkgconf inetutils
-Support: bison flex gettext which
+Required: gcc-libs glibc
+
+Support: bash bzip2 coreutils file filesystem findutils gawk gettext gzip tar
+Support: xz
+
+###############################################################################
+# Minimal package set that is expected in a basic Arch Linux build environment
+# using makepkg (https://wiki.archlinux.org/title/makepkg#Usage). Based on
+# https://archlinux.org/groups/x86_64/base-devel/, with the exclusion of
+# non-useful packages due to the hermetic nature of our own build system.
+
+Required: gcc
+
+Support: autoconf automake binutils bison debugedit fakeroot flex groff
+Support: libtool m4 make patch pkgconf sudo texinfo which
+
+###############################################################################
+# Dubious list of packages that should get their reason to be here reviewed:
+
+Support: acl zlib ncurses perl gpgme libarchive openssl libssh2 libassuan
+Support: libgpg-error attr expat net-tools inetutils
+
+###############################################################################
 
 Prefer: zlib ttf-dejavu
 Prefer: libgl jdk7-openjdk libdrm
 
-Prefer: -nvidia-libgl -nvidia-304xx-utils -nvidia-304xx-utils -nvidia-utils
+Prefer: -nvidia-libgl -nvidia-340xx-utils -nvidia-304xx-utils -nvidia-utils
+Prefer: -pinentry-bemenu
 Prefer: mesa-libgl
 Prefer: curl:ca-certificates
 Prefer: glib-networking:ca-certificates
-Prefer: iptables
+Prefer: systemd:iptables
+Prefer: libelf:curl
+# darix 2022-04-26
+Prefer: mesa
+Prefer: jack2
+
+%define arch_linux 1
 
 %ifarch x86_64
 RepoURL: http://ftp.hosteurope.de/mirror/ftp.archlinux.org/core/os/x86_64


### PR DESCRIPTION
Revamp the file to preinstall the most basic packages that a minimum Arch Linux system expects, but avoiding the addition of packages that are not really needed due to the hermetic nature of our build system. Based on https://archlinux.org/packages/core/any/base/.

Also preinstall the minimum set of packages makepkg expects in a basic build environment, thus excusing them from being explicitly required in a PKGBUILD script. Based on the base-devel package group (https://archlinux.org/groups/x86_64/base-devel/).

Fixes: https://github.com/openSUSE/open-build-service/issues/13403