### PR TITLE
pbuild: Handle string instead of hashref

### DIFF
--- a/PBuild/Checker.pm
+++ b/PBuild/Checker.pm
@@ -728,7 +728,7 @@ sub handlecycle {
     my $notready = $ctx->{'notready'};
     my $pkgsrc = $ctx->{'pkgsrc'};
     if (grep {$notready->{$_->{'name'} || $_->{'pkg'}}} map {$pkgsrc->{$_}} @cycp) {
-      $notready->{$_->{'name'} || $_->{'pkg'}} ||= 1 for @cycp;
+      $notready->{(ref($_) ne "HASH" && $_) || $_->{'name'} || $_->{'pkg'}} ||= 1 for @cycp;
     }
     return (undef, 3);
   }


### PR DESCRIPTION
Without this patch, pbuild (of openSUSE:Factory:Rings:0-Bootstrap standard x86_64) failed with

    building binutils/binutils.spec
    Can't use string ("binutils") as a HASH ref while "strict refs" in use at /usr/lib/build/PBuild/Checker.pm line 731.