### PR TITLE
Drop automatic inclusion of .pc file for baselibs.

### DIFF
--- a/baselibs_configs/baselibs_global.conf
+++ b/baselibs_configs/baselibs_global.conf
@@ -24,7 +24,7 @@ targettype 64bit extension 64
 
 targetname <name>-<targettype>
 
-+.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la|pc)$
++.*/lib(64|ilp32)?/.*\.(so\..*|so|o|a|la)$
 
 targettype 64bit -^(/usr)?/lib(ilp32)?/lib
 targettype 32bit -/lib64/


### PR DESCRIPTION
Fixes #724.

Avoid default inclusion of pkgconfig files in automatically generated baselibs configured biarch packages. This avoids the "have choice" issue seen with `BuildRequires: pkgconfig(FOO)` type dependencies on OBS for any dependents of a biarch FOO-devel package. It is wrong to ask every project supporting biarch devel packages to configure project macros to disfavour one pkgconfig based dependency in favour of another.

Packager may at their wish explicitly include the pkgconfig file in the biarch package explicitly by appropriately configure the associated baselibs.conf file, but as a default, this should be hardly ever required.