### PR TITLE
Add default value for kiwi --add-repo

### DIFF
--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -606,7 +606,7 @@ kiwi_translate_parameters() {
     for i in "${add_repo_url[@]}" ; do
 	local repo_prio="${add_repo_priority[$lasti]}"
 	test -z "$repo_prio" && repo_prio=99
-	KIWI_BUILD_PARAMETERS="$KIWI_BUILD_PARAMETERS --add-repo $i,${add_repo_type[$lasti]},${add_repo_alias[$lasti]},$repo_prio"
+	KIWI_BUILD_PARAMETERS="$KIWI_BUILD_PARAMETERS --add-repo $i,${add_repo_type[$lasti]},${add_repo_alias[$lasti]},$repo_prio,false,false,,,,false"
 	let lasti++
     done
     if test -n "$set_repo_url" ; then


### PR DESCRIPTION
[--add-repo=<source,type,alias,priority,imageinclude,package_gpgcheck,{signing_keys},components,distribution,repo_gpgcheck,repo_sourcetype>...]

createrepo_debian_dist_kiwi does not create Release.gpg, set repo_gpgcheck="false" by default.