### PR TITLE
mkosi fixes

### DIFF
--- a/Build/Mkosi.pm
+++ b/Build/Mkosi.pm
@@ -67,8 +67,9 @@ sub parse {
   if (length $cfg->val('Content', 'BuildPackages')) {
     push(@packages, split /\s+/, $cfg->val('Content', 'BuildPackages'));
   }
-  if (length $cfg->val('Partitions', 'BaseImage')) {
-    push(@packages, $cfg->val('Partitions', 'BaseImage'));
+  # XXX: split by comma
+  if (length $cfg->val('Content', 'BaseTrees')) {
+    push(@packages, "mkosi:".$cfg->val('Content', 'BaseTrees'));
   }
 
   $ret->{'name'} = $fn;

--- a/PBuild/Container.pm
+++ b/PBuild/Container.pm
@@ -55,8 +55,12 @@ sub manifest2obsbinlnk {
     return {};
   }
 
-  foreach my $ext ("", ".gz", ".xz", ".zst", ".zstd") {
-    if (-e "$dir/$prefix$ext") {
+  for my $ext ("", ".raw", ".gz", ".xz", ".zst", ".zstd") {
+    my $fn = "$dir/$prefix$ext";
+    if (-e $fn) {
+      if (-l $fn) {
+        $prefix = readlink($fn);
+      }
       open(my $fh, '<', "$dir/$prefix$ext") or die("Error opening $dir/$prefix$ext: $!\n");
       $md5->addfile($fh);
       close($fh);
@@ -72,14 +76,14 @@ sub manifest2obsbinlnk {
   my $release = $metadata->{'config'}->{'release'};
   my $architecture = $metadata->{'config'}->{'architecture'};
   my $name = $metadata->{'config'}->{'name'};
-  my $version = $metadata->{'config'}->{'version'};
+  my $version = $metadata->{'config'}->{'version'} || '0';
   # Note: release here is not the RPM release, but the distribution release (eg: Debian 10)
-  my @provides = ("$distribution:$release", "$name = $version", "$packid = $version");
+  my @provides = ("$distribution:$release", "mkosi:$name = $version", "mkosi:$packid = $version");
 
   return {
       'provides' => \@provides,
       'source' => $packid,
-      'name' => $name,
+      'name' => "mkosi:$name",
       'version' => $version,
       'release' => '0',
       'arch' => $architecture,

--- a/PBuild/Recipe.pm
+++ b/PBuild/Recipe.pm
@@ -82,7 +82,7 @@ sub find_recipe {
     }
   }
   if (1) {
-    @files = grep {/mkosi\.$/} keys %files;
+    @files = grep {/^mkosi\./} keys %files;
     return $files{$files[0]} if @files == 1;
     if (@files > 1) {
       @files = sort @files;

--- a/PBuild/RepoMgr.pm
+++ b/PBuild/RepoMgr.pm
@@ -170,6 +170,8 @@ sub copyimagebinaries {
       $to =~ s/[\/:]/_/g;
       PBuild::Verify::verify_filename($to);
       $to = "$dstdir/containers/$to";
+    } elsif ($q->{'name'} =~ /^mkosi:/) {
+      $to = "$dstdir/$q->{'lnk'}";
     } else {
       die("package $q->{'name'} is not available\n") unless $q->{'filename'};
       PBuild::Verify::verify_filename($q->{'filename'});

--- a/build-recipe-mkosi
+++ b/build-recipe-mkosi
@@ -93,9 +93,23 @@ recipe_build_mkosi() {
     if [ -n "$RELEASE" ]; then
         image_version="--image-version=${RELEASE}"
     fi
-    chroot "$BUILD_ROOT" sh -c \
-        "cd $TOPDIR/SOURCES && mkosi --default $RECIPEFILE $RELEASE_ARG $image_version --nspawn-keep-unit --output-dir $TOPDIR/OTHER --checksum --repository-key-check=no --with-network=never --local-mirror file:///.build.binaries/ --cache /.build.binaries/ build" \
-        || cleanup_and_exit 1
+    set -- mkosi \
+        --directory "$TOPDIR/SOURCES" \
+        --default \
+        "$RECIPEFILE" \
+        $RELEASE_ARG \
+        $image_version \
+        --nspawn-keep-unit \
+        --output-dir "$TOPDIR/OTHER" \
+        --checksum \
+        --repository-key-check=no \
+        --with-network=never \
+        --local-mirror file:///.build.binaries/ \
+        --cache /.build.binaries/ \
+        build
+
+    echo "running $*"
+    chroot "$BUILD_ROOT" "$@" || cleanup_and_exit 1
 
     # move the output files from the subdirectory, as only files in the OTHER/ directory
     # are published, but they get deposited in OTHER/$DIST~$RELEASE/
@@ -125,3 +139,5 @@ recipe_resultdirs_mkosi() {
 recipe_cleanup_mkosi() {
     :
 }
+
+# vim: syntax=sh

--- a/build-vm
+++ b/build-vm
@@ -657,6 +657,9 @@ vm_detect_2nd_stage() {
         mount -orw -n -t securityfs securityfs /sys/kernel/security 2>/dev/null || :
     fi
 
+    # delete dummy /etc/os-release file
+    test -e /etc/os-release -a ! -s /etc/os-release && rm -f /etc/os-release
+
 # qemu inside of xen does not work, check again with kvm later before enabling this
 #    if test -e /dev/kqemu ; then
 #        # allow abuild user to run qemu
@@ -1073,6 +1076,11 @@ vm_first_stage() {
     fi
 
     if test -n "$VM_ROOT" ; then
+	# create an empty os-release file unless it already exists. newer systemd version insist
+	# will not switch to the root unless it exists
+	if test ! -L "$BUILD_ROOT/etc/os-release" -a ! -e "$BUILD_ROOT/etc/os-release" ; then
+	    touch "$BUILD_ROOT/etc/os-release"
+	fi
 	# copy out kernel & initrd (if they exist) during unmounting VM image
 	KERNEL_TEMP_DIR=
         local vm_type="$VM_TYPE"


### PR DESCRIPTION
Not sure how this worked before. Detecting mkosi recipes didn't work and some of the options used are deprecated.
With the commits provided here, mkosi starts to build for me in pbuild but runs into issues later. 

A config file for mkosi has to specify a distribution so mkosi knows eg what package manager to use. Then the distro comes with a set of default packages that are installed always. The build script cannot know about that before setting up the chroot as the list is part of a package of the target system.

cc @bluca