### PR TITLE
pbuild: Use the Release value from _config

### DIFF
--- a/PBuild/Job.pm
+++ b/PBuild/Job.pm
@@ -332,7 +332,12 @@ sub createjob {
   push @args, '--dist', "$buildroot/.build.config";
   push @args, '--rpmlist', "$buildroot/.build.rpmlist";
   push @args, '--logfile', "$buildroot/.build.log";
-  #push @args, '--release', "$release" if defined $release;
+  my $release = $bconf->{'release'};
+  if (defined $release) {
+    $release =~ s/<CI_CNT>/1/g;
+    $release =~ s/<B_CNT>/1/g;
+    push @args, '--release', $release;
+  }
   push @args, '--debuginfo' if $ctx->{'debuginfo'} || $opts->{'debuginfo'};
   push @args, "--arch=$arch";
   push @args, '--jobs', $opts->{'jobs'} if $opts->{'jobs'};


### PR DESCRIPTION
For reproducible-builds I would like
to be able to produce identical binaries to OBS.

In prjconf I added `Release: 1.1`
but without this patch, pbuild ignored this.

We substitute the OBS CI_CNT and B_CNT counters with 1 to remain compatible.

Because there is a default value of `<CI_CNT>.<B_CNT>`, this will change the default package names from `foo-123-0` to `foo-123-1.1`

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.