### PR TITLE
copy_sources: normalize permissions of copied sources

### DIFF
--- a/build
+++ b/build
@@ -946,6 +946,8 @@ copy_sources() {
 	fi
     fi
     test -n "$RPM_BUILD_IN_PLACE" -a -z "$RUNNING_IN_VM" && cp -f "$RECIPEPATH" "$2"
+    # normalize permissions so that checkout modes do not leak into the result
+    chmod -R a=rX,u+w "$2"
 }
 
 mkdir_build_root() {


### PR DESCRIPTION
Copied sources now always end up as 644 (755 for directories and executables) to ensure consistent permissions in the generated src.rpm.

This patch was done while working on reproducible builds for openSUSE.