### PR TITLE
Install rpms with `SOURCE_DATE_EPOCH=0` set

### DIFF
--- a/build-pkg-rpm
+++ b/build-pkg-rpm
@@ -125,7 +125,7 @@ pkg_install_rpm() {
 	    test -e "$i" && ADDITIONAL_PARAMS="$ADDITIONAL_PARAMS --justdb"
 	done
     fi
-    ( cd $BUILD_ROOT && chroot $BUILD_ROOT rpm --ignorearch --nodeps -U --oldpackage --ignoresize $RPMCHECKOPTS \
+    ( cd $BUILD_ROOT && SOURCE_DATE_EPOCH=0 chroot $BUILD_ROOT rpm --ignorearch --nodeps -U --oldpackage --ignoresize $RPMCHECKOPTS \
 		$ADDITIONAL_PARAMS .init_b_cache/$PKG.rpm 2>&1 || \
 	  touch $BUILD_ROOT/exit ) | \
 	      grep -v "^warning:.*saved as.*rpmorig$"
@@ -166,7 +166,7 @@ pkg_sysrootinstall_rpm() {
     if test "$USE_FORCE" = true ; then
 	export ADDITIONAL_PARAMS="$ADDITIONAL_PARAMS --force"
     fi
-    ( cd $BUILD_ROOT && chroot $BUILD_ROOT rpm --ignorearch --nodeps -U --oldpackage --ignoresize $RPMCHECKOPTS \
+    ( cd $BUILD_ROOT && SOURCE_DATE_EPOCH=0 chroot $BUILD_ROOT rpm --ignorearch --nodeps -U --oldpackage --ignoresize $RPMCHECKOPTS \
 		$ADDITIONAL_PARAMS --noscripts --root "$BUILD_SYSROOT" .init_b_cache/$PKG.rpm 2>&1 || \
 	  touch $BUILD_ROOT/exit ) | \
 	      grep -v "^warning:.*saved as.*rpmorig$"
@@ -181,7 +181,7 @@ pkg_finalize_rpm() {
 	    test "$BUILD_ROOT/.init_b_cache/rpms/$PKG" -ef "$BUILD_ROOT/${CUMULATED_LIST[$num]}" && continue
 	    cp --remove-destination $BUILD_ROOT/.init_b_cache/rpms/$PKG $BUILD_ROOT/${CUMULATED_LIST[$num]} || cleanup_and_exit 1
 	done > $BUILD_ROOT/.init_b_cache/manifest
-	( cd $BUILD_ROOT && chroot $BUILD_ROOT rpm --ignorearch --nodeps -Uh --oldpackage --ignoresize --verbose $RPMCHECKOPTS \
+	( cd $BUILD_ROOT && SOURCE_DATE_EPOCH=0 chroot $BUILD_ROOT rpm --ignorearch --nodeps -Uh --oldpackage --ignoresize --verbose $RPMCHECKOPTS \
 		$ADDITIONAL_PARAMS .init_b_cache/manifest 2>&1 || touch $BUILD_ROOT/exit )
 	for ((num=0; num<=cumulate; num++)) ; do
 	    rm -f $BUILD_ROOT/${CUMULATED_LIST[$num]}


### PR DESCRIPTION
Install rpms with `SOURCE_DATE_EPOCH=0` set so that the buildroot rpm database becomes reproducible: rpm uses it to override the wall-clock `RPMTAG_INSTALLTIME/RPMTAG_INSTALLTID` values stored with each header.

This makes Bernhard's [home:bmwiedemann:reproducible:distribution2026:ring1/altimagebuild](https://build.opensuse.org/package/show/home:bmwiedemann:reproducible:distribution2026:ring1/altimagebuild) fully deterministic.