### PR TITLE
RFC: build-vm: Set personality for cross builds using --vm-type=qemu as well

### DIFF
--- a/build-vm
+++ b/build-vm
@@ -1086,7 +1086,7 @@ vm_first_stage() {
     PERSONALITY=0
     test -n "$PERSONALITY_SYSCALL" && PERSONALITY=`perl -e 'print syscall('$PERSONALITY_SYSCALL', 0)."\n"'`
     test "$PERSONALITY" = -1 && PERSONALITY=0	# syscall failed?
-    case $(uname -m) in
+    case $BUILD_HOST_ARCH in
 	ppc|ppcle|s390) PERSONALITY=8 ;;	# ppc/s390 kernel never tells us if a 32bit personality is active, assume we run on 64bit
 	aarch64) test "$BUILD_ARCH" != "${BUILD_ARCH#armv[567]}" && PERSONALITY=8 ;; # workaround, to be removed
 	s390x) test "$BUILD_ARCH" = "s390" && PERSONALITY=8 ;; # 32bit support was dropped in recent kernels so we only have 32bit support possible in the guest


### PR DESCRIPTION
Builds for openSUSE:Factory/armv7l run an aarch64 kernel with linux32 personality (=> armv8l). Running such a build on a non-arm host with --vm-type=qemu did not set the personality as it used "uname -m" in the host context. What actually matters there is the architecture of the kernel used during build.

RFC because I'm not sure if that's the correct variable to use in that context?