### PR TITLE
Consider %autosetup -N

### DIFF
--- a/spec_add_patch
+++ b/spec_add_patch
@@ -92,7 +92,7 @@ while(<S>)
 
     if ($in_prep
         && /^%auto(patch|setup)\b/) {
-        $autopatch = 1;
+        $autopatch = 1 unless /%autosetup.+-N/;
     }
     if ($in_prep
         && /^%setup\b/) {


### PR DESCRIPTION
Consider `%autosetup -N`
because it [does not include autopatch](https://github.com/rpm-software-management/rpm/blob/5b8b8d5a7383c18309e1dd399de875904dbd3ad7/docs/manual/autosetup.md?plain=1#L55-L57).