### PR TITLE
dist: add more required recommendations for KVM builds

### DIFF
--- a/dist/build.spec
+++ b/dist/build.spec
@@ -72,10 +72,12 @@ BuildRequires:  perl(YAML::LibYAML)
 # None of them are actually required for core features.
 # Perl helper scripts use them.
 Recommends:     perl(Archive::Tar)
-Recommends:     /sbin/mkfs.ext3
+Recommends:     /sbin/mkfs.ext4
 Recommends:     /usr/bin/qemu-kvm
 Recommends:     bsdtar
+Recommends:     hostname
 Recommends:     qemu-linux-user
+Recommends:     xfsprogs
 Recommends:     zstd
 Recommends:     perl(Config::IniFiles)
 Recommends:     perl(Date::Language)


### PR DESCRIPTION
A worker system may have obs-worker installed, but because /usr/bin/build is transferred from obsrepserver, the dependencies of obs-build are not carried over. KVM builds thus fail complaining about absence of mkfs.ext4, mkfs.xfs or the hostname utility (especially if one used zypper in --no-recommends obs-worker, but that's another story).