### PR TITLE
Pass release for reproducible builds when testing

### DIFF
--- a/test/common
+++ b/test/common
@@ -101,6 +101,7 @@ run_build()
 	set -- $linux32 $SU_WRAPPER \
 		$BUILD_DIR/build \
 		--root "${build_root}" \
+		--changelog --release 5.23 \
 		"${repos[@]}" \
 		"${build_args[@]}"
 	echo "$@"

--- a/test/libdummy1.changes
+++ b/test/libdummy1.changes
@@ -1,0 +1,6 @@
+-------------------------------------------------------------------
+Mon Feb 19 08:31:23 UTC 2024 - openSUSE <packaging@lists.opensuse.org>
+
+- package for testing, this entry is needed for reproducible builds to extract
+  SOURCE_DATE_EPOCH, date may be incorrect as this file might not be updated
+

--- a/test/libdummy1.spec
+++ b/test/libdummy1.spec
@@ -20,7 +20,3 @@ build_arch %_build_arch
 %files
 %_libdir/libdummy.so.1
 
-%changelog
-* Mon Feb 19 2024 Dominique Leuenberger <dimstar@opensuse.org>
-- No information provided here - we needed a dated entry for
-  RPM/reproducible builds


### PR DESCRIPTION
also enabling changelog handling and move changelog to changes file, to
more closely do what OBS does normally.

Passing a release might become required in the future on distributions
that have reproducible builds enabled, as otherwise
SOURCE_DATE_EPOCH_MTIME can not be computed. rpms build without that
would result in a hard to notice failures of tools that rely on mtimes
like rsync without --checksum.