### PR TITLE
multibuild: add `buildemptyflavor` attribute to _multibuild xml

### DIFF
--- a/PBuild/Multibuild.pm
+++ b/PBuild/Multibuild.pm
@@ -27,6 +27,7 @@ use PBuild::Verify;
 
 my $dtd_multibuild = [
     'multibuild' =>
+      'buildemptyflavor',
           [ 'package' ],        # obsolete
           [ 'flavor' ],
 ];
@@ -73,10 +74,12 @@ sub expand_multibuilds {
     my $mb = getmultibuild_fromfiles($p->{'dir'}, $p->{'files'});
     next unless $mb;
     my @mbp = @{$mb->{'flavor'} || $mb->{'package'} || []};
+    my $buildemptyflavor = !defined($mb->{'buildemptyflavor'}) || $mb->{'buildemptyflavor'} eq 'true' ? 1 : 0;
     for my $flavor (@mbp) {
       my $mpkg = "$pkg:$flavor";
       $pkgs->{$mpkg} = { %$p, 'pkg' => $mpkg, 'flavor' => $flavor, 'originpackage' => $pkg };
     }
+    delete $pkgs->{$pkg} if @mbp && !$buildemptyflavor;
   }
 }
 

--- a/PBuild/Verify.pm
+++ b/PBuild/Verify.pm
@@ -82,6 +82,9 @@ sub verify_nevraquery {
 
 sub verify_multibuild {
   my ($mb) = @_;
+  if (defined($mb->{'buildemptyflavor'})) {
+    die("buildemptyflavor must be either 'true' or 'false'\n") unless $mb->{'buildemptyflavor'} eq 'true' || $mb->{'buildemptyflavor'} eq 'false';
+  }
   die("multibuild cannot have both package and flavor elements\n") if $mb->{'package'} && $mb->{'flavor'};
   for my $packid (@{$mb->{'package'} || []}) {
     verify_packid($packid);


### PR DESCRIPTION
This commit adds support for a new `_multibuild` root attribute, `buildemptyflavor`, with boolean values `true|false`.

With this attribute we can control whether the base package should be built or not when using multibuilds.

In summary this implementation includes:
* Extend multibuild XML parsing to accept `buildemptyflavor`.
* Validate `buildemptyflavor` in multibuild verification logic.
* Keep existing behavior by default (true when unset): build base package plus flavored packages.
* When `buildemptyflavor="false"`, skip the base package task and build only `pkg:flavor` entries.