### PR TITLE
build-vm-qemu: force sv48 satp mode on riscv64

### DIFF
--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -66,7 +66,7 @@ vm_startup_qemu() {
         riscv64)
             qemu_bin="/usr/bin/qemu-system-riscv64"
             qemu_console=${qemu_console:-ttyS0}
-            qemu_cpu="-cpu rv64"
+            qemu_cpu="-cpu rv64,sv48=on"
             qemu_options="$qemu_options -M virt -bios"
             if test -f /usr/share/qemu/opensbi-riscv64-generic-fw_dynamic.bin; then
                 qemu_options="$qemu_options /usr/share/qemu/opensbi-riscv64-generic-fw_dynamic.bin"


### PR DESCRIPTION
This is needed for openjdk which does not support sv57.