### PR TITLE
generate_sbom: fix support for older RPM versions

### DIFF
--- a/generate_sbom
+++ b/generate_sbom
@@ -173,9 +173,9 @@ sub dump_rpmdb {
         } else {
           system_chroot($root, 'stdout', $outfile, '/usr/bin/rpmdb', '--exportdb');
         }
+        exit($?) if $?;
+        return;
       }
-      exit($?) if $?;
-      return;
     }
     # try to get the dbpath from the root if we can
     if (!$dbpath && can_run($root, '/usr/bin/rpm')) {


### PR DESCRIPTION
Do not abort in dump_rpmdb in case rpmdb does not support --exportdb but use fallback using /usr/lib/rpm/rpmdb_dump.

This fixes SBOM generation on SLE 12 build hosts.