### PR TITLE
fix compatibility with qemu 10.0 (fixes#1071)

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -318,7 +318,18 @@ vm_startup_kvm() {
 	# use qemu user by default if available
 	getent passwd qemu >/dev/null && VM_USER=qemu
     fi
-    [ -n "$VM_USER" ] && kvm_options="$kvm_options -runas $VM_USER"
+    if test -n "$VM_USER" ; then
+	# version 10.0 removed the "-runas" option
+	V=$($qemu_bin -version 2>/dev/null | head -1)
+	case "$V" in
+	    *"version 1"*)
+		kvm_options="$kvm_options -run-with user=$VM_USER"
+		;;
+	    *)
+		kvm_options="$kvm_options -runas $VM_USER"
+		;;
+	esac
+    fi
     if test -n "$VM_SWAP" ; then
 	qemu_args=("${qemu_args[@]}" -drive file="$VM_SWAP",format=raw,if=none,id=swap,$kvm_drive_opts -device "$kvm_device$kvm_device_opts",drive=swap,serial=1)
     fi

--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -158,7 +158,18 @@ vm_startup_qemu() {
         # use qemu user by default if available
         getent passwd qemu >/dev/null && VM_USER=qemu
     fi
-    [ -n "$VM_USER" ] && qemu_options="$qemu_options -runas $VM_USER"
+    if test -n "$VM_USER" ; then
+	V=$($qemu_bin -version 2>/dev/null | head -1)
+	# version 10.0 removed the "-runas" option
+	case "$V" in
+	    *"version 1"*)
+		qemu_options="$qemu_options -run-with user=$VM_USER"
+		;;
+	    *)
+		qemu_options="$qemu_options -runas $VM_USER"
+		;;
+	esac
+    fi
     if test -n "$VM_SWAP" ; then
         qemu_args=("${qemu_args[@]}" -drive file="$VM_SWAP",format=raw,if=none,id=swap,cache=unsafe -device "$qemu_device",drive=swap,serial=1)
     fi


### PR DESCRIPTION
qemu 10.0 has dropped the "-runas" option. Unfortunately the replacement "-run-with user=" was only introduced in qemu-9, which is not included in SLES15, so both variants need to be supported.
Try runtime detection of qemu and select appropriate options.