### PR TITLE
fix: build-receipe-spec: parsing %generate_buildrequires with $BUILD_USER

### DIFF
--- a/build-recipe-spec
+++ b/build-recipe-spec
@@ -265,8 +265,8 @@ recipe_build_spec() {
 		test -f "$i" && reqsfile=${i##*/}
 	    done
 	    test -n "$reqsfile" || cleanup_and_exit 1 "no buildreqs.nosrc.rpm file?"
-	    chroot $BUILD_ROOT rpm -qp --requires "$TOPDIR/SRPMS/$reqsfile" | grep -v '^rpmlib(' | sort -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
-	    HOME=/root chroot $BUILD_ROOT rpmspec -q --srpm --requires "$TOPDIR/SOURCES/$RECIPEFILE" >> $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp || cleanup_and_exit 1 "rpm -q --spec failed"
+	    chroot $BUILD_ROOT su $BUILD_USER -c "rpm -qp --requires '$TOPDIR/SRPMS/$reqsfile' | grep -v '^rpmlib(' | sort -u > '$TOPDIR/OTHER/_generated_buildreqs_tmp'"
+	    chroot $BUILD_ROOT su $BUILD_USER -c "rpmspec -q --srpm --requires '$TOPDIR/SOURCES/$RECIPEFILE' >> $TOPDIR/OTHER/_generated_buildreqs_tmp" || cleanup_and_exit 1 "rpm -q --spec failed"
 	    sort < $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp | uniq -u > $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs
 	    rm -f $BUILD_ROOT$TOPDIR/OTHER/_generated_buildreqs_tmp
 	    while read db ; do


### PR DESCRIPTION
Both static and dynamic BuildRequires were collected with root user before, resulting `%{_topdir}` pointing to wrong place. This breaks `%include` within spec file.

This PR attempts to make the process happen under `$BUILD_USER` so that rpmspec tool can refer to the correct source dir.

Seems that `.rpmmacros` and `.rpmrc` exist both in `/root` and `/home/$BUILD_USER` with identical content, I didn' t catch the reason that it was done previously by root user. Is it specially designed to do so?

This PR is tested on our OBS instance as well as `pbuild`. However `osc` does not support `%generate_buildrequires` well.