### PR TITLE
Fix startdockerd with cgroup v1

### DIFF
--- a/startdockerd
+++ b/startdockerd
@@ -145,8 +145,8 @@ if test "$BUILD_ROOT" != '/' ; then
     mount --rbind /sys/fs/cgroup "$BUILD_ROOT/sys/fs/cgroup"
     mount --make-rslave "$BUILD_ROOT/sys/fs/cgroup"
     export DOCKER_RAMDISK=true
-elif ! test -e /sys/fs/cgroup/unified -o -e /sys/fs/cgroup/cpu.stat ; then
-    # workaround for kernel-obs-build bsc#1198484 
+elif ! [ -e /sys/fs/cgroup/unified ] && ! [ -e /sys/fs/cgroup/cpu.stat ] && ! [ -e /sys/fs/cgroup/cpuset ]; then
+    # workaround for kernel-obs-build bsc#1198484
     mount -t cgroup cgroup /sys/fs/cgroup -o devices
 fi
 

--- a/startdockerd
+++ b/startdockerd
@@ -147,7 +147,7 @@ if test "$BUILD_ROOT" != '/' ; then
     export DOCKER_RAMDISK=true
 elif ! [ -e /sys/fs/cgroup/unified ] && ! [ -e /sys/fs/cgroup/cpu.stat ] && ! [ -e /sys/fs/cgroup/cpuset ]; then
     # workaround for kernel-obs-build bsc#1198484
-    mount -t cgroup cgroup /sys/fs/cgroup -o devices
+    mount -t cgroup cgroup /sys/fs/cgroup -o devices,cpuset
 fi
 
 # setup mounts


### PR DESCRIPTION
If cgroup v1 is used, neither /sys/fs/cgroup/unified nor /sys/fs/cgroup/cpu.stat exist, so it goes into the fallback path to mount the cgroup hierarchy manually. This is mounted on top of the actual cgroup mounts, breaking them. Fix this by recognizing a working cgroupv1 mount.