### PR TITLE
Build: dispatch Build::Deb queries for .ddeb files

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1366,7 +1366,7 @@ sub query {
     $binname = $binname->[0];
   }
   return Build::Rpm::query($handle, %opts) if $do_rpm && $binname =~ /\.d?rpm$/;
-  return Build::Deb::query($handle, %opts) if $do_deb && $binname =~ /\.deb$/;
+  return Build::Deb::query($handle, %opts) if $do_deb && $binname =~ /\.d?deb$/;
   return Build::Kiwi::queryiso($handle, %opts) if $do_kiwi && $binname =~ /\.iso$/;
   return Build::Arch::query($handle, %opts) if $do_arch && $binname =~ /\.pkg\.tar(?:\.gz|\.xz|\.zst)?$/;
   return Build::Arch::query($handle, %opts) if $do_arch && $binname =~ /\.arch$/;
@@ -1395,7 +1395,7 @@ sub showquery {
 sub queryhdrmd5 {
   my ($binname) = @_;
   return Build::Rpm::queryhdrmd5(@_) if $do_rpm && $binname =~ /\.d?rpm$/;
-  return Build::Deb::queryhdrmd5(@_) if $do_deb && $binname =~ /\.deb$/;
+  return Build::Deb::queryhdrmd5(@_) if $do_deb && $binname =~ /\.d?deb$/;
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.iso$/;
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.raw$/;
   return Build::Kiwi::queryhdrmd5(@_) if $do_kiwi && $binname =~ /\.raw.install$/;


### PR DESCRIPTION
`.ddeb` is Ubuntu's debug-symbol package extension (`dh_strip` renames `*-dbgsym_*.deb` on the Ubuntu vendor). The on-disk format is byte-identical to a regular .deb, so route the file through `Build::Deb` in both `query()` and `queryhdrmd5()` instead of returning `undef` for `.ddeb` artifacts.