### PR TITLE
configs/alp: add is_alp macro

### DIFF
--- a/configs/alp.conf
+++ b/configs/alp.conf
@@ -1367,6 +1367,7 @@ Runscripts: cputype-armv7
 Optflags: * -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type %%{?_lto_cflags}
 
 # 15.5 does not exist !
+%define is_alp 1
 %define suse_version 1600
 %define workbench_version 0100
 %define is_opensuse 0
@@ -1375,6 +1376,7 @@ Optflags: * -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-st
 %define _without_avif 1
 
 Macros:
+%is_alp 1
 %suse_version 1600
 %workbench_version 0100
 %is_opensuse 0


### PR DESCRIPTION
One of our use cases can do away with some of the complexity if `is_alp` were to be supported. If this is not planned for some reason, is there a way to identify builds on ALP and otherwise? Thanks