### PR TITLE
test: Add a dated changelog entry to libdummy1.spec

### DIFF
--- a/test/libdummy1.spec
+++ b/test/libdummy1.spec
@@ -21,3 +21,6 @@ build_arch %_build_arch
 %_libdir/libdummy.so.1
 
 %changelog
+* Mon Feb 19 2024 Dominique Leuenberger <dimstar@opensuse.org>
+- No information provided here - we needed a dated entry for
+  RPM/reproducible builds


### PR DESCRIPTION
RPM went a step further for reproducible builds and extracts the date of the most recent changelog entry. We can provide this by a single dated changelog entry in the rpm directly. Alternative would be adding a .changes file, which seems a bit excessive here.