### PR TITLE
docker: include OS name in build result if != linux

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -266,10 +266,14 @@ recipe_build_docker() {
 	return
     fi
 
+    # Check for OS setting
+    GOOS=`$DOCKER_CMD image inspect "$FIRSTTAG" --format '{{ .Os }}'`
+
     # Save the resulting image to a tarball. Use first tag for generating the file name.
     mkdir -p $BUILD_ROOT$TOPDIR/DOCKER
     FILENAME="$FIRSTTAG"
     FILENAME="${FILENAME//[\/:]/-}"
+    test -n "$GOOS" -a "$GOOS" != "linux" && FILENAME="${FILENAME}_$GOOS"
     FILENAME="$FILENAME.${BUILD_ARCH%%:*}"
     test -n "$RELEASE" && FILENAME="$FILENAME-$RELEASE"
     echo "Saving image $FIRSTTAG to $FILENAME.tar"

--- a/call-podman
+++ b/call-podman
@@ -34,7 +34,7 @@ while test -n "$1" ; do
 done
 
 if test -z "$IS_UNSHARED" ; then
-    echo "Unsharing environment"
+    echo "Unsharing environment" >&2
     # unshare mounts and network
     exec unshare -m -n $BUILD_DIR/call-podman --isunshared --root "$BUILD_ROOT" "$@"
     cleanup_and_exit 1 "exec unshare returned"


### PR DESCRIPTION
This avoids file conflicts when building the same container also for MS-Windows or MacOS