### PR TITLE
Drop needsrootforbuild

### DIFF
--- a/dist/build.spec
+++ b/dist/build.spec
@@ -14,7 +14,6 @@
 
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
-# needsrootforbuild
 # needsbinariesforbuild
 
 


### PR DESCRIPTION
Drop `needsrootforbuild`
It seems to not be needed anymore.
It was part of the initial git import in 2017.