### PR TITLE
Make spdx SBOMs readable by trivy scanner

### DIFF
--- a/Build/IntrospectGolang.pm
+++ b/Build/IntrospectGolang.pm
@@ -168,7 +168,7 @@ sub buildinfo  {
   my ($fh) = @_;
   my ($vers, $mod) = rawbuildinfo($fh);
   return undef unless defined $vers;
-  $vers =~ s/^go(.*)/\1/;
+  $vers =~ s/^go(.*)/$1/;
 
   my $buildinfo = { 'goversion' => $vers };
   my $lastmod;

--- a/Build/IntrospectGolang.pm
+++ b/Build/IntrospectGolang.pm
@@ -168,6 +168,8 @@ sub buildinfo  {
   my ($fh) = @_;
   my ($vers, $mod) = rawbuildinfo($fh);
   return undef unless defined $vers;
+  $vers =~ s/^go(.*)/\1/;
+
   my $buildinfo = { 'goversion' => $vers };
   my $lastmod;
   for my $l (split("\n", $mod || '')) {

--- a/Build/IntrospectGolang.pm
+++ b/Build/IntrospectGolang.pm
@@ -168,8 +168,6 @@ sub buildinfo  {
   my ($fh) = @_;
   my ($vers, $mod) = rawbuildinfo($fh);
   return undef unless defined $vers;
-  $vers =~ s/^go(.*)/$1/;
-
   my $buildinfo = { 'goversion' => $vers };
   my $lastmod;
   for my $l (split("\n", $mod || '')) {

--- a/generate_sbom
+++ b/generate_sbom
@@ -857,8 +857,13 @@ sub spdx_encode_pkg {
   }
   $spdx->{'copyrightText'} = $p->{'COPYRIGHTTEXT'} ? $p->{'COPYRIGHTTEXT'} : 'NOASSERTION';
   $spdx->{'homepage'} = $p->{'URL'} if $p->{'URL'};
-  my $purlurl = gen_purl($p, $distro, $pkgtype);
-  push @{$spdx->{'externalRefs'}}, { 'referenceCategory' => 'PACKAGE-MANAGER', 'referenceType' => 'purl', 'referenceLocator', $purlurl } if $purlurl;
+
+  # Let the caller control the presence of external refs
+  if($p->{'external_refs'} // 1) {
+    my $purlurl = gen_purl($p, $distro, $pkgtype);
+    push @{$spdx->{'externalRefs'}}, { 'referenceCategory' => 'PACKAGE-MANAGER', 'referenceType' => 'purl', 'referenceLocator', $purlurl } if $purlurl;
+  }
+
   if (!$p->{'spdx_id'}) {
     my $spdxtype = "Package-$pkgtype";
     $spdxtype = "Package-go-module" if $pkgtype eq 'golang';
@@ -935,6 +940,17 @@ sub spdx_encode_header {
   return $spdx;
 }
 
+sub spdx_encode_dist {
+  my ($dist) = @_;
+
+  return spdx_encode_pkg({
+    NAME => $dist->{id},
+    VERSION => $dist->{version_id},
+    spdx_id => sprintf('SPDXRef-OperatingSystem-%s', gen_pkg_id($dist)),
+    external_refs => 0
+  }, undef, undef, {});
+
+}
 
 ##################################################################################################
 #
@@ -1170,6 +1186,9 @@ if ($format eq 'spdx') {
       push @{$doc->{'files'}}, spdx_encode_file($f);
     }
   }
+
+  push @{$doc->{'packages'}}, spdx_encode_dist($dist);
+
   for (sort keys %unknown_spdx_licenses) {
     push @{$doc->{'hasExtractedLicensingInfos'}}, spdx_encode_extracted_license($unknown_spdx_licenses{$_});
   }

--- a/generate_sbom
+++ b/generate_sbom
@@ -618,6 +618,7 @@ sub gen_purl {
   my ($p, $distro, $pkgtype) = @_;
   my $name = $p->{'NAME'};
   my $vr = $p->{'VERSION'};
+  $vr =~ s/^go// if $pkgtype eq 'golang' && $name eq 'stdlib';
   my $purltype = $pkgtype eq 'rust' ? 'cargo' : $pkgtype;
   my $subpath;
   if ($pkgtype eq 'golang' && $name =~ /\A([^\/]+\/[^\/]+\/[^\/]+)\/(.+)/s) {

--- a/generate_sbom
+++ b/generate_sbom
@@ -618,7 +618,6 @@ sub gen_purl {
   my ($p, $distro, $pkgtype) = @_;
   my $name = $p->{'NAME'};
   my $vr = $p->{'VERSION'};
-  $vr =~ s/^go//;
   my $purltype = $pkgtype eq 'rust' ? 'cargo' : $pkgtype;
   my $subpath;
   if ($pkgtype eq 'golang' && $name =~ /\A([^\/]+\/[^\/]+\/[^\/]+)\/(.+)/s) {

--- a/generate_sbom
+++ b/generate_sbom
@@ -618,6 +618,7 @@ sub gen_purl {
   my ($p, $distro, $pkgtype) = @_;
   my $name = $p->{'NAME'};
   my $vr = $p->{'VERSION'};
+  $vr =~ s/^go//;
   my $purltype = $pkgtype eq 'rust' ? 'cargo' : $pkgtype;
   my $subpath;
   if ($pkgtype eq 'golang' && $name =~ /\A([^\/]+\/[^\/]+\/[^\/]+)\/(.+)/s) {

--- a/generate_sbom
+++ b/generate_sbom
@@ -860,10 +860,12 @@ sub spdx_encode_pkg {
   $spdx->{'homepage'} = $p->{'URL'} if $p->{'URL'};
 
   # Let the caller control the presence of external refs
-  if($p->{'external_refs'} // 1) {
+  if(!$p->{'skip_external_refs'}) {
     my $purlurl = gen_purl($p, $distro, $pkgtype);
     push @{$spdx->{'externalRefs'}}, { 'referenceCategory' => 'PACKAGE-MANAGER', 'referenceType' => 'purl', 'referenceLocator', $purlurl } if $purlurl;
   }
+
+  $spdx->{'primaryPackagePurpose'} = $p->{'primaryPackagePurpose'} if $p->{'primaryPackagePurpose'};
 
   if (!$p->{'spdx_id'}) {
     my $spdxtype = "Package-$pkgtype";
@@ -948,7 +950,8 @@ sub spdx_encode_dist {
     NAME => $dist->{id},
     VERSION => $dist->{version_id},
     spdx_id => sprintf('SPDXRef-OperatingSystem-%s', gen_pkg_id($dist)),
-    external_refs => 0
+    primaryPackagePurpose => 'OPERATING-SYSTEM',
+    skip_external_refs => 1
   }, undef, undef, {});
 
 }


### PR DESCRIPTION
Before:
```
trivy sbom --format template --template '{{ $vuln := 0 }}{{- range . }}{{- range .Vulnerabilities }}{{- $vuln = add $vuln 1 }}{{- end -}}{{- end -}}Vuln count: {{ $vuln }}'  /home/scc/code/obs-build/obs-sbom.spdx.json
2024-11-18T17:50:14+01:00       INFO    [vuln] Vulnerability scanning is enabled
2024-11-18T17:50:15+01:00       INFO    Detected SBOM format    format="spdx-json"
2024-11-18T17:50:18+01:00       WARN    [sbom] Ignore the OS package as no OS is detected.      file_path="/home/scc/code/obs-build/obs-sbom.spdx.json"
2024-11-18T17:50:18+01:00       INFO    Number of language-specific files       num=1
2024-11-18T17:50:18+01:00       INFO    [gobinary] Detecting vulnerabilities...
2024-11-18T17:50:18+01:00       WARN    Version matching error  err="version error (go1.17.9): malformed version: go1.17.9"
# the same, but 103 times more
2024-11-18T17:50:18+01:00       WARN    Version matching error  err="version error (go1.17.9): malformed version: go1.17.9"
Vuln count: 0
```

After:

```
trivy sbom --format template --template '{{ $vuln := 0 }}{{- range . }}{{- range .Vulnerabilities }}{{- $vuln = add $vuln 1 }}{{- end -}}{{- end -}}Vuln count: {{ $vuln }}'  /home/scc/code/obs-build/obs-sbom.spdx.json
2024-11-18T17:57:43+01:00       INFO    [vuln] Vulnerability scanning is enabled
2024-11-18T17:57:44+01:00       INFO    Detected SBOM format    format="spdx-json"
2024-11-18T17:57:47+01:00       INFO    Detected OS     family="sles" version="15.4"
2024-11-18T17:57:47+01:00       WARN    Unsupported os  family="sles"
2024-11-18T17:57:47+01:00       INFO    Number of language-specific files       num=1
2024-11-18T17:57:47+01:00       INFO    [gobinary] Detecting vulnerabilities...
2024-11-18T17:57:47+01:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/dev/docs/scanner/vulnerability#severity-selection for details.
Vuln count: 56
```
