### PR TITLE
generate_sbom: fix runtime errors on old distributions

### DIFF
--- a/generate_sbom
+++ b/generate_sbom
@@ -21,7 +21,12 @@
 ################################################################
 
 BEGIN {
-  unshift @INC, ($::ENV{'BUILD_DIR'} || '/usr/lib/build');
+  if (!$::ENV{'BUILD_DIR'} && $0 ne '-' && $0 ne '-e' && -e $0 && ! -e '/etc/build.conf') {
+    use Cwd ();
+    my $p = Cwd::abs_path($0);
+    $::ENV{'BUILD_DIR'} = $p if $p =~ s/\/[^\/]+$// && $p ne '/usr/lib/build' && -d "$p/Build";
+  }
+  unshift @INC, ($::ENV{'BUILD_DIR'} && ! -e '/etc/build.conf' ? $::ENV{'BUILD_DIR'} : '/usr/lib/build');
 }
 
 use strict;


### PR DESCRIPTION
We run generate_sbom there without BUILD_DIR set, but using perl -I /.build directly

However, generate_sbom is trying to use /usr/lib/build in this situation for it's modules which leads to runtime errors (opts->{'type'} is not set leading to handle everything as oci container).

Instead let's use the path of generate_sbom as perl module directory if BUILD_DIR is not set.