### PR TITLE
Only copy modified dsc sources listed in .changes if OBS-DCH-RELEASE set

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -197,7 +197,7 @@ dsc_move_build_result() {
 	mv "$changes" "$BUILD_ROOT/$TOPDIR/DEBS"
     done
 
-    if test "$RECIPEFILE" != "debian/control" -a "$RECIPEFILE" != "debian.control" ; then
+    if test "$RECIPEFILE" != "debian/control" -a "$RECIPEFILE" != "debian.control" -a -z "$OBS_DCH_RELEASE" ; then
 	# link used sources over to DEB directory
 	ln $BUILD_ROOT/$DEB_SOURCEDIR/$DEB_DSCFILE $BUILD_ROOT/$TOPDIR/DEBS/
 	while read f ; do


### PR DESCRIPTION
In that case modified versions will have been generated as part of the build output. So this avoids coping out two dsc sources, which can cause issues for the source service and schedular trigger dependency rebuilds, or publish hook publishing .dsc source package.

This has happend since the merge of d995de1 dsc_move_build_result() will copy out both original and new one generated .dsc that is list listed in the .changes files. The .changes files list all the modified sources as well as the packages so can be consider definitive.

Closes: 928