### PR TITLE
PBuild: Fix auth for multiple remote registry assets

### DIFF
--- a/PBuild/BearerAuth.pm
+++ b/PBuild/BearerAuth.pm
@@ -37,6 +37,10 @@ sub bearer_authenticate {
   my $realm = $auth_param->{'realm'};
   die("bearer auth did not provide a realm\n") unless $realm;
   die("bearer realm is not http/https\n") unless $realm =~ /^https?:\/\//i;
+  my $url = $proxy ? $request->{proxy} : $request->uri_canonical;
+  my $host_port = $url->host_port;
+  # Remove previously installed handler for an old token
+  $ua->set_my_handler("request_prepare", undef, 'm_host_port' => $host_port);
   my $auri = URI->new($realm);
   my @afields;
   for ('service', 'scope') {
@@ -49,9 +53,7 @@ sub bearer_authenticate {
   my $reply = JSON::XS::decode_json($ares->decoded_content);
   my $token = $reply->{'token'} || $reply->{'access_token'};
   return $response unless $token;
-  my $url = $proxy ? $request->{proxy} : $request->uri_canonical;
-  my $host_port = $url->host_port;
-  my $h = $ua->get_my_handler('request_prepare', 'm_host_port' => $host_port, sub {
+  $ua->get_my_handler('request_prepare', 'm_host_port' => $host_port, sub {
     $_[0]{callback} = sub { $_[0]->header('Authorization' => "Bearer $token") };
   });
   return $ua->request($request->clone, $arg, $size, $response);


### PR DESCRIPTION
If another image needs a new token with different scope, the previous handler needs to be deleted. Otherwise the old handler remains and uses the previous token with the old scope.

Reproducer:

```
#!BuildTag: orthos2:latest
FROM registry.suse.com/bci/bci-base:15.7
FROM registry.suse.com/suse/nginx:1.27
```

Before:

```
> pbuild --dist sle15.7 --registry registry.suse.com orthos2-docker
starting project builder
    source directory: /tmp/systemsmanagement/orthos2/orthos2-docker
    result directory: /tmp/systemsmanagement/orthos2/orthos2-docker/_build.sle15.7.x86_64
    build area: /var/tmp/build-root-fabian
    architecture: x86_64
    build config:
      - sle15.7
getting package information
parsing 1 recipe file
fetching metadata of 0 remote repos
fetching remote registry metadata of 2 tags
requesting bearer auth from https://scc.suse.com/api/registry/authorize [service SUSE Linux Docker Registry scope repository:bci/bci-base:pull]
requesting bearer auth from https://scc.suse.com/api/registry/authorize [service SUSE Linux Docker Registry scope repository:suse/nginx:pull]
download of https://registry.suse.com/v2/suse/nginx/manifests/1.27 failed: 401 Unauthorized
```

After:

```
> pbuild --dist sle15.7 --registry registry.suse.com orthos2-docker
starting project builder
    source directory: /tmp/systemsmanagement/orthos2/orthos2-docker
    result directory: /tmp/systemsmanagement/orthos2/orthos2-docker/_build.sle15.7.x86_64
    build area: /var/tmp/build-root-fabian
    architecture: x86_64
    build config:
      - sle15.7
getting package information
parsing 1 recipe file
fetching metadata of 0 remote repos
fetching remote registry metadata of 2 tags
requesting bearer auth from https://scc.suse.com/api/registry/authorize [service SUSE Linux Docker Registry scope repository:bci/bci-base:pull]
requesting bearer auth from https://scc.suse.com/api/registry/authorize [service SUSE Linux Docker Registry scope repository:suse/nginx:pull]
preparing package pool
expanding dependencies
.: unresolvable (nothing provides patterns-base-fips)
```

(expected, no repos set here)