### PR TITLE
config: sync Tumbleweed config

### DIFF
--- a/configs/tumbleweed.conf
+++ b/configs/tumbleweed.conf
@@ -7,7 +7,7 @@ BuildFlags: genmetaalgo:1
 # The prjconf macros have a serial to help work around issues like https://github.com/openSUSE/open-build-service/issues/4088
 # On macros having impact on dep chains, update the serial (mainly ruby, python)
 # Using a date to indicate when we set the serial
-ExpandFlags: macroserial:20240515
+ExpandFlags: macroserial:20240529
 
 ExpandFlags: kiwi-nobasepackages
 ExpandFlags: docker-nobasepackages
@@ -379,6 +379,7 @@ FileProvides: /usr/bin/nmtui NetworkManager-tui
 FileProvides: /usr/bin/node nodejs-common
 FileProvides: /usr/bin/node20 nodejs20
 FileProvides: /usr/bin/node21 nodejs21
+FileProvides: /usr/bin/node22 nodejs22
 FileProvides: /usr/bin/nohup busybox-coreutils coreutils coreutils-single
 FileProvides: /usr/bin/nslookup bind-utils busybox-bind-utils
 FileProvides: /usr/bin/ocamlrun ocaml-runtime
@@ -494,6 +495,7 @@ FileProvides: /usr/bin/xmllint libxml2-tools
 FileProvides: /usr/bin/xsltproc libxslt-tools
 FileProvides: /usr/bin/xz busybox-xz xz
 FileProvides: /usr/bin/zcat busybox-gzip gzip zstd-gzip
+FileProvides: /usr/bin/zstd zstd
 FileProvides: /usr/sbin/a2enflag apache2
 FileProvides: /usr/sbin/a2enmod apache2
 FileProvides: /usr/sbin/agetty util-linux
@@ -501,6 +503,7 @@ FileProvides: /usr/sbin/fonts-config fonts-config
 FileProvides: /usr/sbin/groupadd shadow
 FileProvides: /usr/sbin/groupdel shadow
 FileProvides: /usr/sbin/groupmod shadow
+FileProvides: /usr/sbin/iconvconfig glibc
 FileProvides: /usr/sbin/ipsec strongswan-ipsec
 FileProvides: /usr/sbin/ldconfig glibc
 FileProvides: /usr/sbin/lpadmin cups-client
@@ -515,7 +518,6 @@ FileProvides: /usr/sbin/update-alternatives update-alternatives
 FileProvides: /usr/sbin/useradd shadow
 FileProvides: /usr/sbin/userdel shadow
 FileProvides: /usr/sbin/usermod shadow
-
 
 # Files which are provided and required by the same package only
 # are not part of primary.xml.gz, thus missing in the section above.
@@ -554,6 +556,7 @@ Prefer: -busybox-procps -procps4
 Prefer: -busybox-psmisc
 Prefer: -busybox-sed
 Prefer: -busybox-tar
+Prefer: -busybox-unzip
 Prefer: -busybox-util-linux
 Prefer: -podman-docker
 # have choice for /usr/bin/dbus-launch needed by gnome-session-core: dbus-1 dbus-1-x11
@@ -783,6 +786,7 @@ Prefer: udev-mini
 # break dependency of the -mini packages: they are valid for OBS, but not for end-user-installation
 Ignore: cmake-mini:this-is-only-for-build-envs
 Ignore: dummy-release:this-is-only-for-build-envs
+Ignore: envsubst-mini:this-is-only-for-build-envs
 Ignore: erlang-rebar-obs:this-is-only-for-build-envs
 Ignore: ffmpeg-5-mini-devel:this-is-only-for-build-envs
 Ignore: ffmpeg-5-mini-libs:this-is-only-for-build-envs
@@ -795,6 +799,8 @@ Ignore: ghc-bootstrap:this-is-only-for-build-envs
 Ignore: ghostscript-mini:this-is-only-for-build-envs
 Ignore: harfbuzz-bootstrap:this-is-only-for-build-envs
 Ignore: jdk-bootstrap:this-is-only-for-build-envs
+Ignore: krb5-mini-devel:this-is-only-for-build-envs
+Ignore: krb5-mini:this-is-only-for-build-envs
 Ignore: libpxbackend-1_0-mini:this-is-only-for-build-envs
 Ignore: libsystemd0-mini:this-is-only-for-build-envs
 Ignore: libudev-mini1:this-is-only-for-build-envs
@@ -806,8 +812,6 @@ Ignore: postgresql16-devel-mini:this-is-only-for-build-envs
 Ignore: systemd-mini-container:this-is-only-for-build-envs
 Ignore: systemd-mini:this-is-only-for-build-envs
 Ignore: udev-mini:this-is-only-for-build-envs
-Ignore: krb5-mini-devel:this-is-only-for-build-envs
-Ignore: krb5-mini:this-is-only-for-build-envs
 
 # Ring0 packages should not pull in 'info' - making the base VM smaller
 Ignore: autoconf:info
@@ -1422,11 +1426,16 @@ Prefer: -unzip-rcc
 Prefer: -primus
 Prefer: -staging-build-key
 Prefer: -clutter-gst-devel
+
 # We have multiple versions of ffmpeg available, the preferred one is ffmpeg5, followd by 4, followed by 3
 %define ffmpeg_pref ffmpeg-6
 Prefer: %{ffmpeg_pref}-mini-libs
 Prefer: %{ffmpeg_pref}-mini-devel
 Prefer: %{ffmpeg_pref} %{ffmpeg_pref}-libavcodec-devel %{ffmpeg_pref}-libavformat-devel %{ffmpeg_pref}-libavutil-devel %{ffmpeg_pref}-libswscale-devel %{ffmpeg_pref}-libavdevice-devel %{ffmpeg_pref}-libavfilter-devel
+Macros:
+%ffmpeg_pref ffmpeg-6
+:Macros
+
 # oxygen5-icon-theme osboletes oxygen-icon-theme
 Prefer: oxygen5-icon-theme
 
@@ -1491,8 +1500,8 @@ Prefer: libsane1
 Prefer: libglfw3
 # have choice for (xclip or wl-clipboard) needed by password-store: wl-clipboard xclip
 Prefer: -wl-clipboard
-# have choice for pkgconfig(libhs): hyperscan-devel vectorscan-devel. hyperscan is for x86 only, prefer that where possible (for now).
-Prefer: hyperscan-devel
+# have choice for pkgconfig(libhs): hyperscan-devel vectorscan-devel. hyperscan is no longer free - de-prefer it
+Prefer: -hyperscan-devel
 
 Ignore: installation-images-openSUSE:cracklib-dict-full
 Ignore: openSUSE-release:openSUSE-release-ftp,openSUSE-release-dvd5,openSUSE-release-biarch,openSUSE-release-livecdkde,openSUSE-release-livecdgnome
@@ -1804,6 +1813,7 @@ BuildFlags: onlybuild:dejavu-fonts
 BuildFlags: onlybuild:deltarpm
 BuildFlags: onlybuild:desktop-file-utils
 BuildFlags: onlybuild:devscripts
+BuildFlags: onlybuild:devscripts:checkbashisms
 BuildFlags: onlybuild:dialog
 BuildFlags: onlybuild:diffutils
 BuildFlags: onlybuild:dirac
@@ -2378,6 +2388,7 @@ BuildFlags: onlybuild:nlohmann_json
 BuildFlags: onlybuild:nodejs-common
 BuildFlags: onlybuild:nodejs20
 BuildFlags: onlybuild:nodejs21
+BuildFlags: onlybuild:nodejs22
 BuildFlags: onlybuild:npth
 BuildFlags: onlybuild:nss-mdns
 BuildFlags: onlybuild:numactl
@@ -2557,6 +2568,7 @@ BuildFlags: onlybuild:perl-Mock-Config
 BuildFlags: onlybuild:perl-Module-Build
 BuildFlags: onlybuild:perl-Module-Build-Tiny
 BuildFlags: onlybuild:perl-Module-Implementation
+BuildFlags: onlybuild:perl-Module-Pluggable
 BuildFlags: onlybuild:perl-Module-Runtime
 BuildFlags: onlybuild:perl-Mojo-DOM58
 BuildFlags: onlybuild:perl-Moo
@@ -2975,6 +2987,7 @@ BuildFlags: onlybuild:qmlpluginexports:qt5
 BuildFlags: onlybuild:qrencode
 BuildFlags: onlybuild:qtdeclarative-imports-provides:qt5
 BuildFlags: onlybuild:quota
+BuildFlags: onlybuild:rapidjson
 BuildFlags: onlybuild:raptor
 BuildFlags: onlybuild:rav1e
 BuildFlags: onlybuild:rdma-core
@@ -3012,6 +3025,7 @@ BuildFlags: onlybuild:rust1.74
 BuildFlags: onlybuild:rust1.75
 BuildFlags: onlybuild:rust1.76
 BuildFlags: onlybuild:rust1.77
+BuildFlags: onlybuild:rust1.78
 BuildFlags: onlybuild:samba
 BuildFlags: onlybuild:sane-backends
 BuildFlags: onlybuild:sassc


### PR DESCRIPTION
Change needed to address this new test failure:

https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:A/build/standard/x86_64

gettext-runtime is splitting out envsubst (andenvsubst-mini); the mini flavor does, as usual, require `thisis-only-for-build-envs' which is to be ignored by OBS/build