### PR TITLE
Build::Docker: parse microdnf as a dnf-equivalent package manager

### DIFF
--- a/Build/Docker.pm
+++ b/Build/Docker.pm
@@ -417,7 +417,7 @@ sub parse {
 	$rcmd = shift @args if @args && ($rcmd eq 'then' || $rcmd eq 'else' || $rcmd eq 'elif' || $rcmd eq 'if' || $rcmd eq 'do');
 	if ($rcmd eq 'zypper') {
 	  cmd_zypper($ret, @args);
-	} elsif ($rcmd eq 'yum' || $rcmd eq 'dnf') {
+	} elsif ($rcmd eq 'yum' || $rcmd eq 'dnf' || $rcmd eq 'microdnf') {
 	  cmd_dnf($ret, @args);
 	} elsif ($rcmd eq 'apt-get') {
 	  cmd_apt_get($ret, @args);

--- a/t/parse_docker.t
+++ b/t/parse_docker.t
@@ -24,6 +24,9 @@ RUN curl -sL --output /usr/bin/example-curl --retry 3 -u "foo:bar" https://local
 RUN wget -O /usr/bin/example-wget -t 3 --user foo --password bar https://localhost:8080/example-wget
 
 FROM opensuse/leap:15.2
+
+RUN microdnf install -y vim
+RUN microdnf -y install tar
 };
 
 $expected = {
@@ -32,6 +35,8 @@ $expected = {
     'container:opensuse/tumbleweed:latest',
     'wget',
     'curl',
+    'vim',
+    'tar',
     'container:opensuse/leap:15.2',
   ],
   'path' => [],


### PR DESCRIPTION
The Dockerfile parser collects build dependencies by recognising package-manager invocations in `RUN` lines. microdnf shares dnf's `install`/`in` subcommand semantics, so route it through `cmd_dnf` alongside `yum` and `dnf`. Without this, `microdnf install <pkg>` commands in RedHat based images were silently ignored.

Extend `t/parse_docker.t` with a `microdnf install` case to cover the new dispatch.