### PR TITLE
dsc: delete _scmsync.obsinfo from BUILD/

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -78,6 +78,9 @@ recipe_prepare_dsc() {
     if test "$RECIPEFILE" = debian/control -o "$RECIPEFILE" = debian.control ; then
 	dsc_export_origtar
 	mv $BUILD_ROOT$DEB_SOURCEDIR $BUILD_ROOT$TOPDIR/BUILD
+	# dpkg-buildpackage will fail if unknown files are in the build directory,
+	# so remove the .obsinfo file that gets added when building scmsync packages
+	rm -f "$BUILD_ROOT$TOPDIR/BUILD/_scmsync.obsinfo"
 	if test -d $BUILD_ROOT$TOPDIR/BUILD/debian ; then
 	    for f in debian.control debian.changelog ; do
 		test -f $BUILD_ROOT$TOPDIR/BUILD/$f || continue


### PR DESCRIPTION
When using scmsync a _scmsync.obsinfo file gets dropped in the build root, and dpkg-buildpackage is not happy about untracked files in the build root and fails the build:

[   33s] dpkg-source: info: local changes detected, the modified files are:
[   33s]  BUILD/_scmsync.obsinfo
[   33s] dpkg-source: error: aborting due to unexpected upstream changes, see /tmp/mkosi_26-3.diff.wbqjcl

Delete it after copying the SOURCES/ content to BUILD/