### PR TITLE
mkosi: Pass --checksum=yes instead of --checksum

### DIFF
--- a/build-recipe-mkosi
+++ b/build-recipe-mkosi
@@ -114,7 +114,7 @@ recipe_build_mkosi() {
         $image_version \
         --nspawn-keep-unit \
         --output-dir "$TOPDIR/OTHER" \
-        --checksum \
+        --checksum=yes \
         --repository-key-check=no \
         --with-network=never \
         --local-mirror file:///.build.binaries/ \


### PR DESCRIPTION
In https://github.com/systemd/mkosi/pull/3507 we've made a slight change to the command line parser to remove ambiguity. This requires all boolean options to receive an explicit argument now. This commit changes OBS to pass all boolean options with an argument. This was already supported by mkosi and will still work even with older versions of mkosi so the change should be safe to make.