### PR TITLE
mkosi: drop most systemd/build-packages deps and use obs_scm directory as source if present

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -158,38 +158,14 @@ my %subst_defaults = (
   'system-packages:livebuild' => [
     'apt-utils', 'cpio', 'dpkg-dev', 'live-build', 'lsb-release', 'tar',
   ],
-  'build-packages:mkosi:rpm' => [
-    'btrfs-progs | btrfsprogs', 'dracut', 'e2fsprogs', 'systemd',
-    'systemd-networkd | systemd-network', 'systemd-udev | udev', 'xfsprogs',
-  ],
-  'build-packages:mkosi:deb' => [
-    'apt', 'btrfs-progs', 'ca-certificates', 'dracut', 'e2fsprogs', 'file',
-    'libpam-systemd', 'mawk', 'systemd', 'systemd-boot', 'systemd-resolved',
-    'systemd-sysv', 'tar', 'xfsprogs',
-  ],
-  'build-packages:mkosi:arch' => [
-    'base', 'btrfs-progs', 'cryptsetup', 'device-mapper', 'dracut', 'e2fsprogs',
-    'linux', 'systemd', 'xfsprogs',
-  ],
   'system-packages:mkosi:rpm' => [
-    'mkosi', 'binutils', 'btrfs-progs | btrfsprogs', 'cpio', 'createrepo',
-    'cryptsetup', 'dnf', 'dosfstools', 'e2fsprogs', 'integritysetup', 'gnupg',
-    'python3dist(cryptography)', 'squashfs-tools | squashfs',
-    'system-release | openSUSE-release', 'systemd-container', 'util-linux',
-    'veritysetup', 'tar', 'xz', 'xfsprogs', 'zstd', 'zypper',
+    'mkosi',
   ],
   'system-packages:mkosi:deb' => [
-    'mkosi', 'apt', 'btrfs-progs', 'cpio', 'cryptsetup-bin', 'dctrl-tools',
-    'debootstrap', 'debconf', 'dosfstools', 'dpkg-dev', 'e2fsprogs', 'fdisk',
-    'gnupg', 'linux-base', 'lsb-release', 'python3-cryptography',
-    'squashfs-tools', 'systemd-container', 'tar', 'xz-utils', 'xfsprogs',
-    'zstd',
+    'mkosi',
   ],
   'system-packages:mkosi:arch' => [
-    'mkosi', 'arch-install-scripts', 'binutils', 'btrfs-progs', 'cpio',
-    'cryptsetup', 'dosfstools', 'e2fsprogs', 'gnupg', 'gzip',
-    'python-cryptography', 'squashfs-tools', 'systemd', 'util-linux', 'tar',
-    'xfsprogs', 'xz', 'zstd',
+    'mkosi',
   ],
   'system-packages:mock' => [
     'mock', 'system-packages:repo-creation',

--- a/build-recipe-mkosi
+++ b/build-recipe-mkosi
@@ -89,6 +89,16 @@ recipe_build_mkosi() {
         fi
     fi
 
+    # If we are running with any source services, the sources might be unpacked in a directory
+    # in SOURCES/, so try to find the right one, by checking where the top level mkosi.conf is.
+    workdir="$TOPDIR/SOURCES/"
+    for d in "$TOPDIR"/SOURCES/*; do
+        if [ ! -d "$d" ]; then continue; fi
+        if [ ! -f "$d/mkosi.conf" ]; then continue; fi
+        workdir="$d"
+        break
+    done
+
     local image_version=""
     if [ -n "$RELEASE" ]; then
         image_version="--image-version=${RELEASE}"
@@ -97,7 +107,7 @@ recipe_build_mkosi() {
         image_version="--image-version=0"
     fi
     set -- mkosi \
-        --directory "$TOPDIR/SOURCES" \
+        --directory "$workdir" \
         --default \
         "$RECIPEFILE" \
         $RELEASE_ARG \


### PR DESCRIPTION
The package itself can pull in what it needs. The list of dependencies changes too often to be hard-coded here.
Also allow storing recipes in git via obs_scm.