### PR TITLE
debian: Ignoring package architecture like we do with rpm

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -94,7 +94,7 @@ pkg_prepare_deb() {
 }
 
 pkg_install_deb() {
-    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --force-architecture --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
     # ugly workaround for upstart system. some packages (procps) try
     # to start a service in their configure phase. As we don't have
@@ -212,7 +212,7 @@ pkg_sysrootinstall_deb() {
 	return
     fi
 
-    ( deb_chroot $BUILD_ROOT dpkg --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
+    ( deb_chroot $BUILD_ROOT dpkg --force-architecture --install $DEB_UNSAFE_IO $DEB_NO_TRIGGERS --force-depends .init_b_cache/$PKG.deb 2>&1 || touch $BUILD_ROOT/exit ) | \
 	perl -ne '$|=1;/^(Configuration file|Installing new config file|Selecting previously deselected|Selecting previously unselected|\(Reading database|Unpacking |Setting up|Creating config file|Preparing to replace dpkg|Preparing to unpack )/||/^$/||print'
 }
 


### PR DESCRIPTION
This is wanted to inject eg 64bit kernel package on a 32bit system.