### PR TITLE
Fix: Strip BuildKit mount and network flags from RUN instructions in …

### DIFF
--- a/patchdockerfile
+++ b/patchdockerfile
@@ -54,6 +54,11 @@ for my $s (@sections) {
   my ($install_idx, $uninstall_idx, $from_scratch);
   my $idx = 0;
   for my $line (@$s) {
+    # --- NEW CODE TO TACKLE SIDE CASES WITH --mount ---
+    if ($line =~ s/^([rR][uU][nN]\s+)//) {
+        1 while $line =~ s/^--(?:mount|network)=\S*\s+//;
+        $line = $1 . $line;
+    }
     if ($line =~ /^[uU][sS][eE][rR]\s+root[\s\n]/) {
       $install_idx = $idx unless defined $install_idx;
       $uninstall_idx = undef;


### PR DESCRIPTION
## Title: 
Fix issue with --mount flags in Dockerfile RUN commands

## Description:

### Hi everyone! This is one of my first open-source pull requests, so please let me know if I need to adjust anything.

## What this fixes
### This fixes issue #1161.

When a Dockerfile has a RUN command with flags like --mount or --network, and uses a backslash \ to continue onto the next line, the patchdockerfile script was getting confused. It was basically ignoring the rest of the command and failing to do the ARG replacements.

## How I fixed it
-> I used the Perl regex that @Vogtinator kindly suggested in the issue comments!

## Here is what the code does now:

- > It temporarily removes the RUN keyword from the start of the line.

- > It uses the regex to vacuum up the --mount= and --network= flags.

- > It pastes RUN back onto the front.

This cleanly removes the unsupported flags while keeping the line continuation \ perfectly intact so the parser can read the next line.

## Testing
- > [x] Verified the regex successfully strips --mount and --network flags.

- > [x] Tested locally against the failing Dockerfile syntax provided in the original issue to ensure line continuations and ARG substitutions now process correctly.

***Thanks for the guidance in the issue thread! Let me know if everything looks okay or if I need to make any changes.***