### PR TITLE
Add support for comparing deb packages

### DIFF
--- a/build
+++ b/build
@@ -2107,13 +2107,13 @@ exitcode=0
 
 # post build work
 # TODO: don't hardcode. instead run scripts in a directory as it's done for the checks
-if test -n "$RPMS" -a -d "$BUILD_ROOT/.build.oldpackages" ; then
+if test \( -n "$RPMS" -o -n "$DEBS" \) -a -d "$BUILD_ROOT/.build.oldpackages" ; then
     rm -f "$BUILD_ROOT/.build/.same_result_marker"
     TIME_BUILDCMP=$SECONDS
     recipe_compare_oldpackages
     TIME_BUILDCMP=$(( $SECONDS - $TIME_BUILDCMP ))
     # no need to create deltas if the build is the same
-    if test ! -e "$BUILD_ROOT/.build/.same_result_marker" ; then
+    if test -n "$RPMS" -a ! -e "$BUILD_ROOT/.build/.same_result_marker" ; then
 	TIME_DELTARPMS=$SECONDS
 	recipe_create_deltarpms
 	TIME_DELTARPMS=$(( $SECONDS - $TIME_DELTARPMS ))

--- a/build-recipe
+++ b/build-recipe
@@ -64,6 +64,10 @@ recipe_resultdirs () {
     recipe_resultdirs_$BUILDTYPE "$@"
 }
 
+recipe_compare_oldpackages () {
+    recipe_compare_oldpackages_$BUILDTYPE "$@"
+}
+
 recipe_cleanup () {
     recipe_cleanup_$BUILDTYPE "$@"
 }

--- a/build-recipe-apk
+++ b/build-recipe-apk
@@ -61,6 +61,10 @@ recipe_resultdirs_apk() {
     echo APKS
 }
 
+recipe_compare_oldpackages_apk() {
+    :
+}
+
 recipe_cleanup_apk() {
     :
 }

--- a/build-recipe-appimage
+++ b/build-recipe-appimage
@@ -119,6 +119,10 @@ recipe_resultdirs_appimage() {
     :
 }
 
+recipe_compare_oldpackages_appimage() {
+    :
+}
+
 recipe_cleanup_appimage() {
     :
 }

--- a/build-recipe-arch
+++ b/build-recipe-arch
@@ -58,6 +58,10 @@ recipe_resultdirs_arch() {
     echo ARCHPKGS
 }
 
+recipe_compare_oldpackages_arch() {
+    :
+}
+
 recipe_cleanup_arch() {
     :
 }

--- a/build-recipe-collax
+++ b/build-recipe-collax
@@ -52,6 +52,10 @@ recipe_resultdirs_collax() {
 	echo DEBS
 }
 
+recipe_compare_oldpackages_collax() {
+	:
+}
+
 recipe_cleanup_collax() {
 	:
 }

--- a/build-recipe-debbuild
+++ b/build-recipe-debbuild
@@ -51,6 +51,10 @@ recipe_resultdirs_debbuild() {
     echo DEBS SDEBS
 }
 
+recipe_compare_oldpackages_debbuild() {
+    recipe_compare_oldpackages_dsc "$@"
+}
+
 recipe_cleanup_debbuild() {
     :
 }

--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -111,6 +111,10 @@ recipe_resultdirs_debootstrap() {
     echo DEBS
 }
 
+recipe_compare_oldpackages_debootstrap() {
+    :
+}
+
 recipe_cleanup_debootstrap() {
     :
 }

--- a/build-recipe-docker
+++ b/build-recipe-docker
@@ -430,6 +430,10 @@ recipe_resultdirs_docker() {
     echo DOCKER
 }
 
+recipe_compare_oldpackages_docker() {
+    :
+}
+
 recipe_cleanup_docker() {
     if test -n "$DOCKERD_STARTED" ; then
 	test -n "$TOPDIR" && rm -f "$BUILD_ROOT/$TOPDIR/SOURCES/.obs-docker-support"

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -222,6 +222,20 @@ recipe_resultdirs_dsc() {
     echo DEBS
 }
 
+recipe_compare_oldpackages_dsc() {
+    if test -x "$BUILD_ROOT/usr/lib/build/same-build-result.sh" ; then
+	echo "... comparing built packages with the former built"
+	if chroot $BUILD_ROOT /usr/lib/build/same-build-result.sh /.build.oldpackages "$TOPDIR/DEBS"; then
+	    chroot $BUILD_ROOT touch /.build/.same_result_marker
+	    chroot $BUILD_ROOT touch /.build.packages/same_result_marker
+	    # dirty build service hack. return exit status 2 to bs_worker for unchanged builds
+	    case "$REASON" in
+		Building\ *\ for\ project\ *\ repository\ *\ srcmd5\ *) exitcode=2 ;;
+	    esac
+	fi
+    fi
+}
+
 recipe_cleanup_dsc() {
     :
 }

--- a/build-recipe-fissile
+++ b/build-recipe-fissile
@@ -133,6 +133,10 @@ recipe_resultdirs_fissile() {
     echo FISSILE
 }
 
+recipe_compare_oldpackages_fissile() {
+    :
+}
+
 recipe_cleanup_fissile() {
     if test -n "$DOCKERD_STARTED" ; then
 	DOCKERD_STARTED=

--- a/build-recipe-flatpak
+++ b/build-recipe-flatpak
@@ -99,6 +99,10 @@ recipe_resultdirs_flatpak() {
     :
 }
 
+recipe_compare_oldpackages_flatpak() {
+    :
+}
+
 recipe_cleanup_flatpak() {
     :
 }

--- a/build-recipe-helm
+++ b/build-recipe-helm
@@ -88,6 +88,10 @@ recipe_resultdirs_helm() {
     echo HELM
 }
 
+recipe_compare_oldpackages_helm() {
+    :
+}
+
 recipe_cleanup_helm() {
     :
 }

--- a/build-recipe-kiwi
+++ b/build-recipe-kiwi
@@ -1009,6 +1009,10 @@ recipe_resultdirs_kiwi() {
     echo KIWI
 }
 
+recipe_compare_oldpackages_kiwi() {
+    :
+}
+
 recipe_cleanup_kiwi() {
     :
 }

--- a/build-recipe-livebuild
+++ b/build-recipe-livebuild
@@ -290,6 +290,10 @@ recipe_resultdirs_livebuild() {
     :
 }
 
+recipe_compare_oldpackages_livebuild() {
+    :
+}
+
 recipe_cleanup_livebuild() {
     :
 }

--- a/build-recipe-mkosi
+++ b/build-recipe-mkosi
@@ -182,6 +182,10 @@ recipe_resultdirs_mkosi() {
     :
 }
 
+recipe_compare_oldpackages_mkosi() {
+    :
+}
+
 recipe_cleanup_mkosi() {
     :
 }

--- a/build-recipe-mock
+++ b/build-recipe-mock
@@ -98,6 +98,10 @@ recipe_resultdirs_mock() {
     echo RPMS SRPMS
 }
 
+recipe_compare_oldpackages_mock() {
+    :
+}
+
 recipe_cleanup_mock() {
     echo RPMS SRPMS
 }

--- a/build-recipe-podman
+++ b/build-recipe-podman
@@ -45,6 +45,10 @@ recipe_resultdirs_podman() {
     recipe_resultdirs_docker "$@"
 }
 
+recipe_compare_oldpackages_podman() {
+    :
+}
+
 recipe_cleanup_podman() {
     recipe_cleanup_docker "$@"
 }

--- a/build-recipe-preinstallimage
+++ b/build-recipe-preinstallimage
@@ -78,6 +78,10 @@ recipe_resultdirs_preinstallimage() {
     :
 }
 
+recipe_compare_oldpackages_preinstallimage() {
+    :
+}
+
 recipe_cleanup_preinstallimage() {
     :
 }

--- a/build-recipe-productcompose
+++ b/build-recipe-productcompose
@@ -115,6 +115,10 @@ recipe_resultdirs_productcompose() {
     echo PRODUCT
 }
 
+recipe_compare_oldpackages_productcompose() {
+    :
+}
+
 recipe_cleanup_productcompose() {
     :
 }

--- a/build-recipe-simpleimage
+++ b/build-recipe-simpleimage
@@ -111,6 +111,10 @@ recipe_resultdirs_simpleimage() {
     :
 }
 
+recipe_compare_oldpackages_simpleimage() {
+    :
+}
+
 recipe_cleanup_simpleimage() {
     :
 }

--- a/build-recipe-snapcraft
+++ b/build-recipe-snapcraft
@@ -121,6 +121,10 @@ recipe_resultdirs_snapcraft() {
     :
 }
 
+recipe_compare_oldpackages_snapcraft() {
+    :
+}
+
 recipe_cleanup_snapcraft() {
     :
 }

--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -370,7 +370,7 @@ recipe_run_rpmlint() {
     fi   
 }
 
-recipe_compare_oldpackages() {
+recipe_compare_oldpackages_spec() {
     if test -x "$BUILD_ROOT/usr/lib/build/same-build-result.sh" ; then 
 	echo "... comparing built packages with the former built"
 	if chroot $BUILD_ROOT /usr/lib/build/same-build-result.sh /.build.oldpackages "$TOPDIR/RPMS" "$TOPDIR/SRPMS"; then 


### PR DESCRIPTION
build-compare just gained support for comparing the result of deb builds too, so add support for it, following the rpm model