### PR TITLE
Introduce buildflag nochecks

### DIFF
--- a/PBuild/Job.pm
+++ b/PBuild/Job.pm
@@ -313,6 +313,7 @@ sub createjob {
   }
 
   push @args, '--clean' unless $opts->{'noclean'};
+  push @args, '--checks' if $opts->{'checks'};
   push @args, '--nochecks' if $opts->{'nochecks'};
   push @args, '--shell' if $opts->{'shell'};
   push @args, '--shell-after-fail' if $opts->{'shell-after-fail'};

--- a/PBuild/Options.pm
+++ b/PBuild/Options.pm
@@ -33,6 +33,7 @@ my $pbuild_options = {
   'reponame' => ':',
   'noclean' => '',
   'no-clean' => 'noclean',
+  'checks' => '',
   'nochecks' => '',
   'no-checks' => 'nochecks',
   'arch' => ':',

--- a/build
+++ b/build
@@ -72,7 +72,7 @@ BUILD_OPTIONS_PARSED=
 DO_INIT=true
 DO_INIT_TOPDIR=true
 DO_LINT=
-DO_CHECKS=true
+DO_CHECKS=
 CLEAN_BUILD=
 GENBUILDREQS_CLEAN_BUILD=
 RECIPEFILES=()
@@ -1065,6 +1065,9 @@ while test -n "$1"; do
 	test "$DO_INIT" = false && DO_INIT_TOPDIR=false
 	DO_INIT=false
       ;;
+      -checks)
+	DO_CHECKS=true # default, but to overwrite possible config setting
+      ;;
       -nochecks|-no-checks)
 	DO_CHECKS=false
       ;;
@@ -1377,7 +1380,6 @@ test "$CONFIG_DIR" != "$BUILD_DIR/configs" && validate_param "--configdir" "$CON
 # validate the buildroot
 validate_buildroot "$BUILD_ROOT"
 
-
 if test -n "$VM_TYPE" -a -z "$RUNNING_IN_VM" ; then
     vm_verify_options
     vm_set_defaults
@@ -1415,6 +1417,8 @@ if test -n "$SEND_SYSRQ" ; then
     sysrq_running_build "$SEND_SYSRQ"
     cleanup_and_exit
 fi
+
+recipe_checks_config
 
 # done option parsing
 BUILD_OPTIONS_PARSED=true

--- a/build-recipe
+++ b/build-recipe
@@ -312,6 +312,16 @@ recipe_build_time_statistics() {
     fi
 }
 
+recipe_checks_config() {
+    if test -z "$DO_CHECKS"; then
+        local nochecks=$(queryconfig \
+                --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" \
+                --archpath "$BUILD_ARCH" buildflags nochecks
+            )
+        test -n "$nochecks" && DO_CHECKS=false || DO_CHECKS=true
+    fi
+}
+
 recipe_gendiff() {
     local obsgendiff=$(queryconfig \
             --dist "$BUILD_DIST" --configdir "$CONFIG_DIR" \

--- a/build.1
+++ b/build.1
@@ -61,6 +61,12 @@ A shell script used to generate a Collax binary package.
 .B --clean
 Remove the build system and reinitialize it from scratch.
 .TP
+.B --checks
+Run checks during build (default).
+.TP
+.B --no-checks
+Don't run checks during build.
+.TP
 .B --no-init
 Skip the build system initialization and start with build immediately.
 .TP

--- a/pbuild.1
+++ b/pbuild.1
@@ -111,6 +111,8 @@ the package.
 .TP
 .B "\-\-xen, \-\-kvm, ..."
 .TP
+.B "\-\-checks"
+.TP
 .B "\-\-no-checks"
 .TP
 .B "\-\-no-clean"


### PR DESCRIPTION
To disable all checks (%check section in rpm).

This can be overwritten by --no-checks or new --checks option on CLI.