### PR TITLE
fix writing _modulemd.yaml

### DIFF
--- a/build
+++ b/build
@@ -1987,7 +1987,7 @@ done
 
 if test -n "$MODULEMDFILE" ; then
    mkdir -p "$BUILD_ROOT/$TOPDIR/OTHER"
-   find "$BUILD_ROOT/$TOPDIR/RPMS" "$BUILD_ROOT/$TOPDIR/SRPMS" -type f -name "*.rpm" | sort | $BUILD_DIR/writemodulemd ${DISTURL:+--disturl "$DISTURL"} "$MODULEMDFILE" - > "$BUILD_ROOT/$TOPDIR/OTHER/_modulemd.yaml"
+   find "$BUILD_ROOT/$TOPDIR/RPMS" "$BUILD_ROOT/$TOPDIR/SRPMS" -type f -name "*.rpm" | sort | $BUILD_DIR/writemodulemd ${DISTURL:+--disturl "$DISTURL"} "$BUILD_ROOT/$TOPDIR/SOURCES/${MODULEMDFILE##*/}" - > "$BUILD_ROOT/$TOPDIR/OTHER/_modulemd.yaml"
    test -s "$BUILD_ROOT/$TOPDIR/OTHER/_modulemd.yaml" || rm -f "$BUILD_ROOT/$TOPDIR/OTHER/_modulemd.yaml"
 fi
 


### PR DESCRIPTION
the used MODULEMDFILE is available in TOPDIR/SOURCES at that time, the /.build-srcdir where the variable points to is long gone when the file is to be used as input for writemodulemd