### PR TITLE
Replace deprecated %patchN usage

### DIFF
--- a/spec_add_patch
+++ b/spec_add_patch
@@ -166,7 +166,7 @@ for my $diffname (keys %diffs) {
     print "Adding patch$striplevel $diffname to $specname\n";
 
 
-    splice @c, $last_patch_in_prep_index+1, 0, ("\%patch$patchnum$striplevel\n") unless $autopatch;
+    splice @c, $last_patch_in_prep_index+1, 0, ("\%patch -P$patchnum$striplevel\n") unless $autopatch;
     splice @c, $last_patch_in_global_index+1, 0,
     (sprintf "Patch%s:%s%s\n", $patchnum, ' ' x (10-length($patchnum)), $diffname);
     ++$last_patch_in_global_index;


### PR DESCRIPTION
Replace [deprecated usage of `%patch$N`](https://github.com/rpm-software-management/rpm/blob/5b8b8d5a7383c18309e1dd399de875904dbd3ad7/docs/manual/spec.md?plain=1#L529)
with `%patch -P$N`
for compatibility with rpm 4.20