### PR TITLE
debian: replace @BUILD_FLAVOR@ in parse and dsc source preparation

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -71,6 +71,7 @@ sub obsarch {
 
 sub parse {
   my ($bconf, $fn) = @_;
+  my $buildflavor = defined($bconf->{'buildflavor'}) ? $bconf->{'buildflavor'} : '';
 
   # get arch and os from macros and map to debian names
   my ($arch, $os) = Build::gettargetarchos($bconf);
@@ -86,6 +87,11 @@ sub parse {
     @control = <F>;
     close F;
     chomp @control;
+  }
+  if ($buildflavor ne '') {
+    s/\@BUILD_FLAVOR\@/$buildflavor/g for @control;
+  } else {
+    s/\@BUILD_FLAVOR\@//g for @control;
   }
   splice(@control, 0, 3) if @control > 3 && $control[0] =~ /^-----BEGIN/;
   my $name;

--- a/build
+++ b/build
@@ -430,8 +430,9 @@ Known Parameters:
               Enable creation of debuginfo packages
 
   --buildflavor FLAVOR
-              Specify the flavor to build. For rpm builds, it replaces 
-              the @BUILD_FLAVOR@ macro in the spec file.
+              Specify the flavor to build. For rpm builds, it replaces
+              @BUILD_FLAVOR@ in the spec file. For Debian dependency
+              parsing, it replaces @BUILD_FLAVOR@ in control metadata.
 
   --changelog
               Append the rpm changelog from a SUSE .changes file to the spec file

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -59,6 +59,18 @@ dsc_export_origtar() {
     rm -rf "$BUILD_ROOT$TOPDIR/SOURCES/build.origtar"
 }
 
+dsc_replace_build_flavor_tokens() {
+    local f
+    local build_flavor="${BUILD_FLAVOR:-}"
+    for f in "$@" ; do
+	test -f "$f" || continue
+    local before_count after_count
+    before_count=$(perl -ne '$c += () = /\@BUILD_FLAVOR\@/g; END { print $c + 0 }' "$f")
+	perl -i -pe 'BEGIN { $v = shift @ARGV } s/\@BUILD_FLAVOR\@/$v/g' "$build_flavor" "$f" || cleanup_and_exit 1 "failed to substitute @BUILD_FLAVOR@ in $f"
+    after_count=$(perl -ne '$c += () = /\@BUILD_FLAVOR\@/g; END { print $c + 0 }' "$f")
+    done
+}
+
 
 recipe_prepare_dsc() {
     rm -rf "$BUILD_ROOT$TOPDIR/BUILD"
@@ -85,12 +97,16 @@ recipe_prepare_dsc() {
 		mv $BUILD_ROOT$TOPDIR/BUILD/$f $BUILD_ROOT$TOPDIR/BUILD/debian/${f#debian.}
 	    done
 	fi
+    dsc_replace_build_flavor_tokens "$BUILD_ROOT$TOPDIR/BUILD/debian/control" "$BUILD_ROOT$TOPDIR/BUILD/debian/rules" "$BUILD_ROOT$TOPDIR/BUILD/debian.control" "$BUILD_ROOT$TOPDIR/BUILD/debian.rules"
 	return
     fi
+
+    dsc_replace_build_flavor_tokens $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE
 
     if test -n "$DEB_TRANSFORM" ; then 
 	CHANGELOGARGS=
 	test -n "$CHANGELOG" -a -f "$BUILD_ROOT/.build-changelog" && CHANGELOGARGS="--changelog $BUILD_ROOT/.build-changelog"
+    dsc_replace_build_flavor_tokens "$BUILD_ROOT$TOPDIR/SOURCES/debian.control" "$BUILD_ROOT$TOPDIR/SOURCES/debian.rules"
 	echo "Found files matching debian.*, running debian transformer..."
         if [ "$RELEASE" ]; then
           echo "release: ($RELEASE), release (DEB) ($DEB_RELEASE)"
@@ -120,6 +136,7 @@ recipe_prepare_dsc() {
 
     # run/copy sources
     chroot $BUILD_ROOT su -c "dpkg-source -x $DEB_SOURCEDIR/$DEB_DSCFILE $TOPDIR/BUILD" - $BUILD_USER
+    dsc_replace_build_flavor_tokens "$BUILD_ROOT$TOPDIR/BUILD/debian/control" "$BUILD_ROOT$TOPDIR/BUILD/debian/rules"
 
     # Alternative to debtransform: apply OBS release number if tag OBS-DCH-RELEASE is set.
     if test -z "$DEB_TRANSFORM" && grep -Eq '^OBS-DCH-RELEASE: 1' $BUILD_ROOT$TOPDIR/SOURCES/$RECIPEFILE; then


### PR DESCRIPTION
This commit improves the support for multibuild when building debian-based packages.

* The `@BUILD_FLAVOR@` can now be used in the `.dsc` or `debian.control` file to correctly identify build dependencies.

* The `@BUILD_FLAVOR@` can also be used `debian/control` and `debian/rules` files, which are processed during build time but before the debian packaging process starts