### PR TITLE
Add IPv6 localhost record to /etc/hosts

### DIFF
--- a/init_buildsystem
+++ b/init_buildsystem
@@ -1319,6 +1319,7 @@ if ! grep -F "127.0.0.1 $HOST" $BUILD_ROOT/etc/hosts > /dev/null ; then
     # on the interface no matter the OS!
     #
     echo "127.0.0.1 $HOST" > $BUILD_ROOT/etc/hosts.new
+	echo "::1 $HOST" >> $BUILD_ROOT/etc/hosts.new
     test -f $BUILD_ROOT/etc/hosts && cat $BUILD_ROOT/etc/hosts >> $BUILD_ROOT/etc/hosts.new
     mv $BUILD_ROOT/etc/hosts.new $BUILD_ROOT/etc/hosts
 fi


### PR DESCRIPTION
Noticed that when building ping, `/etc/hosts` in chroot only contains:
```
127.0.0.1 <myhostname>
127.0.0.1 localhost
```
This PR adds also `::1 localhost` as well, to be able to resolve IPv6 on localhost as well.