### PR TITLE
Parse unknown timezones as UTC

### DIFF
--- a/changelog2spec
+++ b/changelog2spec
@@ -33,6 +33,7 @@ use Time::Zone;
 
 use strict;
 
+$ENV{TZ} = "UTC";
 my @wday = qw{Sun Mon Tue Wed Thu Fri Sat};
 my @mon = qw{Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec};
 


### PR DESCRIPTION
Without this change, parsing changelog entries such as `Tue Mar 28 07:25:39 WEST 2017 - someone@suse` (from `yast2.changes`)

would produce a `Mar 27` date in the .spec file, because

```bash
TZ=CET perl -e 'use Date::Parse; print str2time("28 Mar 2017")'
1490652000
```

considers the local timezone and maps to

```bash
date -d @1490652000 -u -Iseconds
2017-03-27T22:00:00+00:00
```

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).