### PR TITLE
fix file path for Arch repo

### DIFF
--- a/Build/Arch.pm
+++ b/Build/Arch.pm
@@ -248,7 +248,7 @@ sub queryfiles {
   # we use filter_cb here so that Archive::Tar skips the file contents
   $tar->read($handle, 1, {'filter_cb' => sub {
     my ($entry) = @_;
-    push @files, $entry->name unless $entry->is_longlink || (@files && $files[-1] eq $entry->name);
+    push @files, $entry->full_path unless $entry->is_longlink || (@files && $files[-1] eq $entry->full_path);
     return 0;
   }});
   shift @files if @files && $files[0] eq '.PKGINFO';


### PR DESCRIPTION
Currently OBS has a problem with file lookups for the Arch repo, resulting in potentially incorrectly generated `.files` files (missing path prefixes).

As described in https://perldoc.perl.org/Archive::Tar::File :

> `$path = $file->full_path`
> Returns the full path from the tar header; this is basically a concatenation of the prefix and name fields.

Using only `name` will result in the loss of the `prefix` part, e.g. `usr/lib` or `usr/lib/python3.xx` in some python packages.