### PR TITLE
fix: handle trailing slashes in BUILD_ROOT path comparison

### DIFF
--- a/build-recipe-appimage
+++ b/build-recipe-appimage
@@ -30,7 +30,7 @@ recipe_setup_appimage() {
     for i in OTHER SOURCES APPIMAGE_ROOT ; do
 	mkdir -p "$BUILD_ROOT$TOPDIR/$i"
     done
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -30,7 +30,7 @@ recipe_setup_docker() {
     TOPDIR="/usr/src/packages"
     test "$DO_INIT_TOPDIR" != false && rm -Rf "$BUILD_ROOT/$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR/SOURCES"
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
         mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
         if test -z "$LINKSOURCES" ; then 

--- a/build-recipe-flatpak
+++ b/build-recipe-flatpak
@@ -32,7 +32,7 @@ recipe_setup_flatpak() {
     for i in OTHER SOURCES FLATPAK_ROOT ; do
 	mkdir -p "$BUILD_ROOT$TOPDIR/$i"
     done
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"

--- a/build-recipe-helm
+++ b/build-recipe-helm
@@ -22,7 +22,7 @@ recipe_setup_helm() {
     TOPDIR="/usr/src/packages"
     test "$DO_INIT_TOPDIR" != false && rm -Rf "$BUILD_ROOT/$TOPDIR"
     mkdir -p "$BUILD_ROOT$TOPDIR/SOURCES"
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	if test -z "$LINKSOURCES" ; then

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -312,7 +312,7 @@ recipe_setup_kiwi() {
     mkdir -p "$BUILD_ROOT$TOPDIR/RPMS"
     mkdir -p "$BUILD_ROOT$TOPDIR/SRPMS"
     
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then 
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then 
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	if test -z "$LINKSOURCES" ; then 

--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -31,7 +31,7 @@ recipe_setup_livebuild() {
     for i in OTHER SOURCES LIVEBUILD_ROOT ; do
 	mkdir -p "$BUILD_ROOT$TOPDIR/$i"
     done
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"

--- a/build-recipe-productcompose
+++ b/build-recipe-productcompose
@@ -34,7 +34,7 @@ recipe_setup_productcompose() {
     mkdir -p "$BUILD_ROOT$TOPDIR/RPMS"
     mkdir -p "$BUILD_ROOT$TOPDIR/SRPMS"
 
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	if test -z "$LINKSOURCES" ; then

--- a/build-recipe-simpleimage
+++ b/build-recipe-simpleimage
@@ -24,7 +24,7 @@ recipe_setup_simpleimage() {
     for i in SOURCES OTHER ; do
         mkdir -p "$BUILD_ROOT$TOPDIR/$i"
     done
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
         mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
         copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"

--- a/build-recipe-snapcraft
+++ b/build-recipe-snapcraft
@@ -30,7 +30,7 @@ recipe_setup_snapcraft() {
     for i in OTHER SOURCES SNAPCRAFT_ROOT ; do
 	mkdir -p "$BUILD_ROOT$TOPDIR/$i"
     done
-    if test "$MYSRCDIR" = $BUILD_ROOT/.build-srcdir ; then
+    if test "$MYSRCDIR" = ${BUILD_ROOT%/}/.build-srcdir ; then
 	mv "$MYSRCDIR"/* $BUILD_ROOT$TOPDIR/SOURCES/
     else
 	copy_sources "$MYSRCDIR" "$BUILD_ROOT$TOPDIR/SOURCES/"


### PR DESCRIPTION
In the current implementation, we compare the MYSRCDIR variable with a constructed path using the BUILD_ROOT variable. This comparison can fail if BUILD_ROOT ends with a trailing slash(eg. In KVM, BUILD_ROOT is set to '/'), causing copy behavior.