### PR TITLE
mkosi: add back system-packages used by build-recipe directly

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -159,13 +159,13 @@ my %subst_defaults = (
     'apt-utils', 'cpio', 'dpkg-dev', 'live-build', 'lsb-release', 'tar',
   ],
   'system-packages:mkosi:rpm' => [
-    'mkosi',
+    'mkosi', 'createrepo', 'gzip',
   ],
   'system-packages:mkosi:deb' => [
-    'mkosi',
+    'mkosi', 'dpkg-dev', 'lsb-release', 'gzip',
   ],
   'system-packages:mkosi:arch' => [
-    'mkosi',
+    'mkosi', 'arch-install-scripts', 'gzip',
   ],
   'system-packages:mock' => [
     'mock', 'system-packages:repo-creation',


### PR DESCRIPTION
The previous commit was a bit too zealous in dropping system-packages. Add back those that are used directly by the obs-build build-recipe-mkosi as the mkosi packages in the distros won't necessarily use them and thus depend on them directly.

Follow-up for 69e46e72f4be385bd428e4656b04a70395ad73ea