### PR TITLE
obs-docker-support: enable dnf and yum substitutions

### DIFF
--- a/obs-docker-support
+++ b/obs-docker-support
@@ -45,7 +45,7 @@ zypper() {
 	    globalopts[${#globalopts[@]}]="$1"
 	    shift
 	    ;;
-	*)  
+	*)
 	    cmd=$1
 	    shift
 	    break
@@ -103,7 +103,7 @@ apt_get() {
 	    globalopts[${#globalopts[@]}]="$1"
 	    shift
 	    ;;
-	*)  
+	*)
 	    cmd=$1
 	    shift
 	    break
@@ -136,7 +136,7 @@ dnf() {
 	    globalopts[${#globalopts[@]}]="$1"
 	    shift
 	    ;;
-	*)  
+	*)
 	    cmd=$1
 	    shift
 	    break
@@ -166,7 +166,7 @@ yum() {
 	    globalopts[${#globalopts[@]}]="$1"
 	    shift
 	    ;;
-	*)  
+	*)
 	    cmd=$1
 	    shift
 	    break
@@ -342,6 +342,12 @@ apt-get)
     ;;
 curl)
     curl "$@"
+    ;;
+dnf)
+    dnf "$@"
+    ;;
+yum)
+    yum "$@"
     ;;
 *)
     echo "obs-docker-support: unsupported mode ${0##*/}" >&2


### PR DESCRIPTION
All the code for dnf and yum was there since some time, but the entry point was missing, therefore making the "unsupported mode" message appear. Add the correct function call for dnf/yum so also those can successfully work in docker container creation in OBS.