### PR TITLE
Improve capability parsing if not quoted

### DIFF
--- a/obs-docker-support
+++ b/obs-docker-support
@@ -127,6 +127,33 @@ zypper() {
     done
     case $cmd in
     in|install|rm|remove|up|update|if|info)
+	set -- "$@" "$sentinel"
+	local prev=""
+	local o
+	while test "$sentinel" != "$1" ; do
+	    o="$1"
+	    shift
+	    if test -n "$prev" ; then
+		if test "$o" = "=" -o "$o" = "!=" -o "$o" = ">=" -o "$o" = "<=" ; then
+		    prev="$prev $o"
+		    continue
+		fi
+		case "$prev" in
+		    *" ="|*" !="|*" >="|*" <=")
+			prev="$prev $o"
+			set -- "$@" "$prev"
+			prev=""
+			continue
+			;;
+		esac
+		set -- "$@" "$prev"
+	    fi
+	    prev="$o"
+	done
+	if test -n "$prev" ; then
+	    set -- "$@" "$prev"
+	fi
+	shift
 	$testmode /usr/bin/zypper --no-refresh -D $LOCAL_REPOS_D "$@"
 	setup_links_and_exit $?
 	;;
@@ -482,4 +509,3 @@ apk)
     echo "obs-docker-support: unsupported mode ${0##*/}" >&2
     exit 1
 esac
-


### PR DESCRIPTION
When using capability in Dockerfile, if it is not quoted, obs-docker-support gets confused.

Both` zypper in -C "foo = 1.2"` and `zypper in -C foo = 1.2` are working fine on CLI or in a Dockerfile with podman but will fail inside OBS.

