### PR TITLE
generate_sbom: SPDX V3 requires createdBy field

### DIFF
--- a/generate_sbom
+++ b/generate_sbom
@@ -790,7 +790,7 @@ sub cyclonedx_encode_relations {
 }
 
 sub cyclonedx_encode_header {
-  my ($subjectname, $type, $disturl, $vcs) = @_;
+  my ($subjectname, $type, $disturl, $vcss) = @_;
   my $cyc = {
     'bomFormat' => 'CycloneDX',
     'specVersion' => '1.5',
@@ -802,7 +802,7 @@ sub cyclonedx_encode_header {
     },
   };
   push @{$cyc->{'metadata'}->{'component'}->{'externalReferences'}}, { 'url' => $disturl, 'type' => 'build-meta' } if $disturl;
-  push @{$cyc->{'metadata'}->{'component'}->{'externalReferences'}}, { 'url' => $vcs, 'type' => 'vcs' } if $vcs;
+  push @{$cyc->{'metadata'}->{'component'}->{'externalReferences'}}, { 'url' => $_, 'type' => 'vcs' } for grep {defined $_ && $_ ne ''} @{$vcss || []};
   return $cyc;
 }
 
@@ -962,7 +962,7 @@ sub spdx_encode_relations {
 }
 
 sub spdx_encode_header {
-  my ($subjectname, $type, $disturl, $vcs) = @_;
+  my ($subjectname, $type, $disturl, $vcss) = @_;
   my $spdx = {
     'spdxVersion' => 'SPDX-2.3',
     'dataLicense' => 'CC0-1.0',
@@ -981,7 +981,7 @@ sub spdx_encode_header {
     primaryPackagePurpose => uc($type),
     skip_external_refs => 1
   }, undef, undef, {});
-  push @{$rootspdx->{'externalRefs'}}, { 'referenceCategory' => 'OTHER', 'referenceType' => 'vcs', 'referenceLocator' => $vcs } if $vcs;
+  push @{$rootspdx->{'externalRefs'}}, { 'referenceCategory' => 'OTHER', 'referenceType' => 'vcs', 'referenceLocator' => $_ } for grep {defined $_ && $_ ne ''} @{$vcss || []};
   push @{$rootspdx->{'externalRefs'}}, { 'referenceCategory' => 'OTHER', 'referenceType' => 'obs-disturl', 'referenceLocator' => $disturl } if $disturl;
   $spdx->{'packages'} = [ $rootspdx ];
   return $spdx;
@@ -1213,9 +1213,18 @@ sub spdx3_encode_pkg {
   if(!$p->{'skip_external_refs'}) {
     my $purlurl = gen_purl($p, $distro, $pkgtype);
     $spdx->{'software_packageUrl'} = $purlurl if $purlurl;
-###    push @{$spdx->{'externalRefs'}}, { 'referenceCategory' => 'OTHER', 'referenceType' => 'vcs', 'referenceLocator' => $p->{'VCS'} } if $p->{'VCS'};
-###    push @{$spdx->{'externalRefs'}}, { 'referenceCategory' => 'OTHER', 'referenceType' => 'obs-disturl', 'referenceLocator' => $p->{'DISTURL'} } if $p->{'DISTURL'};
+    push @{$spdx->{'externalRef'}}, {
+      'type'            => 'ExternalRef',
+      'externalRefType' => 'vcs',
+      'locator'         => [ $p->{'VCS'} ]
+    } if $p->{'VCS'};
+    push @{$spdx->{'externalRef'}}, {
+      'type'            => 'ExternalRef',
+      'externalRefType' => 'obs-disturl',
+      'locator'         => [ $p->{'DISTURL'} ]
+    } if $p->{'DISTURL'};
   }
+  push @{$spdx->{'externalRef'}}, @{$p->{'externalRef'}} if @{$p->{'externalRef'} || []};
 
   $spdx->{'software_primaryPurpose'} = $p->{'primaryPackagePurpose'} if $p->{'primaryPackagePurpose'};
   if ($p->{'spdx_id'}) {
@@ -1295,7 +1304,7 @@ sub spdx3_gen_spdxid {
 }
 
 sub spdx3_encode_header {
-  my ($subjectname, $type, $disturl, $vcs, $rootp, $agentname, $agentspdxid) = @_;
+  my ($subjectname, $type, $disturl, $vcss, $rootp, $agentname, $agentspdxid) = @_;
   my $doc = [];
   push @$doc, [ '1', [], {}, {}];
   my $tool = { 'type' => 'Tool', 'name' => "$tool_name-$tool_version", 'creationInfo' => '_:creationInfo_0' };
@@ -1309,6 +1318,16 @@ sub spdx3_encode_header {
   $document->{'spdxId'} = 'document0';
   push @{$doc->[0]->[1]}, \$document->{'spdxId'};
   push @$doc, $document;
+  push @{$rootp->{'externalRef'}}, {
+    'type'            => 'ExternalRef',
+    'externalRefType' => 'vcs',
+    'locator'         => [ $_ ]
+  } for grep {defined $_ && $_ ne ''} @{$vcss || []};
+  push @{$rootp->{'externalRef'}}, {
+    'type'            => 'ExternalRef',
+    'externalRefType' => 'obs-disturl',
+    'locator'         => [ $disturl ]
+  } if $disturl;
   spdx3_encode_pkg($doc, $rootp, undef, '');
   spdx3_encode_one_relation($doc, {'spdx_id' => 'document0'}, $rootp, 'DESCRIBES');
   return $doc;
@@ -1364,9 +1383,17 @@ Supported content
   --rpmmd DIRECTORY
      A directory providing rpm-md meta data. A 'repodata/repomd.xml' file is expected.
 
-  --container-docker-archive CONTAINER_ARCHIVE
-  --container-oci-archive CONTAINER_ARCHIVE
-     An container archive providing a system
+   --container-docker-archive CONTAINER_ARCHIVE
+   --container-oci-archive CONTAINER_ARCHIVE
+      An container archive providing a system
+
+Additional metadata
+===================
+
+  --vcs URL
+     Add a version control system URL to the root component of the SBOM.
+     This option can be given multiple times to reference multiple
+     source repositories.
 
 createdBy agent
 ===============
@@ -1396,7 +1423,7 @@ my $known_options = {
   'help' => '',
   'h' => 'help',
   'dist' => ':',
-  'vcs' => ':',
+  'vcs' => '::',
   'disturl' => ':',
   'arch' => ':',
   'archpath' => 'arch:',

--- a/generate_sbom
+++ b/generate_sbom
@@ -1295,14 +1295,16 @@ sub spdx3_gen_spdxid {
 }
 
 sub spdx3_encode_header {
-  my ($subjectname, $type, $disturl, $vcs, $rootp) = @_;
+  my ($subjectname, $type, $disturl, $vcs, $rootp, $agentname, $agentspdxid) = @_;
   my $doc = [];
   push @$doc, [ '1', [], {}, {}];
   my $tool = { 'type' => 'Tool', 'name' => "$tool_name-$tool_version", 'creationInfo' => '_:creationInfo_0' };
   spdx3_gen_spdxid($doc, $tool);
-  my $ci = { '@id' => '_:creationInfo_0', 'type' => 'CreationInfo', 'specVersion' => '3.0.1', 'createdUsing' => [ $tool->{'spdxId'} ], 'created' => rfc3339time($buildtime) };
+  my $agent = { 'type' => 'SoftwareAgent', 'name' => $agentname, 'creationInfo' => '_:creationInfo_0' };
+  $agent->{'spdxId'} = $agentspdxid;
+  my $ci = { '@id' => '_:creationInfo_0', 'type' => 'CreationInfo', 'specVersion' => '3.0.1', 'createdBy' => [ $agent->{'spdxId'} ], 'createdUsing' => [ $tool->{'spdxId'} ], 'created' => rfc3339time($buildtime) };
   push @{$doc->[0]->[1]}, \$ci->{'createdUsing'}->[0];
-  push @$doc, $ci, $tool;
+  push @$doc, $ci, $tool, $agent;
   my $document = { 'type' => 'SpdxDocument', 'dataLicense' => 'http://spdx.org/licenses/CC0-1.0', 'creationInfo' => '_:creationInfo_0' };
   $document->{'spdxId'} = 'document0';
   push @{$doc->[0]->[1]}, \$document->{'spdxId'};
@@ -1366,6 +1368,17 @@ Supported content
   --container-oci-archive CONTAINER_ARCHIVE
      An container archive providing a system
 
+createdBy agent
+===============
+
+   The createdBy field of the SBOM creationInfo references a SoftwareAgent.
+   By default a SoftwareAgent named 'build' with the spdxId
+   https://www.openSUSE.org/Agent/build is used.
+
+  --obsname NAME
+     Use the name 'Open Build Service' and use
+     https://NAME/Agent/OBS-Service as the agent's spdxId instead.
+
 ";
 }
 
@@ -1390,6 +1403,7 @@ my $known_options = {
   'configdir' => ':',
   'no-files-generation' => '',
   'buildtime' => ':',
+  'obsname' => ':',
 };
 
 my ($opts, @args) = Build::Options::parse_options($known_options, @ARGV);
@@ -1425,6 +1439,13 @@ my $no_files_generation = $opts->{'no-files-generation'};
 $no_files_generation = ($config->{'buildflags:spdx-files-generation'} || '') eq 'no' unless defined $no_files_generation;
 
 $buildtime = $opts->{'buildtime'} || time();
+
+my $agent_name = 'build';
+my $agent_spdxid = 'https://www.openSUSE.org/Agent/build';
+if ($opts->{'obsname'}) {
+  $agent_name = 'Open Build Service';
+  $agent_spdxid = "https://$opts->{'obsname'}/Agent/OBS-Service";
+}
 
 my $targettype;
 my $unpackdir;
@@ -1609,7 +1630,7 @@ if ($opts->{'format'} eq 'spdx') {
     primaryPackagePurpose => $targettype,
     skip_external_refs => 1
   };
-  $doc = spdx3_encode_header($subjectname, $targettype, $opts->{'disturl'}, $opts->{'vcs'}, $rootpkg);
+  $doc = spdx3_encode_header($subjectname, $targettype, $opts->{'disturl'}, $opts->{'vcs'}, $rootpkg, $agent_name, $agent_spdxid);
   for my $p (@$pkgs) {
     spdx3_encode_pkg($doc, $p, $distro, $pkgtype);
   }


### PR DESCRIPTION
So generate one by default and allow to set the instance via --obsname parameter.