### PR TITLE
Replace the pkgrel variable with the release number of the build system

### DIFF
--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -41,6 +41,20 @@ recipe_setup_arch() {
 }
 
 recipe_prepare_arch() {
+    echo "Replacing the pkgrel variable..."
+    ARCH_RELEASE=`grep -Eo '^[0-9]+(\.[0-9]+){0,1}' <<< "$RELEASE"`
+    [ -z "$ARCH_RELEASE" ] && ARCH_RELEASE=1
+    ARCH_RELEASE1=`cut -d. -f1 <<< "$ARCH_RELEASE"`
+    ARCH_RELEASE2=`cut -d. -f2 <<< "$ARCH_RELEASE"`
+    chroot $BUILD_ROOT su -c /bin/sh <<EOF
+cd $TOPDIR/SOURCES
+[ ! -f PKGBUILD ] && exit 0
+sed -e "s/^pkgrel=@RELEASE@$/pkgrel=$ARCH_RELEASE/" \
+    -e "s/^pkgrel=@RELEASE1@$/pkgrel=$ARCH_RELEASE1/" \
+    -e "s/^pkgrel=@RELEASE2@$/pkgrel=$ARCH_RELEASE2/" \
+    -i PKGBUILD
+EOF
+
     echo "Preparing sources..."
     if ! _arch_recipe_makepkg -so --skippgpcheck "2>&1" ">/dev/null" ; then
 	cleanup_and_exit 1 "failed to prepare sources"


### PR DESCRIPTION
The `PKGBUILD` file must contain one of the following placeholders:
`pkgrel=@RELEASE@`
`pkgrel=@RELEASE1@`
`pkgrel=@RELEASE2@`

Assuming the `$RELEASE` variable supplied by the build system contains the value `123.456` (default `<CI_CNT>.<B_CNT>`), the corresponding placeholder is replaced as follows:
`pkgrel=123.456`
`pkgrel=123`
`pkgrel=456`

`@RELEASE1@` and `@RELEASE2@` have been implemented in case someone wants to use a stricter variant with only one number.
Then you have the choice between `<CI_CNT>` or `<B_CNT>`.

For the use of `obs-service-set_version` an adjustment is necessary there.
I will link the corresponding pull-request here later.

See also https://github.com/openSUSE/obs-service-set_version/pull/98
