### PR TITLE
pbuild: add --abort-on-fail option

### DIFF
--- a/PBuild/Options.pm
+++ b/PBuild/Options.pm
@@ -33,6 +33,7 @@ my $pbuild_options = {
   'reponame' => ':',
   'noclean' => '',
   'no-clean' => 'noclean',
+  'abort-on-fail' => '',
   'baselibs' => '',
   'release' => ':',
   'checks' => '',

--- a/pbuild
+++ b/pbuild
@@ -625,6 +625,8 @@ while (1) {
   # integrate build artifacts and extra files
   my $bininfo = PBuild::BuildResult::integrate_job($builddir, $job, $code, $buildresult);
 
+  exit 1 if $opts->{'abort-on-fail'} && $code eq 'failed';
+
   # if the build was successful, update artifact information and the local repo
   if ($bininfo && !$opts->{'orphan'}) {
     $repomgr->updatelocalgbininfo($myarch, $p->{'pkg'}, $bininfo);


### PR DESCRIPTION
This will build all packages in the calculated order, but stop once the first package is failing.

This is useful for ai jobs which can analyse the reason, fix it and continue.