### PR TITLE
Make spec2changelog more resiliant to 3rd party spefiles

### DIFF
--- a/spec2changelog
+++ b/spec2changelog
@@ -53,6 +53,7 @@ while (<>) {
     if (/^%changelog/ .. eof()) {
         next if /^%/;
         next if /^\s*#/;
+        next if /^\s*$/;
 
         chomp;
         s/\s+$//;

--- a/spec2changelog
+++ b/spec2changelog
@@ -77,9 +77,11 @@ foreach my $time (sort { $b <=> $a } (keys(%items))) {
     my $head = shift(@$item);
     $head =~ s/^\s+//;
     $head =~ s/^\-\s+//;
-    if ($head =~ m/^(.+?)\s*<(.+?\@.+?\..+?)>(\s*.*)$/) {
+    if ($head =~ m/^(.+?)\s*<(.+?\@.+?\..+?)>(\s*.*)$/ ||
+        $head =~ m/^(.+?)\s*<(.+? at .+? dot .+?)>(\s*.*)$/) {
         $head = "$1 <$2>";
-    } elsif ($head =~ m/^<(.+?\@.+?\..+?)>(\s*.*)$/) {
+    } elsif ($head =~ m/^<(.+?\@.+?\..+?)>(\s*.*)$/ ||
+             $head =~ m/^<(.+? at .+? dot .+?)>(\s*.*)$/) {
         $head = $1;
     }
     if ($head =~ m/^\s*-\s*(.+)$/) {


### PR DESCRIPTION
The two commit will make spec2changelog work with specfiles from Fedora I've encountered:
`%changelog` sections may contain empty lines and people may use "spam-paranoia" email addresses.