### PR TITLE
Only add the time zone offset once

### DIFF
--- a/changelog2spec
+++ b/changelog2spec
@@ -156,7 +156,6 @@ sub parse_suse {
     $tdt = str2time("$year-1-1");
   }
   $tdt += 12 * 3600 unless $dt =~ /\d:\d/;	# 12:00 if not specified
-  $tdt += ($zone || 0);
   my $ok = 1;
   my $change = '';
   while(<>) {


### PR DESCRIPTION
when computing the time of a changes entry in changelog2spec.

This avoids getting a date in the future which would fail when using it for SOURCE_DATE_EPOCH for reproducible builds.

Such failures happened when we tried using it with https://github.com/openSUSE/post-build-checks/pull/58 .

Example failure from build log:
setting SOURCE_DATE_EPOCH to 1698749844
ERROR SOURCE_DATE_EPOCH is in the future, clamping mtime if
 used might fail in hard to notice way, returning error

"Mon Oct 30 12:36:34 CET 2023" in .changes results in SOURCE_DATE_EPOCH=1698669395 but that's Mon 30. Oct 12:36:35 UTC 2023

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1216738