### PR TITLE
Revert & Redo "Better filetype detection for temp changes files"

### DIFF
--- a/vc
+++ b/vc
@@ -118,7 +118,7 @@ if [ ! -e "$changelog" ]; then
 	touch $changelog
 fi
 
-tmpfile=`mktemp -q vctmp.XXXXXX.$changelog`
+tmpfile=`mktemp -q $changelog.vctmp.XXXXXX`
 if [ $? -ne 0 ]; then
 	echo "$0: Can't create temp file, exiting..."
 	exit 1

--- a/vc
+++ b/vc
@@ -118,7 +118,7 @@ if [ ! -e "$changelog" ]; then
 	touch $changelog
 fi
 
-tmpfile=`mktemp -q $changelog.vctmp.XXXXXX`
+tmpfile=`mktemp -q $changelog.vctmp.XXXXXX.changes`
 if [ $? -ne 0 ]; then
 	echo "$0: Can't create temp file, exiting..."
 	exit 1


### PR DESCRIPTION
This reverts commit df38e6fa5dc1e1bdc102a2f1c183224d0f0fae71.

The change broke creation of .changes files in packages which have an upper X in their name.

```
01:31 a4:../XOrg/libX11 $ osc vc
mktemp: too few X's in template ‘vctmp.XXXXXX.libX11.changes’ /usr/lib/build/vc: Can't create temp file, exiting...
```

Fixes: #905