### PR TITLE
Ignore missing assets for arch build type

### DIFF
--- a/PBuild/AssetMgr.pm
+++ b/PBuild/AssetMgr.pm
@@ -216,10 +216,16 @@ sub getremoteassets {
     @assets = prune_cached_assets($assetmgr, @assets);
   }
   if (@assets) {
-    my @missing = sort(map {$_->{'file'}} @assets);
-    print "missing assets: @missing\n";
-    $p->{'error'} = "missing assets: @missing";
-    return;
+    if (($p->{'buildtype'} || '') eq 'arch') {
+      print "ignoring missing assets for arch repo: @missing\n";
+      for my $asset (@assets) {
+        delete $p->{'asset_files'}->{$asset->{'file'}};
+      }
+    } else {
+      print "missing assets: @missing\n";
+      $p->{'error'} = "missing assets: @missing";
+      return;
+    }
   }
   update_srcmd5($assetmgr, $p) if has_mutable_assets($assetmgr, $p);
 }


### PR DESCRIPTION
The source in PKGBUILD may contain variables that prevent the service from fetching assets during runtime; therefore, when the build type is `arch`, missing assets should be ignored (they will be downloaded during build).

example:
```bash
source=("$url/-/archive/${_gittag}/$pkgname-${_gittag}.tar.gz")
```

This is a workaround before SRCINFO (https://github.com/openSUSE/obs-build/pull/1101) is supported