### PR TITLE
Produce docker format containers by default

### DIFF
--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -250,7 +250,12 @@ recipe_build_docker() {
 
     if test "$BUILDENGINE" = podman; then
 	test -n "$squashopt" && squashopt="--layers=false"
-	if ! $DOCKER_CMD build $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
+        buildformat=$(queryconfig --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" --archpath "$BUILD_ARCH" buildflags container-build-format)
+        formatopt="--format docker"
+        if test "$buildformat" = oci; then
+            formatopt="--format oci"
+        fi
+	if ! $DOCKER_CMD build $formatopt $squashopt -v "$TOPDIR/SOURCES/repos:$TOPDIR/SOURCES/repos" --network=host "${tagargs[@]}" "${buildargs[@]}" -f "$TOPDIR/SOURCES/$RECIPEFILE" $TOPDIR/SOURCES/ ; then
 	    cleanup_and_exit 1 "$DOCKER_TOOL build command failed"
 	fi
     else

--- a/docs/build_config.adoc
+++ b/docs/build_config.adoc
@@ -1,6 +1,6 @@
 == About the Build Configuration
 
-The build configuration syntax is 
+The build configuration syntax is
 
 Switch on or off certain features during the build.
 
@@ -42,7 +42,7 @@ build recipe type. If the recipe type is also not set, OBS looks at the
 Preinstall package list for a hint.
 
 ==== BuildEngine: ENGINE
-  
+
 Use an alternative build engine. This is still chained inside of the
 build script for security reasons. Alternatives are mock (for Fedora and
 Red Hat) and debootstrap (for Debian). This will avoid differences in
@@ -51,7 +51,7 @@ and reduced features. It should only be used when you want to emulate
 the distribution build. debbuild engine will build deb files out of a
 spec file description. It can be used by the following definition inside
 of the project build config:
-  
+
   Repotype: debian
   Type: spec
   Binarytype: deb
@@ -59,9 +59,9 @@ of the project build config:
   Support: pax
   Support: debbuild
   Keep: debbuild
-  
+
 ==== BuildFlags: FLAG:VALUE
-  
+
 The BuildFlags keyword defines flags for the build process. The
 following values for FLAG are usable. All flags with a leading colon (:)
 require an additional parameter directly following them.
@@ -165,7 +165,14 @@ formats are spdx and cyclonedx.
 Sets a compression format for container layers. Possible values are gzip, zstd,
 zstd:chunked. The usage of values beside gzip is only supported by podman and buildah.
 
-  
+
+* container-build-format:FORMAT
+
+For podman container builds, it specifies the container config format. Possible values
+are 'docker' and 'oci'. The default is 'docker'. The 'docker' format allows a few
+extensions like ONBUILD, SHELL, DOMAINNAME, COMMENT, HEALTHCHECK amongst others.
+
+
 ==== Constraint: SELECTOR STRING
 
 CAUTION: OBS only
@@ -173,9 +180,9 @@ CAUTION: OBS only
 Define build constraints for build jobs. The selector is a
 colon-separated list which gets a string assigned. See the build job
 constraints page for details.
-  
+
 ==== ExpandFlags: FLAG
-  
+
 Flags which modify the behaviour during dependency resolution.
 
  * unorderedimagerepos (OBS 2.10 or later)
@@ -199,9 +206,9 @@ Enable Red Hat-specific module support in repo md repositories. By
 default, modules are not used, but content can be made available by
 specifying the module name. To remove a module, add an exclamation mark
 (!) as prefix.
-  
+
 ==== ExportFilter: REGEX ARCH
-  
+
 The export filter can be used to export build results from one
 architecture to others. This is required when one architecture needs
 packages from another architecture for building. The REGEX placeholder
@@ -209,49 +216,49 @@ must match the resulting binary name of the package. It will export it
 to all listed scheduler architectures. Using a single dot will export it
 to the architecture which was used to build it. So not using a dot there
 will filter the package.
-  
+
 ==== FileProvides: FILE PACKAGES
-  
+
 &obsa; ignores dependencies to files (instead of package names) by
 default. This is mostly done to reduce the amount of memory needed, as
 the package file lists take up a considerable amount of repository meta
 data. As a workaround, FileProvides can be used to tell the systems
 which packages contain a file. The File needs to have the full path.
-  
+
 ==== HostArch: HOST_ARCH
-  
+
 This is used for cross builds. It defines the host architecture used for
 building, while the scheduler architecture remains the target
 architecture.
-  
+
 ==== Ignore: PACKAGES
-  
+
 Ignore can be used to break dependencies. This can be useful to reduce
 the number of needed packages or to break cyclic dependencies. Be
 careful with this feature, as breaking dependencies can have surprising
 results.
-  
+
 ==== Ignore: PACKAGE_A:PACKAGES
-  
+
 It is possible to define the ignore only for one package. This package
 must be listed first with a colon.
-  
+
 ==== Keep: PACKAGES
-  
+
 To eliminate build cycles the to-be-built package is not installed by
 default, even when it is required. Keep can be used to overwrite this
 behavior. It is usually needed for packages like make that are used to
 build itself. Preinstalled packages are automatically kept, as the
 package installation program needs to work all the time.
-  
+
 ==== OptFlags: TARGET_ARCH FLAGS (RPM only)
-  
+
 Optflags exports compiler flags to the build. They will only have an
 effect when the spec file is using $RPM_OPT_FLAGS. The target
 architecture may be * to affect all architectures.
-  
+
 ==== Order: PACKAGE_A:PACKAGE_B
-  
+
 The build script takes care about the installation order if they are
 defined via dependencies inside of the packages. However, there might be
 dependency loops (reported during setup of the build system) or missing
@@ -260,14 +267,14 @@ to break the loop.
 
 The package in PACKAGE_A will get installed before the package in
 PACKAGE_B.
-  
+
 ==== Patterntype: TYPES
-  
+
 Defines the pattern format. Valid values are: none (default), ymp,
 comps.
-  
+
 ==== Prefer: PACKAGES
-  
+
 In case multiple packages satisfy a dependency, the OBS system will
 complain about that situation. This is unlike like most package managing
 tools, which just pick one of the package. Because one of OBS’ goal is
@@ -275,19 +282,19 @@ to provide reproducible builds, it reports an error in this case instead
 of choosing a random package. The Prefer: tag lists packages to be
 preferred in case a choice exists. When the package name is prefixed
 with a dash, this is treated as a de-prefer.
-  
+
 ==== Prefer: PACKAGE_A:PACKAGES
-  
+
 It is possible to define the prefer only when one package is creating
 the choice error. This package must be listed first with a colon.
-  
+
 ==== Preinstall: PACKAGES
-  
+
 Are needed to run the package installation program. These packages get
 unpacked before the VM gets started. Included scripts are not executed
 during this phase. However, these packages will get installed again
 inside of the VM including script execution.
-  
+
 ==== PublishFlag: FLAG
 
 CAUTION: OBS only
@@ -320,18 +327,18 @@ Also publish internal content tracking files (.report files).
 Defines the distversion to be used in group element of ymp files. This
 is used by the installer to check if the repository is suitable for the
 installed distribution.
-  
+
 ==== PublishFilter: REGEXP [REGEXP]
-  
+
 CAUTION: OBS only
 
 Limits the published binary packages in public repositories. Packages
 that match any REGEXP will not be put into the exported repository.
 There can be only one line of PublishFilter for historic reasons.
 However, multiple REGEXP can be defined.
-  
+
 ==== Repotype: TYPE[:OPTIONS]
-  
+
 Defines the repository format for published repositories. Valid values
 are: none, rpm-md, suse, debian, hdlist2, arch, staticlinks and vagrant.
 The OPTIONS parameter depends on the repository type, for rpm-md the
@@ -340,51 +347,51 @@ or `prestodelta' to create delta rpm packages, `rsyncable' to use
 rsyncable gzip compression. To split the debug packages in an own
 published repository the option splitdebug:REPOSITORY_SUFFIX can be
 appended, e.g.
-  
+
 ==== Repotype: rpm-md splitdebug:-debuginfo
-  
+
 (the repository format may even be omitted to use the default type).
 This results in a debuginfo package repository being created in parallel
 to the package repository.
-  
+
 ==== Required: PACKAGES
-  
+
 Contain one or more packages that always get installed for package
 builds. A change in one of these packages triggers a new build.
-  
+
 ==== Runscripts: PACKAGES
-  
+
 Defines the scripts of preinstalled packages which needs to be executed
 directly after the preinstall phase, but before installing the remaining
 packages.
-  
+
 ==== Substitute: PACKAGE_A PACKAGES
-  
+
 It is possible to replace to BuildRequires with other packages. This
 will have only an effect on directly BuildRequired packages, not on
 indirectly required packages.
-  
+
 ==== Support: PACKAGES
-  
+
 Contain one or more packages which also get installed for package
 builds, but a change in one of the packages does not trigger an
 automatic rebuild.
 
 This is useful for packages that most likely do not influence the build
 result, for example make or coreutils.
-  
+
 ==== Target: TARGET_ARCH (RPM only)
-  
+
 Defines the target architecture. This can be used to build for i686 on
 i586 schedulers for example.
-  
+
 ==== Target: GNU_TRIPLET (DEB only)
-  
-Defines the target architecture via a gnu triplet (not the debian 
+
+Defines the target architecture via a gnu triplet (not the debian
 architecture!). For example arm-linux-gnueabihf for armv7hl builds.
-  
+
 ==== Type: TYPE
-  
+
 Build recipe type. This is the format of the file which provides the
 build description. This gets usually autodetected, but in some rare
 cases it can be set here to either one of these: spec, dsc, kiwi,
@@ -393,9 +400,9 @@ livebuild, arch, preinstallimage.
 Defines the build recipe format. Valid values are currently: none, spec,
 dsc, arch, kiwi, preinstallimage. If no type is specified, OBS deduces a
 type from the binary type.
-  
+
 ==== VMInstall: PACKAGES
-  
+
 Like Preinstall, but these packages get only installed when a virtual
 machine like Xen or KVM is used for building. Usually packages like
 mount are listed here.


### PR DESCRIPTION
podman, unlike docker, defaults to oci. Allow setting that as well but default to be docker compatible with allowing the docker extensions.