### PR TITLE
vm-build: ext3 & ext4: fix disk space allocation

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -433,10 +433,10 @@ vm_img_mkfs() {
     esac
 
     # defaults for creating the filesystem
-    vm_img_mkfs_ext4_options='-O ^has_journal,^huge_file,^resize_inode,sparse_super,^metadata_csum'
-    vm_img_mkfs_ext4_extra='-E lazy_itable_init,discard'
+    vm_img_mkfs_ext4_options='-O ^has_journal,^huge_file,^resize_inode,sparse_super,^metadata_csum -E nodiscard'
+    vm_img_mkfs_ext4_extra='-E lazy_itable_init,nodiscard' # overwrites -E from _options by default
     vm_img_mkfs_ext4="mkfs.ext4 -m 0 -q -F $vm_img_mkfs_ext4_options"
-    vm_img_mkfs_ext3='mkfs.ext3 -m 0 -q -F'
+    vm_img_mkfs_ext3='mkfs.ext3 -m 0 -q -F -E nodiscard'
     vm_img_mkfs_ext2='mkfs.ext2 -m 0 -q -F'
     vm_img_mkfs_reiserfs='mkreiserfs -q -f'
     vm_img_mkfs_btrfs='mkfs.btrfs'


### PR DESCRIPTION
We did fallocate the root device explicit to ensure available disk space according to the config. However, the mkfs is operation with discard and frees the disk space again.

This leads to over-commited when having multiple worker instances.

So we explicit disable the punch hole/fallocate call inside of mkfs.ext3 and mkfs.ext4 by setting nodiscard.

An obs worker instance will disable itself when running into this situation.