### PR TITLE
Add support for 'wget' in Docker images

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -201,6 +201,23 @@ sub cmd_curl {
   }
 }
 
+sub cmd_wget {
+  my ($ret, @args) = @_;
+  my @urls;
+  while (@args) {
+    my $arg = shift @args;
+    if ($arg =~ /^-/) {
+      shift @args if $arg eq '-F' || $arg =~ /--post-data/ || $arg eq '-T' || $arg =~ /--timeout/ || $arg eq '-O' || $arg eq '--output-document' || $arg eq '-t' || $arg =~ /--tries/ || $arg eq '--user' || $arg eq '--password' || $arg eq '-U' || $arg eq '--user-agent' || $arg eq '--header';
+    } else {
+      push @urls, $arg if $arg =~ /^https?:\/\//;
+    }
+  }
+  for my $url (@urls) {
+    my $asset = { 'url' => $url, 'type' => 'webcache' };
+    push @{$ret->{'remoteassets'}}, $asset;
+  }
+}
+
 sub parse {
   my ($cf, $fn) = @_;
 
@@ -378,6 +395,8 @@ sub parse {
 	  cmd_apt_get($ret, @args);
 	} elsif ($rcmd eq 'curl') {
 	  cmd_curl($ret, @args);
+	} elsif ($rcmd eq 'wget') {
+	  cmd_wget($ret, @args);
 	} elsif ($rcmd eq 'obs_pkg_mgr') {
 	  cmd_obs_pkg_mgr($ret, @args);
 	}

--- a/obs-docker-support
+++ b/obs-docker-support
@@ -223,6 +223,49 @@ curl() {
     exec /usr/bin/curl "${cmd[@]}"
 }
 
+wget() {
+    local cmd
+    typeset -a cmd
+    local oopt
+    local oname
+    local fname
+    while test -n "$1"; do
+    case "$1" in
+    http://* | https://*)
+        url=$1
+        urlsha256=$(echo -n "$url" | sha256sum -)
+        urlsha256="${urlsha256%% *}"
+        if test -n "$DATA_DIR"; then
+            cmd[${#cmd[@]}]="file:$DATA_DIR/build-webcache/$urlsha256"
+        else
+            cmd[${#cmd[@]}]="http://localhost:80/build-webcache/$urlsha256"
+        fi
+        fname="${url%%\?*}"
+        fname="${url##*/}"
+        shift
+        ;;
+    -O|--output-document)
+        oopt=true
+        oname="$2"
+        shift 2
+        ;;
+    *)
+        cmd[${#cmd[@]}]="$1"
+        shift
+        ;;
+    esac
+    done
+
+    cmd[${#cmd[@]}]="-O"
+    if test -n "$oopt" -a -n "$oname"; then
+    cmd[${#cmd[@]}]="$oname"
+    else
+    cmd[${#cmd[@]}]="$fname"
+    fi
+
+    exec /usr/bin/wget "${cmd[@]}"
+}
+
 upload_with_perl='
 use Socket;
 $/ = undef;
@@ -264,6 +307,7 @@ setup_links() {
     test -e /usr/bin/dnf -a ! -e /usr/local/sbin/dnf && ln -s obs-docker-support /usr/local/sbin/dnf
     test -e /usr/bin/apt-get -a ! -e /usr/local/sbin/apt-get && ln -s obs-docker-support /usr/local/sbin/apt-get
     test -e /usr/bin/curl -a ! -e /usr/local/sbin/curl && ln -s obs-docker-support /usr/local/sbin/curl
+    test -e /usr/bin/wget -a ! -e /usr/local/sbin/wget && ln -s obs-docker-support /usr/local/sbin/wget
 }
 
 remove_links() {
@@ -272,6 +316,7 @@ remove_links() {
     rm -f /usr/local/sbin/dnf
     rm -f /usr/local/sbin/apt-get
     rm -f /usr/local/sbin/curl
+    rm -f /usr/local/sbin/wget
 }
 
 obs_docker_support() {
@@ -351,6 +396,9 @@ apt-get)
     ;;
 curl)
     curl "$@"
+    ;;
+wget)
+    wget "$@"
     ;;
 dnf)
     dnf "$@"

--- a/t/parse_docker.t
+++ b/t/parse_docker.t
@@ -18,15 +18,35 @@ FROM opensuse/tumbleweed AS tw
 # debug
 RUN cat /etc/os-release
 
+RUN zypper install wget curl
+
+RUN curl -sL --output /usr/bin/example-curl --retry 3 -u "foo:bar" https://localhost:8080/example-curl
+RUN wget -O /usr/bin/example-wget -t 3 --user foo --password bar https://localhost:8080/example-wget
+
 FROM opensuse/leap:15.2
 };
 
 $expected = {
   'name' => 'docker',
-  'deps' => ['container:opensuse/tumbleweed:latest', 'container:opensuse/leap:15.2'],
+  'deps' => [
+    'container:opensuse/tumbleweed:latest',
+    'wget',
+    'curl',
+    'container:opensuse/leap:15.2',
+  ],
   'path' => [],
   'imagerepos' => [],
   'basecontainer' => 'opensuse/leap:15.2',
+  'remoteassets' => [
+    {
+      'type' => 'webcache',
+      'url' => 'https://localhost:8080/example-curl'
+    },
+{
+      'type' => 'webcache',
+      'url' => 'https://localhost:8080/example-wget'
+    }
+  ],
 };
 
 $result = Build::Docker::parse($conf, \$dockerfile);


### PR DESCRIPTION
Allow wget calls to be cached by download_assets.

Sample Dockerfile for testing:

```Dockerfile
#!UseOBSRepositories
#!ExclusiveArch: x86_64 aarch64
#!BuildTag: tumbleweed-logo

FROM opensuse/tumbleweed

RUN zypper in -y wget

RUN wget -O /root/opensuse-icon.svg https://static.opensuse.org/favicon.svg

RUN wget https://static.opensuse.org/favicon.svg

RUN curl -o /root/die-logo.svg https://linux.die.net/style/logo.svg
```