### PR TITLE
Pass-through --buildtool-opt

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -1036,6 +1036,7 @@ vm_first_stage() {
     echo "RUN_SHELL='$RUN_SHELL'" >> $BUILD_ROOT/.build/build.data
     echo "RUN_SHELL_AFTER_FAIL='$RUN_SHELL_AFTER_FAIL'" >> $BUILD_ROOT/.build/build.data
     echo "RUN_SHELL_CMD='$RUN_SHELL_CMD'" >> $BUILD_ROOT/.build/build.data
+    echo "BUILD_TOOL_OPTS='$BUILD_TOOL_OPTS'" >> $BUILD_ROOT/.build/build.data
     echo "DO_STATISTICS='$DO_STATISTICS'" >> $BUILD_ROOT/.build/build.data
     echo "TIME_PREINSTALL='$TIME_PREINSTALL'" >> $BUILD_ROOT/.build/build.data
     echo "VM_WATCHDOG='$VM_WATCHDOG'" >> $BUILD_ROOT/.build/build.data


### PR DESCRIPTION
Pass-through `--buildtool-opt` into VMs to fix

    osc build --vm-type=kvm --build-opt=--buildtool-opt=--noclean