### PR TITLE
Remove elevator=noop from the command build vm kernel cmdline

### DIFF
--- a/build-vm-kvm
+++ b/build-vm-kvm
@@ -360,7 +360,7 @@ vm_startup_kvm() {
         qemu_append="$qemu_append $vm_cmdline"
     else
         # Pick sensible defaults
-        qemu_append="$qemu_append $kvm_qemu_append $vm_linux_kernel_parameter elevator=noop"
+        qemu_append="$qemu_append $kvm_qemu_append $vm_linux_kernel_parameter"
         qemu_append="$qemu_append nmi_watchdog=0 rw rd.driver.pre=binfmt_misc"
     fi
     qemu_append="$qemu_append $vm_linux_always_append console=$kvm_console init=$vm_init_script"

--- a/build-vm-pvm
+++ b/build-vm-pvm
@@ -187,7 +187,7 @@ insmod linux
 insmod disk
 insmod elf
 set root='ieee1275//vdevice/v-scsi@30000002/disk@8100000000000000,msdos2'
-linux /.build.kernel.kvm init=/.build/build console=hvc0 root=/dev/sda2 rw elevator=noop $vm_linux_kernel_parameter
+linux /.build.kernel.kvm init=/.build/build console=hvc0 root=/dev/sda2 rw $vm_linux_kernel_parameter
 initrd /.build.initrd.kvm
 boot
 EOF

--- a/build-vm-qemu
+++ b/build-vm-qemu
@@ -191,7 +191,7 @@ vm_startup_qemu() {
         qemu_append="$qemu_append $vm_linux_kernel_parameter"
         qemu_append="$qemu_append nmi_watchdog=0 rw rd.driver.pre=binfmt_misc"
     fi
-    qemu_append="$qemu_append $vm_linux_always_append elevator=noop console=$qemu_console init=$vm_init_script"
+    qemu_append="$qemu_append $vm_linux_always_append console=$qemu_console init=$vm_init_script"
 
     if test -z "$VM_NETOPT" -a -z "$VM_NETDEVOPT"; then
         qemu_options="$qemu_options -net none"

--- a/build-vm-uml
+++ b/build-vm-uml
@@ -29,7 +29,7 @@ vm_verify_options_uml() {
 }
 
 vm_startup_uml() {
-    set -- $uml_kernel "$@" initrd=$uml_initrd root=ubda init="$vm_init_script" $vm_linux_always_append elevator=noop ubda=$VM_ROOT ubdb=$VM_SWAP ${VM_MEMSIZE:+mem=$VM_MEMSIZE}
+    set -- $uml_kernel "$@" initrd=$uml_initrd root=ubda init="$vm_init_script" $vm_linux_always_append ubda=$VM_ROOT ubdb=$VM_SWAP ${VM_MEMSIZE:+mem=$VM_MEMSIZE}
     echo "$@"
     "$@"
 }

--- a/build-vm-xen
+++ b/build-vm-xen
@@ -77,7 +77,7 @@ vm_startup_xen() {
     echo "on_reboot = \"destroy\""                                           >> $XEN_CONF_FILE
     echo "on_crash = \"destroy\""                                            >> $XEN_CONF_FILE
     if test "$XMCMD" = xm ; then
-	set -- xm create -c $XEN_CONF_FILE name="build_$XENID" $XMROOT $XMSWAP extra="panic=1 quiet init="$vm_init_script" rd.driver.pre=binfmt_misc elevator=noop console=$VM_CONSOLE"
+	set -- xm create -c $XEN_CONF_FILE name="build_$XENID" $XMROOT $XMSWAP extra="panic=1 quiet init="$vm_init_script" rd.driver.pre=binfmt_misc console=$VM_CONSOLE"
     else
 	XLDISK=
 	XLDISK="\"${XMROOT#disk=}\""


### PR DESCRIPTION
Since the switch to blk-mq this does nothing.
the correct way is now either using an udev rule or echo "none" > /sys/block/*/queue/scheduler

It will be better if kernel-obs would default to none instead.