### PR TITLE
Update sl15.5.conf

### DIFF
--- a/configs/sl15.5.conf
+++ b/configs/sl15.5.conf
@@ -82,6 +82,9 @@ FileProvides: /usr/bin/python3 python3-base
 # Recommended by Adrian Schroeter:
 # causes a cycle :(
 # FileProvides: /sbin/mkinitrd dracut
+# https://bugzilla.suse.com/show_bug.cgi?id=1207530
+# Requested by mmaslanova@suse.com on 2024-01-30
+FileProvides: /sbin/showconsole blog
 
 
 Preinstall: aaa_base attr bash coreutils diffutils


### PR DESCRIPTION
Grub on s390x requires showconsole in SLE15.