### PR TITLE
configure mkbaselibs to create glibc-hwcaps baselibs as well

### DIFF
--- a/baselibs_configs/baselibs_global.conf
+++ b/baselibs_configs/baselibs_global.conf
@@ -3,6 +3,9 @@ arch i686   targets x86_64:32bit
 arch s390   targets s390x:32bit
 arch ppc    targets ppc64:32bit
 arch ppc64  targets ppc:64bit
+arch x86_64_v2 targets x86_64:x86-64-v2
+arch x86_64_v3 targets x86_64:x86-64-v3
+arch x86_64_v4 targets x86_64:x86-64-v4
 arch sparc	targets sparc64:32bit
 arch sparcv8	targets sparc64:32bit
 arch sparcv9	targets sparc64:32bit
@@ -35,11 +38,32 @@ targettype x86 prereq "glibc-x86"
 
 package /(.*-devel)$/
 requires "<match1> = <version>"
+targettype x86-64-v2 -/.*
+targettype x86-64-v3 -/.*
+targettype x86-64-v4 -/.*
 
-package /.(?<!-devel)$/
+package /^(.*)(?<!-devel)$/
+targettype x86-64-v2 baselib +^/usr/lib64/(.*\.so.*)$ -> /usr/lib64/glibc-hwcaps/x86-64-v2/$1
+targettype x86-64-v3 baselib +^/usr/lib64/(.*\.so.*)$ -> /usr/lib64/glibc-hwcaps/x86-64-v3/$1
+targettype x86-64-v4 baselib +^/usr/lib64/(.*\.so.*)$ -> /usr/lib64/glibc-hwcaps/x86-64-v4/$1
+targettype x86-64-v2 requires "<match1> = <version>-<release>"
+targettype x86-64-v2 autoreqprov off
+targettype x86-64-v2 supplements "(<match1> = <version> and patterns-glibc-hwcaps-x86_64-v2)"
+targettype x86-64-v3 requires "<match1> = <version>-<release>"
+targettype x86-64-v3 autoreqprov off
+targettype x86-64-v3 supplements "(<match1> = <version> and patterns-glibc-hwcaps-x86_64-v3)"
+targettype x86-64-v4 requires "<match1> = <version>-<release>"
+targettype x86-64-v4 autoreqprov off
+targettype x86-64-v4 supplements "(<match1> = <version> and patterns-glibc-hwcaps-x86_64-v4)"
 post "/sbin/ldconfig"
 
 package /(.*)-debuginfo$/
 targetname <match1>-<targettype>-debuginfo
 +/usr/lib/debug/(.*/)?lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug$
 +/usr/lib/debug/\.build-id/.*
+targettype x86-64-v2 -/usr/lib/debug/\.build-id/.*
+targettype x86-64-v3 -/usr/lib/debug/\.build-id/.*
+targettype x86-64-v4 -/usr/lib/debug/\.build-id/.*
+targettype x86-64-v2 +^/usr/lib/debug/usr/lib64/(.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug)$ -> /usr/lib/debug/usr/lib64/glibc-hwcaps/x86-64-v2/$1
+targettype x86-64-v3 +^/usr/lib/debug/usr/lib64/(.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug)$ -> /usr/lib/debug/usr/lib64/glibc-hwcaps/x86-64-v3/$1
+targettype x86-64-v4 +^/usr/lib/debug/usr/lib64/(.*\.(so\..*|so|o|a|la)(-.*-.*\..*)?\.debug)$ -> /usr/lib/debug/usr/lib64/glibc-hwcaps/x86-64-v4/$1


### PR DESCRIPTION
We can use the baselibs magic to move the libraries built for x86_64_vX architecture into the hwcaps overlay directory and repackaging them as x86_64.rpm.