### PR TITLE
exclude unsupported arch for Arch build

### DIFF
--- a/Build/Arch.pm
+++ b/Build/Arch.pm
@@ -159,6 +159,13 @@ sub parse {
     my @assets = get_assets(\%vars, $asuf);
     push @{$ret->{'remoteassets'}}, @assets if @assets;
   }
+  my @exclarch;
+  push @exclarch, @{$vars{'arch'}};
+  @exclarch = grep {$_ ne "any"} @exclarch;
+  # unify
+  my %exclarch = map {$_ => 1} @exclarch;
+  @exclarch = sort keys %exclarch;
+  $ret->{'exclarch'} = \@exclarch if @exclarch;
   return $ret;
 }
 


### PR DESCRIPTION
Currently Arch build script does not filter out unsupported architectures in `arch=()` and set `exclarch`.

According to [ArchLinux Ports RFC](https://gitlab.archlinux.org/dvzrv/rfcs/-/blob/rfc/arch_linux_ports/rfcs/0032-arch-linux-ports.rst), the `arch` field for PKGBUILDs is now not limited to x86 architectures such as x86_64 i386