### PR TITLE
Better filetype detection for temp changes files

### DIFF
--- a/vc
+++ b/vc
@@ -118,7 +118,7 @@ if [ ! -e "$changelog" ]; then
 	touch $changelog
 fi
 
-tmpfile=`mktemp -q $changelog.vctmp.XXXXXX`
+tmpfile=`mktemp -q vctmp.XXXXXX.$changelog`
 if [ $? -ne 0 ]; then
 	echo "$0: Can't create temp file, exiting..."
 	exit 1


### PR DESCRIPTION
Right now the tempfile when invoking the `osc vc` command has a naming scheme that results in something like `package.changes.vctmp.slkqwo`. This has the problem that editors then can't as easily detect that it is a `.changes` file. This PR changes the naming scheme so that it would be something like `vctmp.slkqwo.package.changes`