### PR TITLE
Additional configuration updates for build-vm-qemu for m68k

### DIFF
--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -108,7 +108,7 @@ vm_startup_qemu() {
             ;;
         m68k)
             qemu_bin="/usr/bin/qemu-system-m68k"
-            qemu_console=${qemu_console:-ttyAMA0}
+            qemu_console=${qemu_console:-ttyGF}
             qemu_cpu="-cpu m68000"
             qemu_options="$qemu_options -M virt"
             ;;

--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -109,7 +109,7 @@ vm_startup_qemu() {
         m68k)
             qemu_bin="/usr/bin/qemu-system-m68k"
             qemu_console=${qemu_console:-ttyGF}
-            qemu_cpu="-cpu m68000"
+            qemu_cpu="-cpu m68040"
             qemu_options="$qemu_options -M virt"
             ;;
         riscv32)


### PR DESCRIPTION
This sets the proper console device and CPU for the virt machine type.