### PR TITLE
productcompose: transport the __all__ packageset as '*' package

### DIFF
--- a/Build/ProductCompose.pm
+++ b/Build/ProductCompose.pm
@@ -76,6 +76,10 @@ sub get_pkgset {
   $flavor = '' unless defined $flavor;
   my @seenps;
   my $lasts;
+
+  # asterisk is our internal marker for all packages
+  return ['*'] if $setname eq '__all__';
+
   for my $s (@$packagesets) {
     push @seenps, $lasts if defined $lasts;
     $lasts = $s;


### PR DESCRIPTION
'*' is our internal marker for all packages, but we want a speaking string in productcompose files.

This is to support builds which take all available packages.