### PR TITLE
Add support for DEB_BUILD_OPTIONS/PROFILES via prjconf

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -77,6 +77,11 @@ sub parse {
   $os = 'linux' unless defined $os;
   $arch = basearch($arch);
 
+  # the active build profiles (DEB_BUILD_PROFILES) are needed to evaluate the
+  # restriction formulas of the build dependencies, so that the resolver pulls
+  # in the same set of dependencies that the build will use
+  my @build_profiles = split(' ', Build::Rpm::expandmacros($bconf, '%{?deb_build_profiles}'));
+
   my @control;
   if (ref($fn) eq 'ARRAY') {
     @control = @$fn;
@@ -124,14 +129,13 @@ sub parse {
         my @needed;
         for my $c (@alts) {
           if ($c =~ /\s+<[^>]+>$/) {
-            my @build_profiles;  # Empty for now
             my $bad = 1;
             while ($c =~ s/\s+<([^>]+)>$//) {
               next if (!$bad);
               my $list_valid = 1;
               for my $term (split(/\s+/, $1)) {
                 my $isneg = ($term =~ s/^\!//);
-                my $profile_match = grep(/^$term$/, @build_profiles);
+                my $profile_match = grep { $_ eq $term } @build_profiles;
                 if (( $profile_match &&  $isneg) ||
                     (!$profile_match && !$isneg)) {
                   $list_valid = 0;

--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -152,6 +152,15 @@ dsc_build() {
     if test -n "$BUILD_JOBS" ; then
 	DSC_BUILD_OPTIONS="parallel=${BUILD_JOBS}"
     fi
+    # Let the project config tune the build via DEB_BUILD_OPTIONS and
+    # DEB_BUILD_PROFILES by defining the %deb_build_options and
+    # %deb_build_profiles macros
+    DSC_BUILD_PROFILES=
+    local deb_build_options deb_build_profiles
+    deb_build_options="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" eval '%{?deb_build_options}')"
+    deb_build_profiles="$(queryconfig --dist "$BUILD_DIST" --archpath "$BUILD_ARCH" --configdir "$CONFIG_DIR" eval '%{?deb_build_profiles}')"
+    test -n "$deb_build_options" && DSC_BUILD_OPTIONS="$DSC_BUILD_OPTIONS $deb_build_options"
+    test -n "$deb_build_profiles" && DSC_BUILD_PROFILES="$DSC_BUILD_PROFILES $deb_build_profiles"
     # Checks to see if a build script should be used
     # this allows the build environment to be manipulated
     # and alternate build commands can be used
@@ -184,12 +193,13 @@ dsc_build() {
 	DSC_BUILD_CMD="$DSC_BUILD_CMD --host-type $ABUILD_TARGET"
     fi
     if test -n "$ABUILD_TARGET" -a -d "$BUILD_ROOT/.build.sysroot" ; then
-	DSC_BUILD_CMD="$DSC_BUILD_CMD -Pcross,nocheck"
+	DSC_BUILD_PROFILES="$DSC_BUILD_PROFILES cross nocheck"
 	DSC_BUILD_OPTIONS="$DSC_BUILD_OPTIONS nocheck"
-	DSC_BUILD_OPTIONS="${DSC_BUILD_OPTIONS# }"
     fi
+    DSC_BUILD_OPTIONS="${DSC_BUILD_OPTIONS# }"
+    DSC_BUILD_PROFILES="${DSC_BUILD_PROFILES# }"
 
-    chroot $buildroot su -c "export DEB_BUILD_OPTIONS='${DSC_BUILD_OPTIONS}' ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
+    chroot $buildroot su -c "export DEB_BUILD_OPTIONS='${DSC_BUILD_OPTIONS}'${DSC_BUILD_PROFILES:+ DEB_BUILD_PROFILES='${DSC_BUILD_PROFILES}'} ; cd $TOPDIR/BUILD && $DSC_BUILD_CMD" - $BUILD_USER < /dev/null && BUILD_SUCCEEDED=true
     if test "$BUILD_SUCCEEDED" = true -a "$DO_CHECKS" != "false" && ( chroot $buildroot su -c "which lintian > /dev/null" - $BUILD_USER < /dev/null ); then
 	DEB_CHANGESFILE=${DEB_DSCFILE%.dsc}$OBS_DCH_RELEASE"_"$(chroot $buildroot su -c 'dpkg-architecture -qDEB_BUILD_ARCH')".changes"
 	chroot $buildroot su -c "cd $TOPDIR && echo Running lintian && (set -x && lintian -i $TOPDIR/$DEB_CHANGESFILE)" - $BUILD_USER < /dev/null || BUILD_SUCCEEDED=false

--- a/docs/build_config.adoc
+++ b/docs/build_config.adoc
@@ -542,6 +542,32 @@ Example:
 Note that the macro lines are copied verbatim, i.e. macro expansion
 does not take place.
 
+=== Setting DEB_BUILD_OPTIONS and DEB_BUILD_PROFILES for Debian builds
+
+When building Debian source packages (`dsc` recipes), the project config
+can influence `dpkg-buildpackage` by defining the `%deb_build_options`
+and `%deb_build_profiles` macros. Their values are passed to the build as
+the `DEB_BUILD_OPTIONS` and `DEB_BUILD_PROFILES` environment variables,
+which is the Debian equivalent of tuning an rpm build through its build
+options.
+
+Example:
+
+    Macros:
+    %deb_build_options nocheck nodoc
+    %deb_build_profiles nodoc
+    :Macros
+
+The build profiles set via `%deb_build_profiles` are also honored when
+resolving the build dependencies, so the restriction formulas (for
+example `<!nocheck>` or `<stage1>`) in the `Build-Depends` are evaluated
+against the active profiles and the same set of packages is pulled in
+that the build will use.
+
+The values are merged with the options and profiles that the build adds
+on its own, for example the `nocheck` option and the `cross` and
+`nocheck` profiles used for cross builds.
+
 === Building with ccache or sccache
 
 The usage of ccache or sccache can be enabled for each package by

--- a/t/parse_dsc.t
+++ b/t/parse_dsc.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More tests => 6;
+
+use Build;
+use Build::Deb;
+
+my $dsc = [
+  'Format: 3.0 (quilt)',
+  'Source: testpkg',
+  'Build-Depends: debhelper-compat (= 13), always-dep, test-dep <!nocheck>, stage1-dep <stage1>, cross-dep <cross !nocheck>',
+];
+
+sub parsedeps {
+  my ($profiles) = @_;
+  my @conf;
+  @conf = ('Macros:', "%deb_build_profiles $profiles", ':Macros') if defined $profiles;
+  my $conf = Build::read_config('x86_64', [ @conf ]);
+  my $d = Build::Deb::parse($conf, $dsc);
+  return join(', ', @{$d->{'deps'} || []});
+}
+
+# no build profiles active: dependencies restricted to <!nocheck> are pulled
+# in (nocheck is not active), <stage1> and <cross> ones are not
+is(parsedeps(undef), 'debhelper-compat = 13, always-dep, test-dep', 'no build profiles');
+is(parsedeps(''), 'debhelper-compat = 13, always-dep, test-dep', 'empty build profiles');
+
+# nocheck active: the <!nocheck> dependency is dropped
+is(parsedeps('nocheck'), 'debhelper-compat = 13, always-dep', 'nocheck profile');
+
+# stage1 active: the <stage1> dependency is pulled in additionally
+is(parsedeps('stage1'), 'debhelper-compat = 13, always-dep, test-dep, stage1-dep', 'stage1 profile');
+
+# cross active: the <cross !nocheck> dependency is pulled in additionally
+is(parsedeps('cross'), 'debhelper-compat = 13, always-dep, test-dep, cross-dep', 'cross profile');
+
+# cross and nocheck active: cross-dep is dropped again because of !nocheck
+is(parsedeps('cross nocheck'), 'debhelper-compat = 13, always-dep', 'cross and nocheck profiles');


### PR DESCRIPTION
RPM builds can be customized with Macros in prjconf. Deb builds can be customized with the DEB_BUILD_OPTIONS and DEB_BUILD_PROFILES env vars, but so far this was not exposed to users.

Add support for defining in prjconf %deb_build_profiles and %deb_build_options, and use them for the build, and in the case of the latter, for dependencies resolution as well.