### PR TITLE
podman: enforce runtime=runc

### DIFF
--- a/build-vm-podman
+++ b/build-vm-podman
@@ -33,6 +33,7 @@ vm_startup_podman() {
     local podman_opts=
     test -n "$VM_TYPE_PRIVILEGED" && podman_opts="--privileged --cap-add=SYS_ADMIN --cap-add=MKNOD"
     podman run \
+        --runtime=runc \
         --rm --name "$name" --net=none $podman_opts \
         --mount "type=bind,source=$BUILD_ROOT,destination=/" \
         "$@" build-scratch:latest "$vm_init_script"


### PR DESCRIPTION
With the default crun runtime of podman, "osc build" fails because the
--mount option with destination=/ doesn't seem to be supported:

   Error: OCI runtime error: crun: mount `/mnt/git/build-root/15.5-x86_64/.mount` to ``: Invalid argument

fcrozat told me on Slack that setting runc as runtime works, and
indeed it does. But if build depends on this, it should rather set
this runtime explitly.

Signed-off-by: Martin Wilck <mwilck@suse.com>
