### PR TITLE
set PACKAGER field in build-recipe-arch

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -35,7 +35,8 @@ recipe_setup_arch() {
 	echo 'source /etc/makepkg.conf'
 	printf '%s=%s\n' \
 	    BUILDDIR $TOPDIR/BUILD \
-	    PKGDEST $TOPDIR/ARCHPKGS
+	    PKGDEST $TOPDIR/ARCHPKGS \
+	    PACKAGER "\"$HOST <abuild@$HOST>\""
     } > $BUILD_ROOT$TOPDIR/makepkg.conf
 }
 


### PR DESCRIPTION
Add `PACKAGER` to makepkg and set to `$HOST <abuild@$HOST>`.

According to Arch's packaging specification, if a package needs to be distributed, the PACKAGER variable needs to be set to provide information about the packager, so it is set here to the hostname of the build machine for identification purposes.